### PR TITLE
feat: add Tavily as a configurable search provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,18 +8,19 @@ GOOGLE_CUSTOM_SEARCH_API_KEY=AIzaSy...your-key-here...
 GOOGLE_CUSTOM_SEARCH_ID=017576662512468239146:omuauf_gy1x
 
 # ── Search Provider (default: google) ────────────────────────────────────────
-# Options: google, brave, serper, searxng, searchapi
+# Options: google, brave, serper, searxng, searchapi, tavily
 # SEARCH_PROVIDER=brave
 # BRAVE_API_KEY=BSA...
 # SERPER_API_KEY=...
 # SEARCHAPI_API_KEY=...
+# TAVILY_API_KEY=tvly-...
 # SEARXNG_URL=http://localhost:8080
 # SEARCH_FALLBACK_PROVIDER=google
 
 # ── Multi-Provider Routing (optional) ───────────────────────────────────────
 # When set, enables intelligent routing with automatic fallback.
 # Simple format (comma-separated priority list):
-# SEARCH_ROUTING=brave,google,serper
+# SEARCH_ROUTING=brave,google,serper,tavily
 # Advanced format (per-operation JSON):
 # SEARCH_ROUTING={"web":"brave,google","news":"brave,serper","images":"google,brave","academic":"searchapi,google","patents":"searchapi,google","default":"brave,google,searchapi"}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,7 @@ type SearchConfig struct {
 	BraveAPIKey      string
 	SerperAPIKey     string
 	SearchAPIKey     string
+	TavilyAPIKey     string
 	SearXNGURL       string
 	CustomLensesPath string
 }
@@ -105,6 +106,11 @@ func Load() (*Config, error) {
 		errs = append(errs, "SEARCHAPI_API_KEY is required when SEARCH_PROVIDER=searchapi")
 	}
 
+	tavilyAPIKey := os.Getenv("TAVILY_API_KEY")
+	if provider == "tavily" && tavilyAPIKey == "" {
+		errs = append(errs, "TAVILY_API_KEY is required when SEARCH_PROVIDER=tavily")
+	}
+
 	port := envInt("PORT", 0)
 	encKey := os.Getenv("CACHE_ENCRYPTION_KEY")
 	if encKey != "" && len(encKey) != 64 {
@@ -125,6 +131,7 @@ func Load() (*Config, error) {
 			BraveAPIKey:      braveKey,
 			SerperAPIKey:     serperKey,
 			SearchAPIKey:     searchAPIKey,
+			TavilyAPIKey:     tavilyAPIKey,
 			SearXNGURL:       searxngURL,
 			CustomLensesPath: os.Getenv("CUSTOM_LENSES_PATH"),
 		},

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -87,6 +87,8 @@ func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 		return NewSearXNGProvider(cfg.SearXNGURL, deps)
 	case "searchapi":
 		return NewSearchAPIProvider(cfg.SearchAPIKey, deps)
+	case "tavily":
+		return NewTavilyProvider(cfg.TavilyAPIKey, deps)
 	default:
 		return NewGoogleProvider(cfg.GoogleAPIKey, cfg.GoogleCX, deps)
 	}
@@ -116,6 +118,10 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 		if cfg.SearchAPIKey != "" {
 			return NewSearchAPIProvider(cfg.SearchAPIKey, deps)
 		}
+	case "tavily":
+		if cfg.TavilyAPIKey != "" {
+			return NewTavilyProvider(cfg.TavilyAPIKey, deps)
+		}
 	}
 	return nil
 }
@@ -125,7 +131,7 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 // circuit breaker for isolation — failures in one provider don't affect others.
 func AvailableProviders(cfg config.SearchConfig, deps Deps) map[string]Provider {
 	providers := make(map[string]Provider)
-	names := []string{"google", "brave", "serper", "searxng", "searchapi"}
+	names := []string{"google", "brave", "serper", "searxng", "searchapi", "tavily"}
 	for _, name := range names {
 		providerDeps := Deps{
 			HTTPClient: deps.HTTPClient,

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -953,6 +954,14 @@ func TestNewProvider_SearchAPI(t *testing.T) {
 	}
 }
 
+func TestNewProvider_Tavily(t *testing.T) {
+	cfg := config.SearchConfig{Provider: "tavily", TavilyAPIKey: "tvly-key"}
+	p := NewProvider(cfg, newTestDeps(http.DefaultClient))
+	if p.Name() != "tavily" {
+		t.Errorf("expected provider name 'tavily', got %q", p.Name())
+	}
+}
+
 // =============================================================================
 // Router Tests
 // =============================================================================
@@ -1267,6 +1276,9 @@ func TestAvailableProviders(t *testing.T) {
 	if _, ok := providers["searxng"]; ok {
 		t.Error("did not expect searxng provider (no URL)")
 	}
+	if _, ok := providers["tavily"]; ok {
+		t.Error("did not expect tavily provider (no key)")
+	}
 }
 
 func TestNewProviderByName_MissingCredentials(t *testing.T) {
@@ -1287,6 +1299,9 @@ func TestNewProviderByName_MissingCredentials(t *testing.T) {
 	}
 	if p := NewProviderByName("google", cfg, deps); p != nil {
 		t.Error("expected nil for google without both key and cx")
+	}
+	if p := NewProviderByName("tavily", cfg, deps); p != nil {
+		t.Error("expected nil for tavily without key")
 	}
 }
 
@@ -1333,6 +1348,155 @@ func TestMapSearchAPIImageSize(t *testing.T) {
 		if got != tt.expected {
 			t.Errorf("mapSearchAPIImageSize(%q) = %q, want %q", tt.input, got, tt.expected)
 		}
+	}
+}
+
+// =============================================================================
+// Tavily Provider Tests
+// =============================================================================
+
+func TestTavilyProvider_WebSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected content-type 'application/json', got %q", r.Header.Get("Content-Type"))
+		}
+
+		body, _ := io.ReadAll(r.Body)
+		var reqBody tavilyRequest
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+		if reqBody.APIKey != "tavily-key" {
+			t.Errorf("expected api_key 'tavily-key', got %q", reqBody.APIKey)
+		}
+		if !strings.Contains(reqBody.Query, "golang testing") {
+			t.Errorf("expected query to contain 'golang testing', got %q", reqBody.Query)
+		}
+		if reqBody.MaxResults != 5 {
+			t.Errorf("expected max_results 5, got %d", reqBody.MaxResults)
+		}
+		if reqBody.Topic != "general" {
+			t.Errorf("expected topic 'general', got %q", reqBody.Topic)
+		}
+
+		resp := tavilyResponse{
+			Results: []struct {
+				Title         string  `json:"title"`
+				URL           string  `json:"url"`
+				Content       string  `json:"content"`
+				Score         float64 `json:"score"`
+				PublishedDate string  `json:"published_date,omitempty"`
+			}{
+				{Title: "Tavily Result", URL: "https://example.com/tavily", Content: "From Tavily", Score: 0.95},
+				{Title: "Tavily Result 2", URL: "https://example.com/tavily2", Content: "Second result", Score: 0.85},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport}}
+	deps := Deps{HTTPClient: client, Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("tavily-key", deps)
+
+	results, err := tv.Web(context.Background(), WebSearchParams{Query: "golang testing", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+	if results[0].Title != "Tavily Result" {
+		t.Errorf("expected first result title 'Tavily Result', got %q", results[0].Title)
+	}
+	if results[0].URL != "https://example.com/tavily" {
+		t.Errorf("expected first result URL 'https://example.com/tavily', got %q", results[0].URL)
+	}
+}
+
+func TestTavilyProvider_NewsSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var reqBody tavilyRequest
+		if err := json.Unmarshal(body, &reqBody); err != nil {
+			t.Fatalf("failed to parse request body: %v", err)
+		}
+		if reqBody.Topic != "news" {
+			t.Errorf("expected topic 'news', got %q", reqBody.Topic)
+		}
+		if reqBody.APIKey != "tavily-key" {
+			t.Errorf("expected api_key 'tavily-key', got %q", reqBody.APIKey)
+		}
+
+		resp := tavilyResponse{
+			Results: []struct {
+				Title         string  `json:"title"`
+				URL           string  `json:"url"`
+				Content       string  `json:"content"`
+				Score         float64 `json:"score"`
+				PublishedDate string  `json:"published_date,omitempty"`
+			}{
+				{Title: "News Item", URL: "https://news.example.com/article", Content: "Breaking news", Score: 0.9, PublishedDate: "2024-01-15"},
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport}}
+	deps := Deps{HTTPClient: client, Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("tavily-key", deps)
+
+	results, err := tv.News(context.Background(), NewsSearchParams{Query: "technology", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Title != "News Item" {
+		t.Errorf("expected title 'News Item', got %q", results[0].Title)
+	}
+	if results[0].Source != "news.example.com" {
+		t.Errorf("expected source 'news.example.com', got %q", results[0].Source)
+	}
+	if results[0].PublishedAt != "2024-01-15" {
+		t.Errorf("expected published_at '2024-01-15', got %q", results[0].PublishedAt)
+	}
+}
+
+func TestTavilyProvider_RateLimit(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	client := &http.Client{Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport}}
+	deps := Deps{HTTPClient: client, Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("key", deps)
+
+	_, err := tv.Web(context.Background(), WebSearchParams{Query: "test", NumResults: 5})
+	if err == nil {
+		t.Fatal("expected error for 429 response")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("expected rate limit error, got: %v", err)
+	}
+}
+
+func TestTavilyProvider_ImageSearchUnsupported(t *testing.T) {
+	tv := NewTavilyProvider("key", newTestDeps(http.DefaultClient))
+	_, err := tv.Images(context.Background(), ImageSearchParams{Query: "cats"})
+	if err == nil {
+		t.Fatal("expected error for unsupported image search")
+	}
+	if !strings.Contains(err.Error(), "does not support image search") {
+		t.Errorf("expected unsupported error, got: %v", err)
 	}
 }
 

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 )
 
 type TavilyProvider struct {
@@ -96,10 +97,14 @@ func (t *TavilyProvider) doNewsSearch(ctx context.Context, params NewsSearchPara
 
 	var results []NewsResult
 	for _, r := range resp.Results {
+		source := r.URL
+		if u, err := url.Parse(r.URL); err == nil && u.Host != "" {
+			source = u.Host
+		}
 		results = append(results, NewsResult{
 			Title:       r.Title,
 			URL:         r.URL,
-			Source:      r.URL,
+			Source:      source,
 			PublishedAt: r.PublishedDate,
 			Snippet:     r.Content,
 		})

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -1,0 +1,159 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+type TavilyProvider struct {
+	apiKey string
+	deps   Deps
+}
+
+func NewTavilyProvider(apiKey string, deps Deps) *TavilyProvider {
+	return &TavilyProvider{apiKey: apiKey, deps: deps}
+}
+
+func (t *TavilyProvider) Name() string { return "tavily" }
+
+func (t *TavilyProvider) Web(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	var results []SearchResult
+	err := t.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = t.doWebSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+func (t *TavilyProvider) Images(_ context.Context, _ ImageSearchParams) ([]ImageResult, error) {
+	return nil, fmt.Errorf("tavily provider does not support image search")
+}
+
+func (t *TavilyProvider) News(ctx context.Context, params NewsSearchParams) ([]NewsResult, error) {
+	var results []NewsResult
+	err := t.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = t.doNewsSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+func (t *TavilyProvider) doWebSearch(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	reqBody := tavilyRequest{
+		APIKey:      t.apiKey,
+		Query:       buildQuery(params),
+		MaxResults:  clamp(params.NumResults, 1, 20),
+		SearchDepth: "basic",
+		Topic:       "general",
+	}
+
+	body, err := t.doRequest(ctx, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tavilyResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse tavily response: %w", err)
+	}
+
+	var results []SearchResult
+	for _, r := range resp.Results {
+		results = append(results, SearchResult{
+			Title:       r.Title,
+			URL:         r.URL,
+			Snippet:     r.Content,
+			DisplayLink: r.URL,
+		})
+	}
+	return results, nil
+}
+
+func (t *TavilyProvider) doNewsSearch(ctx context.Context, params NewsSearchParams) ([]NewsResult, error) {
+	reqBody := tavilyRequest{
+		APIKey:      t.apiKey,
+		Query:       params.Query,
+		MaxResults:  clamp(params.NumResults, 1, 20),
+		SearchDepth: "basic",
+		Topic:       "news",
+	}
+
+	body, err := t.doRequest(ctx, reqBody)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tavilyResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse tavily news response: %w", err)
+	}
+
+	var results []NewsResult
+	for _, r := range resp.Results {
+		results = append(results, NewsResult{
+			Title:       r.Title,
+			URL:         r.URL,
+			Source:      r.URL,
+			PublishedAt: r.PublishedDate,
+			Snippet:     r.Content,
+		})
+	}
+	return results, nil
+}
+
+func (t *TavilyProvider) doRequest(ctx context.Context, reqBody tavilyRequest) ([]byte, error) {
+	jsonBody, err := json.Marshal(reqBody)
+	if err != nil {
+		return nil, fmt.Errorf("tavily: failed to marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", "https://api.tavily.com/search", bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := t.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		return nil, fmt.Errorf("tavily API rate limited")
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("tavily API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+}
+
+type tavilyRequest struct {
+	APIKey      string `json:"api_key"`
+	Query       string `json:"query"`
+	SearchDepth string `json:"search_depth,omitempty"`
+	MaxResults  int    `json:"max_results,omitempty"`
+	Topic       string `json:"topic,omitempty"`
+}
+
+type tavilyResponse struct {
+	Results []struct {
+		Title         string  `json:"title"`
+		URL           string  `json:"url"`
+		Content       string  `json:"content"`
+		Score         float64 `json:"score"`
+		PublishedDate string  `json:"published_date,omitempty"`
+	} `json:"results"`
+}
+
+// Ensure TavilyProvider implements Provider at compile time.
+var _ Provider = (*TavilyProvider)(nil)


### PR DESCRIPTION
## Summary

Adds Tavily as a new search provider option, selectable via `SEARCH_PROVIDER=tavily` or includable in `SEARCH_ROUTING` fallback chains. This is an **additive** change — all existing providers remain untouched.

## What changed

- **`internal/search/tavily.go`** (new): `TavilyProvider` implementing the `search.Provider` interface via Tavily's REST API (`POST https://api.tavily.com/search`). Supports `Web()` (topic=general) and `News()` (topic=news) searches. `Images()` returns an unsupported-operation error. Uses the same circuit-breaker pattern as other providers.
- **`internal/search/provider.go`**: Added `"tavily"` case to `NewProvider()`, `NewProviderByName()` (guarded by `cfg.TavilyAPIKey != ""`), and `AvailableProviders()` names list.
- **`internal/config/config.go`**: Added `TavilyAPIKey` field to `SearchConfig`, reads `TAVILY_API_KEY` env var, validates it's set when `SEARCH_PROVIDER=tavily`.
- **`.env.example`**: Documented `TAVILY_API_KEY`, added `tavily` to `SEARCH_PROVIDER` options and `SEARCH_ROUTING` example.

## Dependency changes

- None — Tavily REST API is called via the existing `net/http` client, consistent with all other provider adapters.

## Environment variable changes

- Added `TAVILY_API_KEY` (required when `SEARCH_PROVIDER=tavily` or `tavily` appears in `SEARCH_ROUTING`)

## Notes for reviewers

- Follows the exact same structural pattern as `brave.go` (struct with apiKey+deps, circuit breaker wrapping, response type mapping)
- Tavily supports up to 20 results per query (vs 10 for Brave); `clamp` range set accordingly
- Go compiler not available in CI-less environment; code reviewed manually for correctness against existing patterns


### Automated Review

- Passed after 2 attempt(s)
- Final review: The Tavily provider implementation is clean, correct, and consistent with the existing codebase. All patterns match other providers (BraveProvider, SearXNG, etc.): circuit-breaker wrapping, struct layout, factory registration, config wiring, and env var documentation. The review feedback from attempt 1 has been fully addressed — tests are comprehensive (factory, web, news, rate-limit, images-unsupported, available-providers, missing-credentials) and `NewsResult.Source` now correctly parses the URL hostname via `net/url`. The compile-time interface guard (`var _ Provider = (*TavilyProvider)(nil)`) ensures correctness. No regressions or unintended changes were found.
