### PR TITLE
docs: remove public personal email from Code of Conduct reporting

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -2,4 +2,10 @@
 
 This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/).
 
-Please report concerns to zohar.babin@gmail.com.
+## Reporting concerns
+
+Please report Code of Conduct concerns privately to the maintainer. For
+sensitive reports, open a [private security advisory](https://github.com/zoharbabin/web-researcher-mcp/security/advisories/new)
+(GitHub keeps it confidential between you and the maintainer) or contact the
+maintainer through their [GitHub profile](https://github.com/zoharbabin). All
+reports are handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -258,7 +258,7 @@ Please include:
 
 ## Code of Conduct
 
-This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to zohar.babin@gmail.com.
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. To report unacceptable behavior, see the confidential reporting instructions in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md#reporting-concerns).
 
 ## Adding a New Tool
 


### PR DESCRIPTION
## What

Removes the personal Gmail address exposed in `CODE_OF_CONDUCT.md` and `CONTRIBUTING.md` as the conduct-reporting contact. It was both a spam/scraping vector and a typo'd address.

Code-of-Conduct reports now route through GitHub-native private channels — a private Security Advisory or the maintainer's GitHub profile — mirroring how security vulnerabilities are already handled. No email appears anywhere in the tracked repo.

## Why

- Public personal email is a scraping/spam vector.
- Conduct reports should be confidential; a public `mailto` is the wrong channel.
- Consistent with the existing private security-reporting model.

## Not affected

- Provider "polite pool" contact emails (`OPENALEX_EMAIL` / `CROSSREF_EMAIL`, and the planned EDGAR `User-Agent`) are operator-supplied env vars, never a hardcoded address — correct as-is.
- Git author identity is already correct.

## Out of scope

The typo'd address remains in 2 historical commits (one on `main`); per maintainer decision, history is left as-is — the live scrapeable surface is now clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)