### PR TITLE
docs: fix Copilot-flagged accuracy issues (error taxonomy, cache key, circuit breakers)

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -260,7 +260,7 @@ SEARCH_ROUTING='{"web":"brave,google","news":"brave,serper","images":"google,bra
 **How it works:**
 - Requests route to the first healthy provider in the priority list
 - If a provider fails (timeout, rate limit, 5xx), the next provider is tried automatically
-- Each provider gets an independent circuit breaker. Routing breakers open after 3 consecutive failures and reset after 30s; the domain (patent/academic) provider breakers use 5 failures / 60s (see `internal/search/router.go` and `internal/search/domain.go` for the authoritative values)
+- Each provider gets an independent circuit breaker. The routing-layer breakers that govern fallback (web, patent, and academic alike) open after 3 consecutive failures and reset after 30s (`internal/search/router.go`). Domain providers additionally wrap their own upstream HTTP calls in an inner breaker (5 failures / 60s, `internal/search/domain.go`) — a separate, deeper layer, not the effective routing breaker. See those files for the authoritative values.
 - Lenses can override routing via the `"routing"` field in their JSON definition
 
 **Operation types:** `web`, `images`, `news`, `academic`, `patents`, `default`. The `academic` and `patents` lists are filtered to providers that implement the academic/patent interface — `academic` accepts only `openalex`, `crossref`; `patents` accepts only `searchapi`, `epo`, `lens`, `uspto`. Names that don't implement the interface are silently dropped, so use the example values above.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -249,23 +249,16 @@ When a single agent spawns many parallel tool calls:
 
 Protects against cascading failures when upstream APIs are down.
 
-**States:** CLOSED → OPEN → HALF_OPEN → CLOSED
+**States:** CLOSED → OPEN → HALF_OPEN → CLOSED. Each provider gets an independent breaker, so a failure in one never blocks fallback to another. There are three distinct breaker layers, each with its own thresholds (see `internal/search/provider.go`, `internal/search/domain.go`, and `internal/search/router.go` for the authoritative values):
 
-**Configuration (per-provider breaker):**
-- Failure threshold: 5 consecutive failures
-- Reset timeout: 60 seconds
-- Half-open attempts: 1
+| Layer | Wraps | Threshold | Reset |
+|-------|-------|-----------|-------|
+| Web provider breaker (`AvailableProviders`) | Each web provider (Google, Brave, Serper, SearXNG, SearchAPI, DuckDuckGo) | 3 failures | 120s |
+| Domain provider breaker (`Available{Patent,Academic}Providers`) | Each patent/academic provider's own upstream HTTP calls | 5 failures | 60s |
+| Routing breaker (`SEARCH_ROUTING`) | Fallback decision across the priority list (web, patent, academic) | 3 failures | 30s |
 
-**Configuration (multi-provider router breaker):**
-- Failure threshold: 3 consecutive failures
-- Reset timeout: 30 seconds
-- Half-open attempts: 1
-
-**Per-Provider Breakers:**
-- Each configured search provider (Google, Brave, Serper, SearXNG, SearchAPI, DuckDuckGo) gets an independent circuit breaker
-- When using multi-provider routing (`SEARCH_ROUTING`), the router adds a second breaker layer with tighter thresholds for faster failover
-- Failures in one provider don't affect others
-- Scraping (per domain): optional, prevent hammering broken sites
+- Half-open attempts: 1 (all layers)
+- Scraping (per domain): optional, prevents hammering broken sites
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -138,7 +138,7 @@ Raw mode still runs through the **same safety guards** as every other scrape: `v
 
 **Trade-off — untrusted bytes.** Because sanitization is skipped, raw content may contain active `<script>`/HTML, embedded markup, or indirect prompt-injection payloads. The bytes are untrusted: never execute or render them, and treat any instructions inside them as data, not commands. For normal reading, prefer `full` (sanitized). `search_and_scrape` is always sanitized and has no raw mode.
 
-Raw responses use a distinct cache key (`url + "raw"`) so a raw result never collides with a cleaned `full`/`preview` entry for the same URL.
+Raw responses are keyed like any other scrape: the cache key includes `mode` (so `raw` never collides with a cleaned `full`/`preview` entry for the same URL) and `max_length`. See the Cache section below for the full key.
 
 ### Scraping Strategy (Tiered Fallback)
 
@@ -213,7 +213,7 @@ All scrape errors are typed as `ScrapeError{Kind, Message, Cause, URL, Tier}`. T
 | `ErrValidation` | no (permanent) | Unsupported scheme, empty host, SSRF / private-IP / blocked-hostname denial, domain allowlist denial | "URL rejected for {url}: {detail}. Provide a valid public http(s) URL." |
 | `ErrNetwork` | yes | DNS failure, timeout, connection refused, TLS | "Network error on {url}: {detail}. Check connectivity." |
 | `ErrBlocked` | yes | HTTP 403, remote bot detection | "Blocked: {url} uses bot detection. Try alternative source or report at {issueURL}" |
-| `ErrBrowser` | yes | Chrome not found, launch failed, connect failed | "Scrape failed: Chrome unavailable. Set CHROME_PATH or install Chrome. Report at {issueURL}" |
+| `ErrBrowser` | no | Chrome not found, launch failed, connect failed | "Scrape failed: Chrome unavailable. Set CHROME_PATH or install Chrome. Report at {issueURL}" |
 | `ErrContent` | yes | Page loaded but no usable content extracted | "No content extracted from {url}. May need browser rendering. Report at {issueURL}" |
 | `ErrAuth` | no | HTTP 401, login redirect | "Auth required: {url} is behind a login wall." |
 | `ErrRateLimit` | yes (after delay) | HTTP 429 | "Rate limited on {url}. Retry in 60 seconds." |


### PR DESCRIPTION
Follow-up to #98. The Copilot reviewer flagged 3 accuracy issues on that PR; this fixes them plus one related pre-existing error found while verifying against the code.

## Fixes

- **TOOLS.md — `ErrBrowser` retryable.** Code (`internal/tools/errors.go`) sets browser-unavailable scrape errors to `Retryable=false` / `report_bug`; the taxonomy table said "yes". Corrected to "no".
- **TOOLS.md — stale raw cache-key sentence.** Line 141 still claimed raw responses key on `url + "raw"`, contradicting the real key (`url+mode+max_length`). Raw is just `mode=raw`; updated to point at the Cache section.
- **DEPLOYMENT.md — circuit-breaker layering.** Clarified that the routing breakers governing fallback (web/patent/academic) are all 3 failures / 30s; the 5/60s breakers are an inner layer wrapping each domain provider's own HTTP calls, not the effective routing breaker.
- **SECURITY.md — pre-existing breaker error (found while verifying).** Claimed web providers use 5/60; they actually use 3/120 (`internal/search/provider.go`). Replaced the two ad-hoc config blocks with an accurate three-layer table: web 3/120, domain 5/60, routing 3/30.

## Verification

- CI doc-drift tests pass (`TestToolsDocMatchesRegistry`, `TestOutputSchemaMatchesResponse`, etc.)
- Every value cross-checked against `internal/tools/errors.go`, `internal/search/{provider,domain,router}.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)