### PR TITLE
feat: SearXNG Basic auth + custom headers (#109)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,12 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 # SERPER_API_KEY=...
 # SEARCHAPI_API_KEY=...
 # SEARXNG_URL=http://localhost:8080
+# If your SearXNG sits behind HTTP Basic auth (issue #109), supply the credential:
+# SEARXNG_BASIC_AUTH=user:password
+# For non-Basic schemes (bearer token, Cloudflare Access, API-gateway secret), set
+# static request headers as comma-separated "Name: Value" pairs (no commas or
+# newlines inside a value; a custom Authorization header overrides SEARXNG_BASIC_AUTH):
+# SEARXNG_HEADERS=X-Proxy-Token: abc123, CF-Access-Client-Id: client.id
 # SEARCH_FALLBACK_PROVIDER=google
 
 # ── Academic Search Providers (optional, enables rich scholarly metadata) ────

--- a/docs/API_SETUP.md
+++ b/docs/API_SETUP.md
@@ -182,6 +182,28 @@ export SEARCH_PROVIDER=searxng
 export SEARXNG_URL=http://localhost:8080
 ```
 
+### Step 4: Authenticating to a protected SearXNG (optional)
+
+If your instance is behind HTTP Basic auth or a reverse proxy that requires a token, supply the credential at deploy time. Both variables are optional — unset, the server talks to SearXNG exactly as before.
+
+```bash
+# HTTP Basic auth (the most common case):
+export SEARXNG_BASIC_AUTH=user:password   # everything after the first ':' is the password, so colons in the password are fine
+
+# Non-Basic schemes (bearer token, Cloudflare Access service token, API-gateway shared secret) —
+# comma-separated "Name: Value" pairs:
+export SEARXNG_HEADERS="X-Proxy-Token: abc123, CF-Access-Client-Id: client.id"
+```
+
+Notes:
+
+- **Never logged.** The credential and header values never appear in logs, errors, or audit records — messages name only the variable or the header name.
+- **Fail-closed & validated.** A malformed value — Basic auth without a `user:password` shape, a header missing its `:`, an invalid header name, or a newline/control character in a value — is rejected at startup and never sent on the wire. In HTTP mode (`PORT` set) the server refuses to start; in STDIO mode it logs the error and drops the bad value (matching the existing zero-config startup behavior). Either way the malformed credential is never used.
+- **No commas or newlines inside a header value** — commas delimit the pairs, and newlines are rejected to prevent header injection.
+- **Precedence.** A custom `Authorization` header in `SEARXNG_HEADERS` overrides `SEARXNG_BASIC_AUTH` (last writer wins), which lets a bearer-token proxy take priority.
+- Auth applies whenever `SEARXNG_URL` is set — including when SearXNG is only a `SEARCH_ROUTING` or fallback target, not just when `SEARCH_PROVIDER=searxng`.
+- Never commit real credentials; set these as deployment secrets.
+
 ---
 
 ## SearchAPI.io

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -230,6 +230,8 @@ Note: Google keys are validated as required only when you explicitly select `SEA
 | `SERPER_API_KEY` | Serper.dev API key | — |
 | `SEARCHAPI_API_KEY` | SearchAPI.io API key | — |
 | `SEARXNG_URL` | SearXNG instance URL | — |
+| `SEARXNG_BASIC_AUTH` | HTTP Basic credential `user:password` for a SearXNG behind Basic auth (malformed value fails startup; never logged) | — |
+| `SEARXNG_HEADERS` | Static request headers for SearXNG as comma-separated `Name: Value` pairs (no commas/newlines in a value; a custom `Authorization` overrides `SEARXNG_BASIC_AUTH`) | — |
 | `CUSTOM_LENSES_PATH` | External lenses directory | — |
 
 ### Patent Providers (Optional)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,8 @@ type SearchConfig struct {
 	SerperAPIKey     string
 	SearchAPIKey     string
 	SearXNGURL       string
+	SearXNGBasicAuth string            // raw "user:password" for a SearXNG behind HTTP Basic auth; "" => none (never logged)
+	SearXNGHeaders   map[string]string // validated static request headers for SearXNG; nil/empty => none
 	CustomLensesPath string
 
 	// Patent-specific providers (optional, enables structured patent search)
@@ -204,6 +206,20 @@ func Load() (*Config, error) {
 	if provider == "searxng" && searxngURL == "" {
 		errs = append(errs, "SEARXNG_URL is required when SEARCH_PROVIDER=searxng")
 	}
+
+	// SearXNG auth (optional). Parsed unconditionally — not gated on
+	// SEARCH_PROVIDER=searxng — because SearXNG can also be a SEARCH_ROUTING or
+	// fallback target. Malformed values are fail-closed (append to errs so the
+	// server refuses to start) with redacted messages that never echo the
+	// credential or a header value.
+	searxngBasicAuth := os.Getenv("SEARXNG_BASIC_AUTH")
+	if searxngBasicAuth != "" {
+		if _, _, ok := splitSearXNGBasicAuth(searxngBasicAuth); !ok {
+			errs = append(errs, "SEARXNG_BASIC_AUTH must be in 'user:password' form (non-empty username and password, single ':' delimiter)")
+		}
+	}
+	searxngHeaders, hdrErrs := parseSearXNGHeaders(os.Getenv("SEARXNG_HEADERS"))
+	errs = append(errs, hdrErrs...)
 
 	searchAPIKey := os.Getenv("SEARCHAPI_API_KEY")
 	if provider == "searchapi" && searchAPIKey == "" {
@@ -291,6 +307,8 @@ func Load() (*Config, error) {
 			SerperAPIKey:      serperKey,
 			SearchAPIKey:      searchAPIKey,
 			SearXNGURL:        searxngURL,
+			SearXNGBasicAuth:  searxngBasicAuth,
+			SearXNGHeaders:    searxngHeaders,
 			CustomLensesPath:  os.Getenv("CUSTOM_LENSES_PATH"),
 			USPTOAPIKey:       os.Getenv("USPTO_API_KEY"),
 			EPOConsumerKey:    os.Getenv("EPO_OPS_CONSUMER_KEY"),
@@ -469,6 +487,76 @@ func validateStdioUserID(raw string) (string, bool) {
 		}
 	}
 	return s, true
+}
+
+// splitSearXNGBasicAuth splits "user:password" on the FIRST colon. ok is true
+// only when a colon is present and both halves are non-empty. The password
+// (everything after the first colon) is preserved verbatim, so passwords may
+// contain colons.
+func splitSearXNGBasicAuth(raw string) (user, pass string, ok bool) {
+	user, pass, found := strings.Cut(raw, ":")
+	if !found || user == "" || pass == "" {
+		return "", "", false
+	}
+	return user, pass, true
+}
+
+// parseSearXNGHeaders parses "Name1: V1, Name2: V2" into a map. It splits on
+// commas, each segment on its FIRST colon, trims ASCII space/tab around name
+// and value, skips blank segments (tolerating trailing/doubled commas), and
+// validates each name as an RFC 7230 token and each value as free of CR/LF/NUL
+// — closing CRLF header-injection at the boundary. It returns the map plus
+// redacted error strings (header NAME or shape only, never the value). Empty
+// input => (nil, nil), the zero-config path identical to today. Duplicate
+// names: last wins, deterministic across restarts.
+func parseSearXNGHeaders(raw string) (map[string]string, []string) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, nil
+	}
+	out := make(map[string]string)
+	var errsOut []string
+	for _, seg := range strings.Split(raw, ",") {
+		if strings.TrimSpace(seg) == "" {
+			continue // tolerate trailing/doubled commas
+		}
+		name, value, found := strings.Cut(seg, ":")
+		name = strings.TrimSpace(name)
+		value = strings.TrimSpace(value)
+		if !found {
+			errsOut = append(errsOut, "SEARXNG_HEADERS entry is missing a ':' delimiter")
+			continue
+		}
+		if !isHTTPToken(name) {
+			errsOut = append(errsOut, fmt.Sprintf("SEARXNG_HEADERS header name %q is not a valid HTTP token", name))
+			continue
+		}
+		if strings.ContainsAny(value, "\r\n\x00") {
+			errsOut = append(errsOut, fmt.Sprintf("SEARXNG_HEADERS value for header %q contains a forbidden control character", name))
+			continue
+		}
+		out[name] = value
+	}
+	if len(out) == 0 {
+		return nil, errsOut
+	}
+	return out, errsOut
+}
+
+// isHTTPToken reports whether s is a non-empty RFC 7230 header-name token.
+func isHTTPToken(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'a' && c <= 'z', c >= 'A' && c <= 'Z', c >= '0' && c <= '9':
+		case strings.IndexByte("!#$%&'*+-.^_`|~", c) >= 0:
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 func defaultCacheDir() string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log/slog"
+	"net/textproto"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -507,8 +508,10 @@ func splitSearXNGBasicAuth(raw string) (user, pass string, ok bool) {
 // validates each name as an RFC 7230 token and each value as free of CR/LF/NUL
 // — closing CRLF header-injection at the boundary. It returns the map plus
 // redacted error strings (header NAME or shape only, never the value). Empty
-// input => (nil, nil), the zero-config path identical to today. Duplicate
-// names: last wins, deterministic across restarts.
+// input => (nil, nil), the zero-config path identical to today. Names are
+// canonicalized (textproto.CanonicalMIMEHeaderKey), so case-variant duplicates
+// collapse to one entry; duplicate names: last wins, deterministic across
+// restarts. An empty value is allowed (RFC 7230 permits empty header values).
 func parseSearXNGHeaders(raw string) (map[string]string, []string) {
 	if strings.TrimSpace(raw) == "" {
 		return nil, nil
@@ -534,7 +537,10 @@ func parseSearXNGHeaders(raw string) (map[string]string, []string) {
 			errsOut = append(errsOut, fmt.Sprintf("SEARXNG_HEADERS value for header %q contains a forbidden control character", name))
 			continue
 		}
-		out[name] = value
+		// Canonicalize the name (e.g. "x-api-key" -> "X-Api-Key") so dedup matches
+		// the on-the-wire key http.Header.Set uses; otherwise case-variant
+		// duplicates would collide nondeterministically via random map order.
+		out[textproto.CanonicalMIMEHeaderKey(name)] = value
 	}
 	if len(out) == 0 {
 		return nil, errsOut

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1129,3 +1129,179 @@ func TestStdioUserID(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// SearXNG auth (issue #109)
+// =============================================================================
+
+func TestSplitSearXNGBasicAuth(t *testing.T) {
+	tests := []struct {
+		name, in, user, pass string
+		ok                   bool
+	}{
+		{"valid", "alice:secret", "alice", "secret", true},
+		{"colon in password", "u:a:b:c", "u", "a:b:c", true},
+		{"no colon", "nocolon", "", "", false},
+		{"empty user", ":pass", "", "", false},
+		{"empty pass", "user:", "", "", false},
+		{"empty", "", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			u, p, ok := splitSearXNGBasicAuth(tt.in)
+			if ok != tt.ok || u != tt.user || p != tt.pass {
+				t.Errorf("splitSearXNGBasicAuth(%q) = (%q,%q,%v), want (%q,%q,%v)", tt.in, u, p, ok, tt.user, tt.pass, tt.ok)
+			}
+		})
+	}
+}
+
+func TestParseSearXNGHeaders(t *testing.T) {
+	t.Run("empty => nil, no errors", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("")
+		if m != nil || len(errs) != 0 {
+			t.Errorf("expected (nil, nil), got (%v, %v)", m, errs)
+		}
+		m, errs = parseSearXNGHeaders("   ")
+		if m != nil || len(errs) != 0 {
+			t.Errorf("whitespace-only: expected (nil, nil), got (%v, %v)", m, errs)
+		}
+	})
+
+	t.Run("valid pairs with trimming", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("  X-Api-Key :  abc , CF-Access-Client-Id: xyz ")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if m["X-Api-Key"] != "abc" || m["CF-Access-Client-Id"] != "xyz" {
+			t.Errorf("unexpected map: %v", m)
+		}
+	})
+
+	t.Run("value may contain colons", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("Authorization: Bearer abc:def")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if m["Authorization"] != "Bearer abc:def" {
+			t.Errorf("got %q", m["Authorization"])
+		}
+	})
+
+	t.Run("blank/doubled/trailing commas skipped", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("X-A: 1,,X-B: 2, ")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(m) != 2 || m["X-A"] != "1" || m["X-B"] != "2" {
+			t.Errorf("unexpected map: %v", m)
+		}
+	})
+
+	t.Run("duplicate name last wins", func(t *testing.T) {
+		m, _ := parseSearXNGHeaders("X-A: 1, X-A: 2")
+		if m["X-A"] != "2" {
+			t.Errorf("expected last-wins '2', got %q", m["X-A"])
+		}
+	})
+
+	t.Run("missing colon => generic error, no value leak", func(t *testing.T) {
+		_, errs := parseSearXNGHeaders("BadEntryWithoutColon")
+		if len(errs) != 1 || !strings.Contains(errs[0], "missing a ':'") {
+			t.Fatalf("expected missing-colon error, got %v", errs)
+		}
+		if strings.Contains(errs[0], "BadEntryWithoutColon") {
+			t.Errorf("error must not echo the raw entry: %q", errs[0])
+		}
+	})
+
+	t.Run("invalid token name", func(t *testing.T) {
+		_, errs := parseSearXNGHeaders("X Bad: v")
+		if len(errs) != 1 || !strings.Contains(errs[0], "not a valid HTTP token") {
+			t.Errorf("expected token error, got %v", errs)
+		}
+	})
+
+	t.Run("CRLF/NUL in value rejected without leaking value", func(t *testing.T) {
+		for _, bad := range []string{"X-Inject: a\r\nEvil: 1", "X-Inject: a\nb", "X-Inject: a\x00b"} {
+			_, errs := parseSearXNGHeaders(bad)
+			if len(errs) != 1 || !strings.Contains(errs[0], "forbidden control character") {
+				t.Fatalf("expected control-char rejection for %q, got %v", bad, errs)
+			}
+			if strings.Contains(errs[0], "Evil") || strings.Contains(errs[0], "\n") || strings.Contains(errs[0], "\x00") {
+				t.Errorf("error leaked the value: %q", errs[0])
+			}
+		}
+	})
+}
+
+func TestLoadSearXNGBasicAuthValid(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SEARCH_PROVIDER", "searxng")
+	t.Setenv("SEARXNG_URL", "http://localhost:8080")
+	t.Setenv("SEARXNG_BASIC_AUTH", "svc:a:b:c") // colon-in-password, valid shape
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Search.SearXNGBasicAuth != "svc:a:b:c" {
+		t.Errorf("basic auth stored verbatim, got %q", cfg.Search.SearXNGBasicAuth)
+	}
+}
+
+func TestLoadSearXNGBasicAuthMalformedFailsClosedRedacted(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SEARCH_PROVIDER", "searxng")
+	t.Setenv("SEARXNG_URL", "http://localhost:8080")
+	t.Setenv("SEARXNG_BASIC_AUTH", "topsecretpassword") // no colon
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected fail-closed error for malformed SEARXNG_BASIC_AUTH")
+	}
+	if strings.Contains(err.Error(), "topsecretpassword") {
+		t.Errorf("error leaked the credential: %v", err)
+	}
+}
+
+func TestLoadSearXNGHeadersValid(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SEARCH_PROVIDER", "searxng")
+	t.Setenv("SEARXNG_URL", "http://localhost:8080")
+	t.Setenv("SEARXNG_HEADERS", "X-Api-Key: abc, CF-Access-Client-Id: xyz")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Search.SearXNGHeaders["X-Api-Key"] != "abc" || cfg.Search.SearXNGHeaders["CF-Access-Client-Id"] != "xyz" {
+		t.Errorf("unexpected headers map: %v", cfg.Search.SearXNGHeaders)
+	}
+}
+
+func TestLoadSearXNGHeadersInjectionFailsClosedRedacted(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SEARCH_PROVIDER", "searxng")
+	t.Setenv("SEARXNG_URL", "http://localhost:8080")
+	t.Setenv("SEARXNG_HEADERS", "X-Token: secretval\r\nEvil-Injected: 1")
+	_, err := Load()
+	if err == nil {
+		t.Fatal("expected fail-closed error for CRLF in SEARXNG_HEADERS")
+	}
+	if strings.Contains(err.Error(), "secretval") || strings.Contains(err.Error(), "Evil-Injected") {
+		t.Errorf("error leaked header value/injected name: %v", err)
+	}
+}
+
+func TestLoadSearXNGAuthUnsetZeroConfig(t *testing.T) {
+	setRequiredEnv(t)
+	t.Setenv("SEARCH_PROVIDER", "searxng")
+	t.Setenv("SEARXNG_URL", "http://localhost:8080")
+	t.Setenv("SEARXNG_BASIC_AUTH", "")
+	t.Setenv("SEARXNG_HEADERS", "")
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.Search.SearXNGBasicAuth != "" || cfg.Search.SearXNGHeaders != nil {
+		t.Errorf("expected zero-config (empty/nil), got auth=%q headers=%v", cfg.Search.SearXNGBasicAuth, cfg.Search.SearXNGHeaders)
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1173,7 +1173,8 @@ func TestParseSearXNGHeaders(t *testing.T) {
 		if len(errs) != 0 {
 			t.Fatalf("unexpected errors: %v", errs)
 		}
-		if m["X-Api-Key"] != "abc" || m["CF-Access-Client-Id"] != "xyz" {
+		// Names are canonicalized: "CF-Access-Client-Id" => "Cf-Access-Client-Id".
+		if m["X-Api-Key"] != "abc" || m["Cf-Access-Client-Id"] != "xyz" {
 			t.Errorf("unexpected map: %v", m)
 		}
 	})
@@ -1202,6 +1203,35 @@ func TestParseSearXNGHeaders(t *testing.T) {
 		m, _ := parseSearXNGHeaders("X-A: 1, X-A: 2")
 		if m["X-A"] != "2" {
 			t.Errorf("expected last-wins '2', got %q", m["X-A"])
+		}
+	})
+
+	t.Run("case-variant names canonicalize and dedup deterministically", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("x-api-key: 1, X-API-KEY: 2")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if len(m) != 1 || m["X-Api-Key"] != "2" {
+			t.Errorf("expected single canonical key X-Api-Key=2, got %v", m)
+		}
+	})
+
+	t.Run("empty value allowed (RFC 7230)", func(t *testing.T) {
+		m, errs := parseSearXNGHeaders("X-Flag:")
+		if len(errs) != 0 {
+			t.Fatalf("unexpected errors: %v", errs)
+		}
+		if v, ok := m["X-Flag"]; !ok || v != "" {
+			t.Errorf("expected X-Flag set to empty string, got %v (ok=%v)", m, ok)
+		}
+	})
+
+	t.Run("comma in value splits into a malformed second entry", func(t *testing.T) {
+		// Documented limitation: commas delimit pairs, so "a, b" splits and the
+		// "b" fragment has no colon => fail-closed error (never silently mangled).
+		_, errs := parseSearXNGHeaders("X-List: a, b")
+		if len(errs) != 1 || !strings.Contains(errs[0], "missing a ':'") {
+			t.Errorf("expected the post-comma fragment to error, got %v", errs)
 		}
 	})
 
@@ -1272,7 +1302,7 @@ func TestLoadSearXNGHeadersValid(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.Search.SearXNGHeaders["X-Api-Key"] != "abc" || cfg.Search.SearXNGHeaders["CF-Access-Client-Id"] != "xyz" {
+	if cfg.Search.SearXNGHeaders["X-Api-Key"] != "abc" || cfg.Search.SearXNGHeaders["Cf-Access-Client-Id"] != "xyz" {
 		t.Errorf("unexpected headers map: %v", cfg.Search.SearXNGHeaders)
 	}
 }

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -116,7 +116,7 @@ func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 	case "serper":
 		return NewSerperProvider(cfg.SerperAPIKey, deps)
 	case "searxng":
-		return NewSearXNGProvider(cfg.SearXNGURL, deps)
+		return NewSearXNGProvider(cfg.SearXNGURL, cfg.SearXNGBasicAuth, cfg.SearXNGHeaders, deps)
 	case "searchapi":
 		return NewSearchAPIProvider(cfg.SearchAPIKey, deps)
 	case "duckduckgo":
@@ -147,7 +147,7 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 		}
 	case "searxng":
 		if cfg.SearXNGURL != "" {
-			return NewSearXNGProvider(cfg.SearXNGURL, deps)
+			return NewSearXNGProvider(cfg.SearXNGURL, cfg.SearXNGBasicAuth, cfg.SearXNGHeaders, deps)
 		}
 	case "searchapi":
 		if cfg.SearchAPIKey != "" {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -468,7 +468,7 @@ func TestSearXNGProvider_WebSearch(t *testing.T) {
 	defer ts.Close()
 
 	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
-	s := NewSearXNGProvider(ts.URL, deps)
+	s := NewSearXNGProvider(ts.URL, "", nil, deps)
 
 	results, err := s.Web(context.Background(), WebSearchParams{Query: "test", NumResults: 5})
 	if err != nil {
@@ -503,7 +503,7 @@ func TestSearXNGProvider_NewsSearch(t *testing.T) {
 	defer ts.Close()
 
 	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
-	s := NewSearXNGProvider(ts.URL, deps)
+	s := NewSearXNGProvider(ts.URL, "", nil, deps)
 
 	results, err := s.News(context.Background(), NewsSearchParams{Query: "tech", NumResults: 5, Freshness: "week"})
 	if err != nil {
@@ -535,7 +535,7 @@ func TestSearXNGProvider_LimitsResults(t *testing.T) {
 	defer ts.Close()
 
 	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
-	s := NewSearXNGProvider(ts.URL, deps)
+	s := NewSearXNGProvider(ts.URL, "", nil, deps)
 
 	results, err := s.Web(context.Background(), WebSearchParams{Query: "test", NumResults: 3})
 	if err != nil {
@@ -543,6 +543,146 @@ func TestSearXNGProvider_LimitsResults(t *testing.T) {
 	}
 	if len(results) != 3 {
 		t.Errorf("expected 3 results (capped), got %d", len(results))
+	}
+}
+
+func TestSearXNGProvider_NoAuthWhenUnset(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "" {
+			t.Errorf("expected no Authorization header, got %q", got)
+		}
+		if got := r.Header.Get("X-Api-Key"); got != "" {
+			t.Errorf("expected no custom header, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x"}}})
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	s := NewSearXNGProvider(ts.URL, "", nil, deps)
+	if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearXNGProvider_BasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if !ok || u != "alice" || p != "secret" {
+			t.Errorf("expected basic auth alice/secret, got user=%q pass=%q ok=%v", u, p, ok)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x"}}})
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	s := NewSearXNGProvider(ts.URL, "alice:secret", nil, deps)
+	if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestSearXNGProvider_BasicAuthColonInPassword(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		u, p, _ := r.BasicAuth()
+		if u != "u" || p != "a:b:c" {
+			t.Errorf("expected user=u pass=a:b:c, got user=%q pass=%q", u, p)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x"}}})
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	s := NewSearXNGProvider(ts.URL, "u:a:b:c", nil, deps)
+	if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestSearXNGProvider_CustomHeadersAllPaths proves the headers map is injected
+// on Web, Images, AND News — i.e. that all three share the doRequest choke point.
+func TestSearXNGProvider_CustomHeadersAllPaths(t *testing.T) {
+	headers := map[string]string{"X-Proxy-Token": "abc123", "CF-Access-Client-Id": "client.id"}
+	check := func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Proxy-Token") != "abc123" || r.Header.Get("CF-Access-Client-Id") != "client.id" {
+			t.Errorf("missing custom headers on %s: %v", r.URL.Query().Get("categories"), r.Header)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x", ImgSrc: "http://img"}}})
+	}
+	ts := httptest.NewServer(http.HandlerFunc(check))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	s := NewSearXNGProvider(ts.URL, "", headers, deps)
+	if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("Web error: %v", err)
+	}
+	if _, err := s.Images(context.Background(), ImageSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("Images error: %v", err)
+	}
+	if _, err := s.News(context.Background(), NewsSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("News error: %v", err)
+	}
+}
+
+// TestSearXNGProvider_HeadersOverrideBasicAuth documents last-writer-wins: a
+// custom Authorization header in SEARXNG_HEADERS overrides Basic auth.
+func TestSearXNGProvider_HeadersOverrideBasicAuth(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer t0ken" {
+			t.Errorf("expected custom bearer to win, got %q", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x"}}})
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	s := NewSearXNGProvider(ts.URL, "alice:secret", map[string]string{"Authorization": "Bearer t0ken"}, deps)
+	if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestSearXNGProvider_HalfFormedBasicAuthNotSent guards the wire-safety
+// invariant: a half-formed credential that config flagged but (in STDIO mode)
+// did not abort startup must still never reach the server.
+func TestSearXNGProvider_HalfFormedBasicAuthNotSent(t *testing.T) {
+	for _, bad := range []string{"user:", ":pass", "nocolon"} {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if got := r.Header.Get("Authorization"); got != "" {
+				t.Errorf("half-formed basicAuth %q must not be sent, got %q", bad, got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			json.NewEncoder(w).Encode(searxngResponse{Results: []searxngResult{{Title: "R", URL: "http://x"}}})
+		}))
+		deps := Deps{HTTPClient: ts.Client(), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+		s := NewSearXNGProvider(ts.URL, bad, nil, deps)
+		if _, err := s.Web(context.Background(), WebSearchParams{Query: "q", NumResults: 1}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		ts.Close()
+	}
+}
+
+func TestNewProvider_SearXNGThreadsAuth(t *testing.T) {
+	cfg := config.SearchConfig{
+		Provider:         "searxng",
+		SearXNGURL:       "http://localhost:8080",
+		SearXNGBasicAuth: "alice:secret",
+		SearXNGHeaders:   map[string]string{"X-Api-Key": "abc"},
+	}
+	p := NewProvider(cfg, Deps{Breaker: circuit.New(circuit.Config{FailureThreshold: 5})})
+	sx, ok := p.(*SearXNGProvider)
+	if !ok {
+		t.Fatalf("expected *SearXNGProvider, got %T", p)
+	}
+	if sx.basicAuth != "alice:secret" || sx.headers["X-Api-Key"] != "abc" {
+		t.Errorf("auth not threaded to provider: basicAuth=%q headers=%v", sx.basicAuth, sx.headers)
 	}
 }
 

--- a/internal/search/searxng.go
+++ b/internal/search/searxng.go
@@ -7,15 +7,18 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strings"
 )
 
 type SearXNGProvider struct {
-	baseURL string
-	deps    Deps
+	baseURL   string
+	basicAuth string            // "user:password"; "" => no Basic auth
+	headers   map[string]string // validated static headers; nil/empty => none
+	deps      Deps
 }
 
-func NewSearXNGProvider(baseURL string, deps Deps) *SearXNGProvider {
-	return &SearXNGProvider{baseURL: baseURL, deps: deps}
+func NewSearXNGProvider(baseURL, basicAuth string, headers map[string]string, deps Deps) *SearXNGProvider {
+	return &SearXNGProvider{baseURL: baseURL, basicAuth: basicAuth, headers: headers, deps: deps}
 }
 
 func (s *SearXNGProvider) Name() string { return "searxng" }
@@ -135,6 +138,21 @@ func (s *SearXNGProvider) doRequest(ctx context.Context, apiURL string) ([]byte,
 	req, err := http.NewRequestWithContext(ctx, "GET", apiURL, nil)
 	if err != nil {
 		return nil, err
+	}
+
+	// Auth injection (operator infrastructure credentials, validated at config
+	// load). Basic auth first; custom headers after, so a custom Authorization
+	// header in SEARXNG_HEADERS deterministically overrides Basic (last wins).
+	// The user/pass non-empty guard mirrors config.splitSearXNGBasicAuth so a
+	// half-formed credential (e.g. "user:") is never put on the wire even in
+	// STDIO mode, where config errors are logged-but-not-fatal. s.headers only
+	// ever holds entries that passed config validation, so the loop cannot
+	// inject a malformed header.
+	if user, pass, found := strings.Cut(s.basicAuth, ":"); found && user != "" && pass != "" {
+		req.SetBasicAuth(user, pass)
+	}
+	for k, v := range s.headers {
+		req.Header.Set(k, v)
 	}
 
 	resp, err := s.deps.HTTPClient.Do(req)


### PR DESCRIPTION
Closes #109.

## Problem

An operator running a self-hosted SearXNG behind **HTTP Basic auth** (or a reverse proxy requiring a token) couldn't use it: `SearXNGProvider.doRequest` sent no auth/custom headers, so protected instances returned `401`. There was no config to supply credentials.

## Solution

Two optional, deploy-time env vars — parsed and validated entirely at the config boundary (`internal/config/config.go`), threaded through both `provider.go` construction sites into read-only fields on `SearXNGProvider`, and injected at the **single `doRequest` choke point** shared by `Web`/`Images`/`News`:

| Var | Purpose |
|---|---|
| `SEARXNG_BASIC_AUTH=user:password` | HTTP Basic auth via `req.SetBasicAuth` (RFC 7617 — same primitive as the EPO provider). First colon splits user/password, so colons in the password are preserved. |
| `SEARXNG_HEADERS="Name: Value, ..."` | Comma-separated static headers for non-Basic schemes (bearer token, Cloudflare Access service token, API-gateway secret). Applied **after** Basic auth, so a custom `Authorization` header overrides it (documented last-writer-wins). |

**Unset → byte-for-byte today's behavior** (zero-config preserved).

## Security

- **CRLF/header-injection closed at the boundary:** header names validated as RFC 7230 tokens; values rejected if they contain `\r`, `\n`, or `\x00`.
- **Secrets never logged:** config errors name only the variable or the header *name*, never the value (regression-guarded by tests asserting the credential substring is absent from the error).
- **Fail-closed & never on the wire:** malformed values are rejected at startup (HTTP mode refuses to start; STDIO logs-and-drops per the existing zero-config behavior). A provider-side non-empty guard mirrors the validator so a half-formed credential like `user:` can't reach the wire even on the STDIO log-and-continue path.
- **No new dependency** (stdlib only); requests still flow through the shared SSRF-safe client. SearXNG auth is operator/infrastructure-level (not per-tenant), and the provider is read-only after construction → concurrent-session safe with no locking, identical across STDIO/HTTP.

## How the architecture was chosen

Ran a multi-agent design workflow: three competing architecture candidates (KISS-minimalist, headers-unified, enterprise/compliance) → an architect agent scored them against correctness/KISS/security/ergonomics/parity and synthesized one spec. Winner: the enterprise/gov base (fail-closed, injection defense, redaction) with the minimalist candidate's lean two-var surface.

## Testing

- **Unit:** config helpers (`splitSearXNGBasicAuth`, `parseSearXNGHeaders` incl. CRLF/NUL rejection, trimming, duplicate-last-wins, colon-in-password); `Load()` redaction + fail-closed; provider auth/headers across **all three** search paths; last-writer-wins; half-formed-not-sent guard; factory threading.
- **Real end-to-end smoke** against a mock SearXNG requiring auth: correct Basic auth served the gated result; wrong password → `searxng error 401` + `isError` with no leak; `X-Proxy-Token` delivered; malformed config redacted in logs.
- `go test -race ./...`, `gofmt`, `go vet`, `gosec`, `golangci-lint` — all clean.

## Docs

`.env.example`, `docs/DEPLOYMENT.md` (env table), and `docs/API_SETUP.md` (new "Authenticating to a protected SearXNG" subsection) — accuracy validated against the real binary behavior, including the HTTP-vs-STDIO fail-mode distinction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
