### PR TITLE
test: deflake TestTTLExpiry

### DIFF
--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -227,7 +227,13 @@ func TestDeleteAll(t *testing.T) {
 }
 
 func TestTTLExpiry(t *testing.T) {
-	m := newTestManager(50*time.Millisecond, 10)
+	// Use a generous TTL so the "accessible immediately" assertion cannot lose a
+	// race against expiry on a loaded CI runner (a GC pause or scheduler delay
+	// between Create and the first GetIndex must stay under the TTL). The sleep is
+	// scaled well past the TTL so expiry stays deterministic. A previous 50ms TTL
+	// made the first assertion flaky in CI.
+	const ttl = 250 * time.Millisecond
+	m := newTestManager(ttl, 10)
 	defer m.Close()
 
 	idx, _ := m.Create("tenant-1", "u1")
@@ -237,7 +243,7 @@ func TestTTLExpiry(t *testing.T) {
 		t.Fatal("session should be accessible immediately after creation")
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	time.Sleep(ttl * 3)
 
 	_, ok = m.GetIndex("tenant-1", "u1", idx.ID)
 	if ok {


### PR DESCRIPTION
## Why

The CI `Test` job showed red on commit `366f5c7` (v1.16.0). Root cause: GitHub rolls checks up by **commit SHA**, and the `v1.16.0` tag points at the same commit as `main` HEAD — so a flaky `Test` run triggered by the *tag* push attached its failure to the commit, even though the *branch* push CI on the same commit was green.

The flake is `TestTTLExpiry` in `internal/session` — a package v1.16.0 did not touch. It created a session with a **50ms TTL** then asserted it was accessible "immediately after creation"; under CI load a GC/scheduler delay between `Create` and the first `GetIndex` could exceed 50ms and expire the session, failing the first assertion.

## Fix

Test-only: raise the TTL to 250ms (well above realistic jitter) and scale the post-expiry sleep to 3× the TTL so expiry stays deterministic. No production code changed. Passes **30/30** under `-count` stress locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)