### PR TITLE
ci: sign Windows .exe via Azure Trusted Signing (replaces SignPath)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,71 +61,96 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
 
-      - name: Sign Windows binary (SignPath)
-        if: ${{ vars.SIGNPATH_ENABLED == 'true' }}
+      # ── Windows Authenticode signing via Azure Trusted/Artifact Signing ──────
+      # Signs the GoReleaser-built .exe IN PLACE on this Linux runner using jsign
+      # (no Windows job, no Wine — jsign calls the Azure REST endpoint directly),
+      # then re-packages the zip and rewrites checksums so the published artifact
+      # and checksums.txt cover the SIGNED binary. Gated on AZURE_SIGNING_ENABLED
+      # so an unset/false flag ships unsigned exactly as before (zero regression).
+      # Identity: CN=Zohar Babin (Azure individual validation). Certs are short-
+      # lived (~3 days) and auto-rotate per sign; the RFC-3161 timestamp keeps the
+      # signature valid after the cert expires. See docs/RELEASE_SIGNING.md.
+      - name: Sign Windows binary (Azure Trusted Signing)
+        if: ${{ vars.AZURE_SIGNING_ENABLED == 'true' }}
         id: sign-windows
+        env:
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          # Endpoint host for the signing account's region (East US).
+          SIGN_ENDPOINT: https://eus.codesigning.azure.net/
+          # jsign alias = "<account>/<certificate-profile>".
+          SIGN_ALIAS: web-researcher-signing/web-researcher-public
         run: |
-          # Find the Windows exe built by GoReleaser
+          set -euo pipefail
           WIN_EXE=$(find dist -name "web-researcher-mcp.exe" -path "*windows*" | head -1)
           if [ -z "$WIN_EXE" ]; then
             echo "::warning::Windows exe not found in dist/, skipping signing"
             exit 0
           fi
+
+          # Toolchain: JRE for jsign + Azure CLI for the access token.
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq default-jre-headless
+          if ! command -v az >/dev/null 2>&1; then
+            curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash >/dev/null
+          fi
+
+          JSIGN_VERSION="7.4"
+          curl -fsSL -o /tmp/jsign.jar \
+            "https://github.com/ebourg/jsign/releases/download/${JSIGN_VERSION}/jsign-${JSIGN_VERSION}.jar"
+
+          # Service-principal login → token scoped to the code-signing resource.
+          az login --service-principal \
+            -u "$AZURE_CLIENT_ID" -p "$AZURE_CLIENT_SECRET" --tenant "$AZURE_TENANT_ID" >/dev/null
+          ACCESS_TOKEN=$(az account get-access-token \
+            --resource https://codesigning.azure.net \
+            --query accessToken -o tsv)
+
+          # Sign in place. Timestamp via Microsoft RFC-3161 TSA so the signature
+          # outlives the short-lived cert.
+          java -jar /tmp/jsign.jar \
+            --storetype TRUSTEDSIGNING \
+            --keystore "$SIGN_ENDPOINT" \
+            --storepass "$ACCESS_TOKEN" \
+            --alias "$SIGN_ALIAS" \
+            --tsmode RFC3161 \
+            --tsaurl http://timestamp.acs.microsoft.com \
+            "$WIN_EXE"
+
           echo "exe_path=$WIN_EXE" >> "$GITHUB_OUTPUT"
-          mkdir -p unsigned-artifact
-          cp "$WIN_EXE" unsigned-artifact/web-researcher-mcp.exe
+          echo "::notice::Windows binary signed via Azure Trusted Signing"
 
-      - name: Upload unsigned Windows binary
-        if: ${{ vars.SIGNPATH_ENABLED == 'true' && steps.sign-windows.outputs.exe_path != '' }}
-        id: upload-unsigned
-        uses: actions/upload-artifact@v4
-        with:
-          name: web-researcher-mcp-unsigned
-          path: unsigned-artifact/web-researcher-mcp.exe
-
-      - name: Submit SignPath signing request
-        if: ${{ vars.SIGNPATH_ENABLED == 'true' && steps.sign-windows.outputs.exe_path != '' }}
-        id: signpath-sign
-        uses: signpath/github-action-submit-signing-request@v1
-        with:
-          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-          organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-          project-slug: Web-Researcher-MCP
-          signing-policy-slug: release-signing
-          github-artifact-id: ${{ steps.upload-unsigned.outputs.artifact-id }}
-          wait-for-completion: true
-          output-artifact-directory: signed-artifact
-          wait-for-completion-timeout-in-seconds: 300
-
-      - name: Replace unsigned exe in release zip
-        if: ${{ vars.SIGNPATH_ENABLED == 'true' && steps.sign-windows.outputs.exe_path != '' }}
+      - name: Repackage signed Windows zip + checksums
+        if: ${{ vars.AZURE_SIGNING_ENABLED == 'true' && steps.sign-windows.outputs.exe_path != '' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIGNED_EXE: ${{ steps.sign-windows.outputs.exe_path }}
         run: |
+          set -euo pipefail
           VERSION="${GITHUB_REF_NAME#v}"
           ZIP_NAME="web-researcher-mcp_${VERSION}_windows_amd64.zip"
           ZIP_PATH="dist/$ZIP_NAME"
 
-          if [ -f "signed-artifact/web-researcher-mcp.exe" ] && [ -f "$ZIP_PATH" ]; then
-            # Replace the exe inside the zip
-            cd signed-artifact
-            zip -j "../$ZIP_PATH" web-researcher-mcp.exe
-            cd ..
-
-            # Re-upload the zip to the release
-            gh release upload "${{ github.ref_name }}" "$ZIP_PATH" --clobber
-
-            # Update checksums
-            sha256sum "$ZIP_PATH" | sed "s|dist/||" > /tmp/new_checksum.txt
-            if [ -f dist/checksums.txt ]; then
-              grep -v "$ZIP_NAME" dist/checksums.txt > /tmp/remaining.txt || true
-              cat /tmp/remaining.txt /tmp/new_checksum.txt > dist/checksums.txt
-              gh release upload "${{ github.ref_name }}" dist/checksums.txt --clobber
-            fi
-            echo "::notice::Windows binary signed and release updated"
-          else
-            echo "::warning::Signed artifact not found, release contains unsigned binary"
+          if [ ! -f "$ZIP_PATH" ]; then
+            echo "::warning::$ZIP_PATH not found; release retains its archived exe"
+            exit 0
           fi
+
+          # Swap the signed exe into the release zip (the exe is stored flat in the
+          # archive, hence -j), then re-upload and rewrite its checksum entry.
+          cp "$SIGNED_EXE" /tmp/web-researcher-mcp.exe
+          ( cd /tmp && zip -j "$OLDPWD/$ZIP_PATH" web-researcher-mcp.exe )
+
+          gh release upload "${{ github.ref_name }}" "$ZIP_PATH" --clobber
+
+          sha256sum "$ZIP_PATH" | sed "s|dist/||" > /tmp/new_checksum.txt
+          if [ -f dist/checksums.txt ]; then
+            grep -v "$ZIP_NAME" dist/checksums.txt > /tmp/remaining.txt || true
+            cat /tmp/remaining.txt /tmp/new_checksum.txt > dist/checksums.txt
+            gh release upload "${{ github.ref_name }}" dist/checksums.txt --clobber
+          fi
+          echo "::notice::Signed Windows zip and checksums.txt updated"
 
       - name: Build .mcpb bundles
         run: |

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -1,0 +1,71 @@
+# Release Signing
+
+How the Windows `.exe` in each release is Authenticode-signed, and how to operate, rotate, and disable it.
+
+## What & where
+
+Windows binaries are signed with **Azure Trusted Signing** (a.k.a. Azure Artifact Signing) from the release job in `.github/workflows/release.yml`. Signing happens **in place on the Linux runner** via [`jsign`](https://ebourg.github.io/jsign/) — which calls the Azure signing REST endpoint directly, so there is no separate Windows job and no Wine. The job then re-packages the Windows zip and rewrites its `checksums.txt` entry so the published artifact and checksum cover the **signed** binary.
+
+macOS/Linux binaries are not Authenticode-signed (not applicable); release integrity for all platforms is additionally covered by the cosign signatures + SBOM produced by GoReleaser.
+
+## Toggle (mechanical)
+
+- The signing steps run **only when** the repository variable `AZURE_SIGNING_ENABLED == 'true'`.
+- Unset or `false` → releases ship the unsigned binary exactly as before (zero regression). This is the safe default and the fallback if signing ever breaks.
+
+```bash
+gh variable set AZURE_SIGNING_ENABLED --body true     # enable
+gh variable set AZURE_SIGNING_ENABLED --body false    # disable
+```
+
+## Identity & certificate
+
+- Signing identity (individual validation, Azure): `CN=Zohar Babin, O=Zohar Babin, L=Weston, S=fl, C=US`.
+- Certificates issued by Trusted Signing are **short-lived (~3 days) and auto-rotate on every sign**. The signature stays valid after the cert expires because it is **RFC-3161 timestamped** (`http://timestamp.acs.microsoft.com`). This is expected behavior, not a misconfiguration.
+- SmartScreen note: a valid signature establishes a **verified publisher**, but Microsoft SmartScreen reputation still builds with download volume — early downloaders may see a warning that fades over time. No certificate class (OV/EV/Azure) clears SmartScreen instantly.
+
+## Azure resources (fixed inputs)
+
+| Input | Value |
+|-------|-------|
+| Endpoint (region: East US) | `https://eus.codesigning.azure.net/` |
+| Signing account | `web-researcher-signing` |
+| Certificate profile | `web-researcher-public` |
+| jsign alias (`<account>/<profile>`) | `web-researcher-signing/web-researcher-public` |
+
+These are non-secret and live in the workflow. The signing account requires a **paid** Azure subscription (Artifact Signing is unavailable on free/trial subscriptions). Individual eligibility is currently USA/Canada only.
+
+## CI authentication (GitHub Actions secrets)
+
+The release job authenticates as a service principal (`web-researcher-signing-ci`) that holds the **Trusted Signing Certificate Profile Signer** role on the signing account. Three repo secrets are consumed by the Azure CLI login, which then mints the short-lived signing token jsign uses:
+
+| Secret | Purpose |
+|--------|---------|
+| `AZURE_TENANT_ID` | Directory (tenant) ID — identifier, not sensitive |
+| `AZURE_CLIENT_ID` | App (client) ID — identifier, not sensitive |
+| `AZURE_CLIENT_SECRET` | Service-principal client secret — **sensitive** |
+
+`AZURE_SUBSCRIPTION_ID` is also set (used by other Azure flows; not required by signing).
+
+## Rotating the client secret
+
+The client secret expires (set when created). Rotate before expiry, or any time it may have been exposed:
+
+1. Azure portal → **Entra ID → App registrations → `web-researcher-signing-ci` → Certificates & secrets** → **+ New client secret** → copy the new **Value**.
+2. Update the GitHub secret without putting the value in shell history:
+   ```bash
+   gh secret set AZURE_CLIENT_SECRET   # paste at the prompt
+   ```
+3. Update the local keychain copy:
+   ```bash
+   security add-generic-password -a "$USER" -s AZURE_CLIENT_SECRET -w -U   # prompts for value
+   ```
+4. Delete the old secret in the Azure portal.
+
+## Verifying a signed release
+
+On a Windows machine (or with `osslsigncode verify` on Linux/macOS), confirm the published `.exe` shows publisher **Zohar Babin** and a valid timestamp. The release `checksums.txt` entry for `*_windows_amd64.zip` must match the re-uploaded signed zip.
+
+## Local secret convention (maintainer)
+
+Secret **names** are registered in `~/.zshenv` (`_SECRETS`); **values** live in the macOS Keychain (`_keychain_set <NAME>`). The `AZURE_CLIENT_ID` / `AZURE_TENANT_ID` / `AZURE_CLIENT_SECRET` entries follow that pattern.


### PR DESCRIPTION
## Why
SignPath Foundation declined the project (traction gate, not quality — reapply once adoption grows). Windows Authenticode signing moves to **Azure Trusted/Artifact Signing**: paid (~\$10/mo), no traction gate, individual-eligible (US), and CI-native. Azure identity validation is **complete** and a **Public Trust** certificate profile is **Active** (`CN=Zohar Babin, …, C=US`).

## What
Replaces the 4 gated SignPath steps in `release.yml` with a **jsign**-based pair that signs the GoReleaser-built `.exe` **in place on the existing Linux runner** — jsign 7.4 calls the Azure signing REST endpoint directly, so **no separate Windows job and no Wine** (the jsign-author-endorsed path). It then re-zips and rewrites the `checksums.txt` entry so the published artifact + checksum cover the **signed** binary (same proven repackage plumbing as before).

- **Feature-gated** on `vars.AZURE_SIGNING_ENABLED` — unset/`false` ⇒ unsigned exactly as today (**zero regression**).
- **Auth:** service principal `web-researcher-signing-ci` with the **Trusted Signing Certificate Profile Signer** role on the account → `az login` → token scoped to `https://codesigning.azure.net` → `jsign --storepass`.
- **Endpoint** `eus.codesigning.azure.net` (East US), **alias** `web-researcher-signing/web-researcher-public`. **RFC-3161 timestamp** keeps the signature valid past the short-lived (~3-day) auto-rotating cert.
- New `docs/RELEASE_SIGNING.md`: operate / rotate-secret / disable guide; honest SmartScreen note (reputation builds with download volume — no cert clears it instantly).

## Secrets (set out of band)
`AZURE_TENANT_ID` / `AZURE_CLIENT_ID` / `AZURE_CLIENT_SECRET` / `AZURE_SUBSCRIPTION_ID` are configured as repo secrets. The legacy `SIGNPATH_*` secrets/vars can be deleted once this is verified on a live release.

## Go-live (after merge)
1. `gh variable set AZURE_SIGNING_ENABLED --body true`
2. Cut a `v*` tag; confirm the Windows `.exe` shows publisher **Zohar Babin** + valid timestamp, and `checksums.txt` matches the re-uploaded signed zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)