### PR TITLE
fix: drop trailing slash from Azure signing endpoint (jsign 404)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,8 +77,10 @@ jobs:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
           AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
-          # Endpoint host for the signing account's region (East US).
-          SIGN_ENDPOINT: https://eus.codesigning.azure.net/
+          # Endpoint host for the signing account's region (East US). NO trailing
+          # slash — jsign concatenates the API path directly, so a trailing slash
+          # produces a double-slash URL and a 404 from the signing endpoint.
+          SIGN_ENDPOINT: https://eus.codesigning.azure.net
           # jsign alias = "<account>/<certificate-profile>".
           SIGN_ALIAS: web-researcher-signing/web-researcher-public
         run: |

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -28,7 +28,7 @@ gh variable set AZURE_SIGNING_ENABLED --body false    # disable
 
 | Input | Value |
 |-------|-------|
-| Endpoint (region: East US) | `https://eus.codesigning.azure.net/` |
+| Endpoint (region: East US) | `https://eus.codesigning.azure.net` (no trailing slash — jsign appends the API path, so a trailing slash 404s) |
 | Signing account | `web-researcher-signing` |
 | Certificate profile | `web-researcher-public` |
 | jsign alias (`<account>/<profile>`) | `web-researcher-signing/web-researcher-public` |


### PR DESCRIPTION
## Why
The first live Azure signing run (v1.16.1) **failed** at the signing step:

```
HTTP Error 404 - Not Found (https://eus.codesigning.azure.net//codesigningaccounts/.../sign?...)
```

jsign concatenates the API path onto the keystore endpoint **literally**, so the trailing slash in `https://eus.codesigning.azure.net/` produced a double-slash URL → 404. Everything else was correct (it was a **404, not a 401** — auth, the `Trusted Signing Certificate Profile Signer` role, token scope `https://codesigning.azure.net`, and alias `web-researcher-signing/web-researcher-public` all worked).

## Fix
One character: use the **bare host** (no trailing slash) for `SIGN_ENDPOINT`. Same correction applied to `docs/RELEASE_SIGNING.md`.

## Follow-up (release redo)
The v1.16.1 release published binaries + Docker but **skipped** the post-signing steps (unsigned Windows zip; missing .mcpb bundles, aggregate SBOM, cosign signatures). After this merges I'll delete and re-cut the v1.16.1 tag to re-run the full pipeline cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)