### PR TITLE
feat: Tavily search provider (#54)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,12 +11,13 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 
 # ── Search Provider (variable default: google; resolves to zero-config ───────
 # ── DuckDuckGo at runtime when google is selected but no key is set) ──────────
-# Options: google, brave, serper, searxng, searchapi, duckduckgo
+# Options: google, brave, serper, searxng, searchapi, duckduckgo, tavily
 # DuckDuckGo requires no API key (works immediately, rate-limited for heavy use)
 # SEARCH_PROVIDER=brave
 # BRAVE_API_KEY=BSA...
 # SERPER_API_KEY=...
 # SEARCHAPI_API_KEY=...
+# TAVILY_API_KEY=tvly-...   # search API built for AI agents; clean LLM-ready content (get from app.tavily.com)
 # SEARXNG_URL=http://localhost:8080
 # If your SearXNG sits behind HTTP Basic auth (issue #109), supply the credential:
 # SEARXNG_BASIC_AUTH=user:password

--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ Set `SEARCH_PROVIDER=brave` and you're done. No Google keys needed.
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SEARCH_PROVIDER` | Which engine to use: `google`, `brave`, `serper`, `searxng`, `searchapi`, or `duckduckgo` | `google` (falls back to `duckduckgo` if no key is set) |
+| `SEARCH_PROVIDER` | Which engine to use: `google`, `brave`, `serper`, `searxng`, `searchapi`, `duckduckgo`, or `tavily` | `google` (falls back to `duckduckgo` if no key is set) |
 | `BRAVE_API_KEY` | Brave Search API key | |
 | `SERPER_API_KEY` | Serper.dev API key (uses Google results) | |
 | `SEARCHAPI_API_KEY` | SearchAPI.io key | |

--- a/docs/API_SETUP.md
+++ b/docs/API_SETUP.md
@@ -145,6 +145,29 @@ export SERPER_API_KEY=your-serper-key
 
 ---
 
+## Tavily
+
+**Free tier**: monthly credits for development; paid plans for higher volume
+
+Tavily is a search API purpose-built for AI agents — it returns clean, extracted, LLM-ready content rather than raw result pages. It supports web and news search (no native image search; image queries fall through to another provider when routing is enabled).
+
+### Step 1: Get an API Key
+
+1. Go to [app.tavily.com](https://app.tavily.com/)
+2. Sign up for an account
+3. Copy the `tvly-...` API key from your dashboard
+
+### Step 2: Configure
+
+```bash
+export SEARCH_PROVIDER=tavily
+export TAVILY_API_KEY=tvly-your-key
+```
+
+The key is sent as an `Authorization: Bearer` header (never in the request body), and queries are capped at Tavily's 400-character limit automatically.
+
+---
+
 ## SearXNG (Self-Hosted)
 
 **Free**: Open source, self-hosted — no API key needed, no query limits
@@ -269,6 +292,7 @@ See [docs/DEPLOYMENT.md](DEPLOYMENT.md) for advanced routing configuration.
 | **Serper** | Google-identical results without PSE setup | One-time free credit only |
 | **SearXNG** | Air-gapped/private deployments, no vendor lock-in | Requires self-hosting |
 | **SearchAPI.io** | Multiple engine backends via unified API | Smaller free tier |
+| **Tavily** | AI-agent search; clean LLM-ready extracted content | Paid after free credits; no native image search |
 
 **Recommendation**: Start with Brave (generous free tier, fast) and add Google as a fallback. Use `SEARCH_ROUTING=brave,google` for the best balance of speed and coverage.
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -223,12 +223,13 @@ Note: Google keys are validated as required only when you explicitly select `SEA
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `SEARCH_PROVIDER` | Primary provider: google, brave, serper, searxng, searchapi, duckduckgo | `google` (variable default); at runtime, when `google` is selected but no Google key is set, the server falls back to the zero-config `duckduckgo` provider |
+| `SEARCH_PROVIDER` | Primary provider: google, brave, serper, searxng, searchapi, duckduckgo, tavily | `google` (variable default); at runtime, when `google` is selected but no Google key is set, the server falls back to the zero-config `duckduckgo` provider |
 | `SEARCH_FALLBACK_PROVIDER` | Fallback provider (simple fallback) | — |
 | `SEARCH_ROUTING` | Multi-provider routing (see below) | — |
 | `BRAVE_API_KEY` | Brave Search API key | — |
 | `SERPER_API_KEY` | Serper.dev API key | — |
 | `SEARCHAPI_API_KEY` | SearchAPI.io API key | — |
+| `TAVILY_API_KEY` | Tavily API key (AI-agent search; sent as a Bearer token) | — |
 | `SEARXNG_URL` | SearXNG instance URL | — |
 | `SEARXNG_BASIC_AUTH` | HTTP Basic credential `user:password` for a SearXNG behind Basic auth (malformed value fails startup; never logged) | — |
 | `SEARXNG_HEADERS` | Static request headers for SearXNG as comma-separated `Name: Value` pairs (no commas/newlines in a value; a custom `Authorization` overrides `SEARXNG_BASIC_AUTH`) | — |

--- a/docs/PRIVACY.md
+++ b/docs/PRIVACY.md
@@ -45,6 +45,7 @@ When you search, your query goes directly to whichever provider you configured. 
 | Brave Search | Your query, your API key | [brave.com/privacy](https://brave.com/privacy/browser/) |
 | Serper.dev | Your query, your API key | [serper.dev/privacy](https://serper.dev/privacy) |
 | SearchAPI.io | Your query, your API key | [searchapi.io/privacy](https://www.searchapi.io/privacy-policy) |
+| Tavily | Your query, your API key | [tavily.com/privacy](https://www.tavily.com/privacy) |
 | SearXNG | Your query (self-hosted — no third party) | N/A (you control the server) |
 | DuckDuckGo | Your query (zero-config default when no provider is configured) | [duckduckgo.com/privacy](https://duckduckgo.com/privacy) |
 | OpenAlex | Your academic query | [openalex.org/legal](https://openalex.org/legal/privacy-policy) |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -480,7 +480,7 @@ On a zero-result response, `hints` carries the same `ZeroResultHints` object as 
 | `pdf_only` | bool | no | false | — |
 | `sort_by` | string | no | `relevance` | relevance, date |
 | `open_access` | bool | no | false | Only return open-access papers |
-| `provider` | string | no | — | Force provider: openalex, crossref (academic APIs), or google, brave, serper, searxng, searchapi (web fallback) |
+| `provider` | string | no | — | Force provider: openalex, crossref (academic APIs), or google, brave, serper, searxng, searchapi, duckduckgo, tavily (web fallback) |
 | `sessionId` | string | no | — | Link results to a `sequential_search` session; sources are auto-recorded for recovery after context loss |
 
 ### Output Fields

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,6 +130,7 @@ type SearchConfig struct {
 	BraveAPIKey      string
 	SerperAPIKey     string
 	SearchAPIKey     string
+	TavilyAPIKey     string
 	SearXNGURL       string
 	SearXNGBasicAuth string            // raw "user:password" for a SearXNG behind HTTP Basic auth; "" => none (never logged)
 	SearXNGHeaders   map[string]string // validated static request headers for SearXNG; nil/empty => none
@@ -227,6 +228,11 @@ func Load() (*Config, error) {
 		errs = append(errs, "SEARCHAPI_API_KEY is required when SEARCH_PROVIDER=searchapi")
 	}
 
+	tavilyKey := os.Getenv("TAVILY_API_KEY")
+	if provider == "tavily" && tavilyKey == "" {
+		errs = append(errs, "TAVILY_API_KEY is required when SEARCH_PROVIDER=tavily")
+	}
+
 	port := envInt("PORT", 0)
 	encKey := os.Getenv("CACHE_ENCRYPTION_KEY")
 	if encKey != "" && len(encKey) != 64 {
@@ -307,6 +313,7 @@ func Load() (*Config, error) {
 			BraveAPIKey:       braveKey,
 			SerperAPIKey:      serperKey,
 			SearchAPIKey:      searchAPIKey,
+			TavilyAPIKey:      tavilyKey,
 			SearXNGURL:        searxngURL,
 			SearXNGBasicAuth:  searxngBasicAuth,
 			SearXNGHeaders:    searxngHeaders,

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -107,7 +107,7 @@ type Deps struct {
 }
 
 // SupportedProviders lists all provider names that can be configured.
-var SupportedProviders = []string{"google", "brave", "serper", "searxng", "searchapi", "duckduckgo"}
+var SupportedProviders = []string{"google", "brave", "serper", "searxng", "searchapi", "duckduckgo", "tavily"}
 
 func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 	switch cfg.Provider {
@@ -119,6 +119,8 @@ func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 		return NewSearXNGProvider(cfg.SearXNGURL, cfg.SearXNGBasicAuth, cfg.SearXNGHeaders, deps)
 	case "searchapi":
 		return NewSearchAPIProvider(cfg.SearchAPIKey, deps)
+	case "tavily":
+		return NewTavilyProvider(cfg.TavilyAPIKey, deps)
 	case "duckduckgo":
 		return NewDuckDuckGoProvider(deps)
 	default:
@@ -153,6 +155,10 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 		if cfg.SearchAPIKey != "" {
 			return NewSearchAPIProvider(cfg.SearchAPIKey, deps)
 		}
+	case "tavily":
+		if cfg.TavilyAPIKey != "" {
+			return NewTavilyProvider(cfg.TavilyAPIKey, deps)
+		}
 	case "duckduckgo":
 		return NewDuckDuckGoProvider(deps)
 	}
@@ -164,7 +170,7 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 // circuit breaker for isolation — failures in one provider don't affect others.
 func AvailableProviders(cfg config.SearchConfig, deps Deps) map[string]Provider {
 	providers := make(map[string]Provider)
-	names := []string{"google", "brave", "serper", "searxng", "searchapi", "duckduckgo"}
+	names := []string{"google", "brave", "serper", "searxng", "searchapi", "duckduckgo", "tavily"}
 	for _, name := range names {
 		providerDeps := Deps{
 			HTTPClient: deps.HTTPClient,

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"unicode/utf8"
 
 	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
 	"github.com/zoharbabin/web-researcher-mcp/internal/config"
@@ -1853,6 +1855,7 @@ func TestAvailableProviders(t *testing.T) {
 		GoogleCX:     "gcx",
 		BraveAPIKey:  "bkey",
 		SearchAPIKey: "skey",
+		TavilyAPIKey: "tkey",
 	}
 	deps := newTestDeps(http.DefaultClient)
 	providers := AvailableProviders(cfg, deps)
@@ -1865,6 +1868,9 @@ func TestAvailableProviders(t *testing.T) {
 	}
 	if _, ok := providers["searchapi"]; !ok {
 		t.Error("expected searchapi provider")
+	}
+	if _, ok := providers["tavily"]; !ok {
+		t.Error("expected tavily provider")
 	}
 	if _, ok := providers["serper"]; ok {
 		t.Error("did not expect serper provider (no key)")
@@ -1892,6 +1898,12 @@ func TestNewProviderByName_MissingCredentials(t *testing.T) {
 	}
 	if p := NewProviderByName("google", cfg, deps); p != nil {
 		t.Error("expected nil for google without both key and cx")
+	}
+	if p := NewProviderByName("tavily", cfg, deps); p != nil {
+		t.Error("expected nil for tavily without key")
+	}
+	if p := NewProviderByName("tavily", config.SearchConfig{TavilyAPIKey: "k"}, deps); p == nil || p.Name() != "tavily" {
+		t.Error("expected tavily provider when key is set")
 	}
 }
 
@@ -1937,6 +1949,273 @@ func TestMapSearchAPIImageSize(t *testing.T) {
 		got := mapSearchAPIImageSize(tt.input)
 		if got != tt.expected {
 			t.Errorf("mapSearchAPIImageSize(%q) = %q, want %q", tt.input, got, tt.expected)
+		}
+	}
+}
+
+// =============================================================================
+// Tavily Provider Tests
+// =============================================================================
+
+func TestNewProvider_Tavily(t *testing.T) {
+	cfg := config.SearchConfig{Provider: "tavily", TavilyAPIKey: "tkey"}
+	p := NewProvider(cfg, newTestDeps(http.DefaultClient))
+	if p.Name() != "tavily" {
+		t.Errorf("expected provider name 'tavily', got %q", p.Name())
+	}
+}
+
+// tavilyTestClient builds an http.Client that redirects Tavily's fixed POST URL
+// to the given httptest server (Tavily has no base-URL override).
+func tavilyTestClient(ts *httptest.Server) *http.Client {
+	return &http.Client{Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport}}
+}
+
+// decodeTavilyBody reads the JSON request body in a test handler.
+func decodeTavilyBody(t *testing.T, r *http.Request) map[string]any {
+	t.Helper()
+	raw, _ := io.ReadAll(r.Body)
+	var body map[string]any
+	if err := json.Unmarshal(raw, &body); err != nil {
+		t.Fatalf("failed to decode request body: %v", err)
+	}
+	return body
+}
+
+func TestTavilyProvider_WebSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != "POST" {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer tavily-key" {
+			t.Errorf("expected 'Bearer tavily-key', got %q", got)
+		}
+		if r.Header.Get("Content-Type") != "application/json" {
+			t.Errorf("expected content-type application/json, got %q", r.Header.Get("Content-Type"))
+		}
+		body := decodeTavilyBody(t, r)
+		if body["topic"] != "general" {
+			t.Errorf("expected topic 'general', got %v", body["topic"])
+		}
+		if body["query"] != "test" {
+			t.Errorf("expected query 'test', got %v", body["query"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[{"title":"Tavily Result","url":"https://example.com/t","content":"From Tavily","score":0.9}]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("tavily-key", deps)
+
+	results, err := tv.Web(context.Background(), WebSearchParams{Query: "test", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Title != "Tavily Result" || results[0].Snippet != "From Tavily" {
+		t.Errorf("unexpected result mapping: %+v", results[0])
+	}
+	if results[0].URL != "https://example.com/t" || results[0].DisplayLink != "https://example.com/t" {
+		t.Errorf("expected URL == DisplayLink == https://example.com/t, got %+v", results[0])
+	}
+}
+
+func TestTavilyProvider_WebSearch_WithSiteOperator(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := decodeTavilyBody(t, r)
+		q, _ := body["query"].(string)
+		if !strings.Contains(q, "site:example.com") {
+			t.Errorf("expected query to include injected site operator, got %q", q)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+	if _, err := tv.Web(context.Background(), WebSearchParams{Query: "test", Site: "example.com", NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+// TestTavilyProvider_LongQueryWithSiteOperatorSurvives is the regression guard
+// for the audit finding: when a long query plus a site: operator together exceed
+// the 400-char cap, the cap must trim the user-query portion and keep the
+// site: operator intact (never slice through it).
+func TestTavilyProvider_LongQueryWithSiteOperatorSurvives(t *testing.T) {
+	var sent string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sent, _ = decodeTavilyBody(t, r)["query"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+
+	// 390-char query + " site:example.com" would overflow 400 if capped naively.
+	longQ := strings.Repeat("a", 390)
+	if _, err := tv.Web(context.Background(), WebSearchParams{Query: longQ, Site: "example.com", NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if utf8.RuneCountInString(sent) > tavilyMaxQueryLen {
+		t.Errorf("query exceeds %d-char cap: %d", tavilyMaxQueryLen, utf8.RuneCountInString(sent))
+	}
+	if !strings.HasSuffix(sent, " site:example.com") {
+		t.Errorf("site: operator was truncated — must survive intact; got tail %q", sent[max(0, len(sent)-30):])
+	}
+}
+
+func TestTavilyProvider_NewsSearch(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := decodeTavilyBody(t, r)
+		if body["topic"] != "news" {
+			t.Errorf("expected topic 'news', got %v", body["topic"])
+		}
+		if body["time_range"] != "week" {
+			t.Errorf("expected time_range 'week', got %v", body["time_range"])
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[{"title":"News Item","url":"https://www.wired.com/x","content":"Breaking","published_date":"Fri, 29 May 2026 12:00:00 GMT"}]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+
+	results, err := tv.News(context.Background(), NewsSearchParams{Query: "ai", NumResults: 3, Freshness: "week"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].Source != "www.wired.com" {
+		t.Errorf("expected source 'www.wired.com' (host extracted), got %q", results[0].Source)
+	}
+	if results[0].PublishedAt != "Fri, 29 May 2026 12:00:00 GMT" {
+		t.Errorf("expected RFC1123 published date passthrough, got %q", results[0].PublishedAt)
+	}
+}
+
+func TestTavilyProvider_EmptyResults(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+	results, err := tv.Web(context.Background(), WebSearchParams{Query: "nothing", NumResults: 5})
+	if err != nil {
+		t.Fatalf("zero results must not be an error, got: %v", err)
+	}
+	if len(results) != 0 {
+		t.Errorf("expected 0 results, got %d", len(results))
+	}
+}
+
+func TestTavilyProvider_RateLimited(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+	_, err := tv.Web(context.Background(), WebSearchParams{Query: "test", NumResults: 5})
+	if err == nil {
+		t.Fatal("expected error for 429")
+	}
+	if !strings.Contains(err.Error(), "rate limited") {
+		t.Errorf("error must contain 'rate limited' for isRateLimitError classification, got: %v", err)
+	}
+}
+
+func TestTavilyProvider_APIError(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"detail":{"error":"Query is missing."}}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+	_, err := tv.Web(context.Background(), WebSearchParams{Query: "x", NumResults: 5})
+	if err == nil || !strings.Contains(err.Error(), "tavily API error 400") {
+		t.Errorf("expected 'tavily API error 400', got: %v", err)
+	}
+}
+
+// TestTavilyProvider_ImagesEmpty locks the #54 convention: Images returns empty
+// without error and makes NO HTTP call (server fails the test if hit).
+func TestTavilyProvider_ImagesEmpty(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		t.Error("Images must not make an HTTP request")
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+	results, err := tv.Images(context.Background(), ImageSearchParams{Query: "cats"})
+	if err != nil {
+		t.Errorf("Images must return nil error (no breaker trip), got: %v", err)
+	}
+	if results != nil {
+		t.Errorf("Images must return nil slice, got: %v", results)
+	}
+}
+
+func TestTavilyProvider_QueryTruncation(t *testing.T) {
+	var sent string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := decodeTavilyBody(t, r)
+		sent, _ = body["query"].(string)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"results":[]}`)
+	}))
+	defer ts.Close()
+
+	deps := Deps{HTTPClient: tavilyTestClient(ts), Breaker: circuit.New(circuit.Config{FailureThreshold: 5})}
+	tv := NewTavilyProvider("k", deps)
+
+	// ASCII: 500 chars must be capped to exactly 400, with no "..." suffix.
+	if _, err := tv.Web(context.Background(), WebSearchParams{Query: strings.Repeat("a", 500), NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := utf8.RuneCountInString(sent); n != tavilyMaxQueryLen {
+		t.Errorf("expected query capped to %d runes, got %d", tavilyMaxQueryLen, n)
+	}
+	if strings.HasSuffix(sent, "...") {
+		t.Errorf("query cap must not add an ellipsis suffix")
+	}
+
+	// Multibyte: 500 'é' runes must cap to 400 runes (rune-safe, valid UTF-8).
+	if _, err := tv.Web(context.Background(), WebSearchParams{Query: strings.Repeat("é", 500), NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n := utf8.RuneCountInString(sent); n != tavilyMaxQueryLen {
+		t.Errorf("expected multibyte query capped to %d runes, got %d", tavilyMaxQueryLen, n)
+	}
+	if !utf8.ValidString(sent) {
+		t.Errorf("truncation produced invalid UTF-8")
+	}
+}
+
+func TestMapTavilyTimeRange(t *testing.T) {
+	cases := map[string]string{
+		"hour": "day", "day": "day", "week": "week",
+		"month": "month", "year": "year", "": "", "bogus": "",
+	}
+	for in, want := range cases {
+		if got := mapTavilyTimeRange(in); got != want {
+			t.Errorf("mapTavilyTimeRange(%q) = %q, want %q", in, got, want)
 		}
 	}
 }

--- a/internal/search/tavily.go
+++ b/internal/search/tavily.go
@@ -1,0 +1,224 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const (
+	tavilySearchURL   = "https://api.tavily.com/search" // single endpoint for web AND news (topic switches mode)
+	tavilyMaxQueryLen = 400                             // Tavily hard query cap; >400 chars => HTTP 400. Truncate before sending (#54).
+)
+
+type TavilyProvider struct {
+	apiKey string
+	deps   Deps
+}
+
+func NewTavilyProvider(apiKey string, deps Deps) *TavilyProvider {
+	return &TavilyProvider{apiKey: apiKey, deps: deps}
+}
+
+func (t *TavilyProvider) Name() string { return "tavily" }
+
+func (t *TavilyProvider) Web(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	var results []SearchResult
+	err := t.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = t.doWebSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+// Images returns empty without error: Tavily has no dedicated image-search
+// endpoint (#54). Matches the DuckDuckGo convention — returning an error here
+// would trip the per-provider circuit breaker and break Router image fallback.
+// No breaker call and no HTTP request are made.
+func (t *TavilyProvider) Images(_ context.Context, _ ImageSearchParams) ([]ImageResult, error) {
+	return nil, nil
+}
+
+func (t *TavilyProvider) News(ctx context.Context, params NewsSearchParams) ([]NewsResult, error) {
+	var results []NewsResult
+	err := t.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = t.doNewsSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+func (t *TavilyProvider) doWebSearch(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	body := map[string]any{
+		"query":        cappedWebQuery(params),          // cap user query first so an appended site: operator survives (see below)
+		"max_results":  clamp(params.NumResults, 1, 20), // Tavily supports up to 20; the tool layer already caps num_results at 10
+		"search_depth": "basic",                         // KISS default (1 credit); "advanced" doubles cost — not exposed
+		"topic":        "general",
+	}
+	if tr := mapTavilyTimeRange(params.TimeRange); tr != "" {
+		body["time_range"] = tr
+	}
+
+	respBody, err := t.doRequest(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tavilyResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse tavily response: %w", err)
+	}
+
+	var results []SearchResult
+	for _, r := range resp.Results {
+		results = append(results, SearchResult{
+			Title:       r.Title,
+			URL:         r.URL,
+			Snippet:     r.Content,
+			DisplayLink: r.URL,
+		})
+	}
+	return results, nil
+}
+
+func (t *TavilyProvider) doNewsSearch(ctx context.Context, params NewsSearchParams) ([]NewsResult, error) {
+	body := map[string]any{
+		"query":        capTavilyQuery(params.Query),
+		"max_results":  clamp(params.NumResults, 1, 20),
+		"search_depth": "basic",
+		"topic":        "news", // #54: News uses topic:"news"
+	}
+	if tr := mapTavilyTimeRange(params.Freshness); tr != "" {
+		body["time_range"] = tr
+	}
+
+	respBody, err := t.doRequest(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp tavilyResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse tavily news response: %w", err)
+	}
+
+	var results []NewsResult
+	for _, r := range resp.Results {
+		results = append(results, NewsResult{
+			Title:       r.Title,
+			URL:         r.URL,
+			Source:      extractDisplayLink(r.URL), // Tavily has no separate source field; host is the honest source
+			PublishedAt: r.PublishedDate,           // populated on topic:"news" (RFC1123); empty on general => dropped by NewsResult omitempty
+			Snippet:     r.Content,
+		})
+	}
+	return results, nil
+}
+
+func (t *TavilyProvider) doRequest(ctx context.Context, payload map[string]any) ([]byte, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", tavilySearchURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("Authorization", "Bearer "+t.apiKey) // current Tavily auth; never logged
+
+	resp, err := t.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		return nil, fmt.Errorf("tavily API rate limited") // must contain "rate limited" so tools.isRateLimitError classifies it (brave.go parity)
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("tavily API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+}
+
+// cappedWebQuery builds the web query string while keeping it under Tavily's
+// 400-char limit WITHOUT corrupting an appended site:/lens operator. buildQuery
+// (and the lens path upstream) append site: operators — for lenses, a whole
+// "(site:a OR site:b ...)" group of ~200+ chars — to params.Query. Capping the
+// combined string (the naive approach) could slice through that operator
+// mid-token and send Tavily a malformed query. Instead we measure the operator
+// suffix buildQuery adds and cap only the user-query portion, so the operator is
+// always appended intact. If the operator suffix alone already exceeds the limit
+// (pathological lens), we fall back to capping the whole thing — a truncated
+// operator is no worse than the alternative of dropping the query entirely.
+func cappedWebQuery(params WebSearchParams) string {
+	full := buildQuery(params)
+	if len([]rune(full)) <= tavilyMaxQueryLen {
+		return full
+	}
+	suffix := full[len(params.Query):] // the operator portion buildQuery appended (byte-safe: params.Query is a prefix)
+	budget := tavilyMaxQueryLen - len([]rune(suffix))
+	if budget <= 0 {
+		return capTavilyQuery(full) // operator suffix alone overflows; best-effort hard cap
+	}
+	return capTavilyQuery(params.Query, budget) + suffix
+}
+
+// capTavilyQuery truncates q to at most limit runes (default tavilyMaxQueryLen),
+// enforcing Tavily's hard 400-char query limit (>400 => HTTP 400). Rune-safe
+// (never splits a multi-byte UTF-8 char); no "..." suffix since this is a literal
+// search query, not display text.
+func capTavilyQuery(q string, limit ...int) string {
+	max := tavilyMaxQueryLen
+	if len(limit) > 0 {
+		max = limit[0]
+	}
+	r := []rune(q)
+	if len(r) > max {
+		return string(r[:max])
+	}
+	return q
+}
+
+// mapTavilyTimeRange maps the project's freshness vocabulary to Tavily's
+// time_range enum (day|week|month|year). "hour" has no sub-day equivalent so it
+// collapses to "day"; unknown values omit the field.
+func mapTavilyTimeRange(tr string) string {
+	switch tr {
+	case "hour", "day":
+		return "day"
+	case "week":
+		return "week"
+	case "month":
+		return "month"
+	case "year":
+		return "year"
+	default:
+		return ""
+	}
+}
+
+// tavilyResponse serves both Web and News (PublishedDate is empty for general
+// topic). Field names: results[]{url,title,content,score,published_date}.
+type tavilyResponse struct {
+	Results []struct {
+		Title         string  `json:"title"`
+		URL           string  `json:"url"`
+		Content       string  `json:"content"`
+		Score         float64 `json:"score"`
+		PublishedDate string  `json:"published_date"`
+	} `json:"results"`
+}
+
+var _ Provider = (*TavilyProvider)(nil)

--- a/internal/search/tavily_live_test.go
+++ b/internal/search/tavily_live_test.go
@@ -1,0 +1,85 @@
+//go:build live
+
+// Live external-API integration test — excluded from the default suite
+// (non-deterministic external dependency). Run with `make test-live`.
+package search
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+func TestTavilyLiveIntegration(t *testing.T) {
+	key := os.Getenv("TAVILY_API_KEY")
+	if key == "" {
+		t.Skip("TAVILY_API_KEY not set, skipping live integration test")
+	}
+
+	provider := NewTavilyProvider(key, Deps{
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+
+	t.Run("web search returns results", func(t *testing.T) {
+		results, err := provider.Web(context.Background(), WebSearchParams{
+			Query:      "Go programming language concurrency patterns",
+			NumResults: 3,
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) == 0 {
+			t.Fatal("expected at least one result")
+		}
+		r := results[0]
+		t.Logf("first web result: %s — %s", r.Title, r.URL)
+		if r.Title == "" || r.URL == "" {
+			t.Errorf("expected non-empty title and URL, got %+v", r)
+		}
+	})
+
+	t.Run("news search returns dated results", func(t *testing.T) {
+		results, err := provider.News(context.Background(), NewsSearchParams{
+			Query:      "artificial intelligence regulation",
+			NumResults: 3,
+			Freshness:  "week",
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(results) == 0 {
+			t.Fatal("expected at least one news result")
+		}
+		r := results[0]
+		t.Logf("first news result: %s — %s (%s)", r.Title, r.Source, r.PublishedAt)
+		if r.Source == "" {
+			t.Error("expected non-empty source (host) on news result")
+		}
+	})
+
+	t.Run("images returns empty without error", func(t *testing.T) {
+		results, err := provider.Images(context.Background(), ImageSearchParams{Query: "cats"})
+		if err != nil {
+			t.Errorf("expected nil error from unsupported image search, got: %v", err)
+		}
+		if len(results) != 0 {
+			t.Errorf("expected empty image results, got %d", len(results))
+		}
+	})
+
+	t.Run("oversized query is accepted (capped, not rejected)", func(t *testing.T) {
+		long := ""
+		for i := 0; i < 500; i++ {
+			long += "a"
+		}
+		// Without the 400-char cap this would return HTTP 400 from Tavily.
+		if _, err := provider.Web(context.Background(), WebSearchParams{Query: long, NumResults: 1}); err != nil {
+			t.Errorf("expected capped query to succeed, got: %v", err)
+		}
+	})
+}

--- a/internal/tools/academic.go
+++ b/internal/tools/academic.go
@@ -48,7 +48,7 @@ type academicSearchInput struct {
 	Source     string `json:"source,omitempty" jsonschema:"Restrict to an academic source: all (default), arxiv, pubmed, ieee, nature, springer."`
 	PDFOnly    bool   `json:"pdf_only,omitempty" jsonschema:"Only return papers with direct PDF links (default: false). Useful when you plan to scrape the full paper."`
 	SortBy     string `json:"sort_by,omitempty" jsonschema:"Sort order: relevance (default) or date (newest first)."`
-	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific provider. Academic: openalex, crossref. Web fallback: google, brave, serper, searxng, searchapi, duckduckgo. Omit to use automatic selection (recommended)."`
+	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific provider. Academic: openalex, crossref. Web fallback: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use automatic selection (recommended)."`
 	OpenAccess bool   `json:"open_access,omitempty" jsonschema:"Only return open-access papers with free full-text (default: false)."`
 	SessionID  string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded for recovery after context loss."`
 }

--- a/internal/tools/imagesearch.go
+++ b/internal/tools/imagesearch.go
@@ -19,7 +19,7 @@ type imageSearchInput struct {
 	DominantColor string `json:"dominant_color,omitempty" jsonschema:"Filter by dominant color: black, blue, brown, gray, green, orange, pink, purple, red, teal, white, yellow."`
 	FileType      string `json:"file_type,omitempty" jsonschema:"Filter by file format: jpg, gif, png, bmp, svg, webp."`
 	Safe          string `json:"safe,omitempty" jsonschema:"SafeSearch level: off, medium (default), high."`
-	Provider      string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo. Omit to use configured default."`
+	Provider      string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use configured default."`
 }
 
 func registerImageSearch(srv *mcp.Server, deps Dependencies) {

--- a/internal/tools/newssearch.go
+++ b/internal/tools/newssearch.go
@@ -16,7 +16,7 @@ type newsSearchInput struct {
 	Freshness  string `json:"freshness,omitempty" jsonschema:"How recent articles must be: hour, day, week (default), month, or year."`
 	SortBy     string `json:"sort_by,omitempty" jsonschema:"Sort order: relevance (default) or date (newest first)."`
 	NewsSource string `json:"news_source,omitempty" jsonschema:"Restrict to a specific news outlet domain (e.g. reuters.com, bbc.co.uk)."`
-	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo. Omit to use configured default."`
+	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use configured default."`
 	SessionID  string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded for recovery after context loss."`
 }
 

--- a/internal/tools/patent.go
+++ b/internal/tools/patent.go
@@ -24,7 +24,7 @@ type patentSearchInput struct {
 	CPCCode      string `json:"cpc_code,omitempty" jsonschema:"Cooperative Patent Classification code to narrow by technology area (e.g. G06F for computing, H04L for networking)."`
 	YearFrom     int    `json:"year_from,omitempty" jsonschema:"Only include patents filed in or after this year."`
 	YearTo       int    `json:"year_to,omitempty" jsonschema:"Only include patents filed in or before this year."`
-	Provider     string `json:"provider,omitempty" jsonschema:"Force a specific patent provider: searchapi, epo, lens, uspto (patent-specific), or google, brave, serper, searxng, duckduckgo (web search fallback). Omit for automatic selection based on configured providers and region."`
+	Provider     string `json:"provider,omitempty" jsonschema:"Force a specific patent provider: searchapi, epo, lens, uspto (patent-specific), or google, brave, serper, searxng, duckduckgo, tavily (web search fallback). Omit for automatic selection based on configured providers and region."`
 	SessionID    string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded for recovery after context loss."`
 }
 

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -34,7 +34,7 @@ type webSearchInput struct {
 	ExcludeTerms string `json:"exclude_terms,omitempty" jsonschema:"Terms to exclude from results (space-separated)."`
 	Country      string `json:"country,omitempty" jsonschema:"Restrict to a country using ISO 3166-1 alpha-2 code (e.g. US, GB)."`
 	Lens         string `json:"lens,omitempty" jsonschema:"Focus your search on trusted sites in a specific field: docs, academic, clinical, security, journalism, programming, news, tech, legal, medical, finance, science, government. Only one lens can be active at a time (overrides the site parameter)."`
-	Provider     string `json:"provider,omitempty" jsonschema:"Choose which search engine to use for this query: google, brave, serper, searxng, searchapi, duckduckgo. Leave empty to use the default. Returns an error if the chosen provider isn't set up."`
+	Provider     string `json:"provider,omitempty" jsonschema:"Choose which search engine to use for this query: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Leave empty to use the default. Returns an error if the chosen provider isn't set up."`
 	SessionID    string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded in the session for recovery after context loss."`
 }
 

--- a/internal/tools/searchandscrape.go
+++ b/internal/tools/searchandscrape.go
@@ -21,7 +21,7 @@ type searchAndScrapeInput struct {
 	MaxLengthPerSource int    `json:"max_length_per_source,omitempty" jsonschema:"Max content bytes extracted per source (default: 50000)."`
 	TotalMaxLength     int    `json:"total_max_length,omitempty" jsonschema:"Max total bytes for combined output (default: 300000). Reduce for faster, more concise results."`
 	FilterByQuery      bool   `json:"filter_by_query,omitempty" jsonschema:"Remove sources with low relevance to the query (default: false). Enable for precision over recall."`
-	Provider           string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo. Omit to use configured default."`
+	Provider           string `json:"provider,omitempty" jsonschema:"Force a specific search provider: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use configured default."`
 	SessionID          string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. All scraped sources are automatically recorded for recovery after context loss."`
 }
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -119,7 +119,7 @@ Then configure as in Option A.
 
 | Variable | Description |
 |----------|-------------|
-| `SEARCH_PROVIDER` | Which provider to use: `google`, `brave`, `serper`, `searxng`, `searchapi`, `duckduckgo` (defaults to `google`, falling back to `duckduckgo` when no key is set) |
+| `SEARCH_PROVIDER` | Which provider to use: `google`, `brave`, `serper`, `searxng`, `searchapi`, `duckduckgo`, `tavily` (defaults to `google`, falling back to `duckduckgo` when no key is set) |
 | `SEARCH_ROUTING` | Multi-provider fallback list (e.g., `brave,google,serper`) |
 
 ## Available Tools

--- a/tests/e2e/providers_test.go
+++ b/tests/e2e/providers_test.go
@@ -93,6 +93,48 @@ func TestProviders_Live(t *testing.T) {
 	}
 }
 
+// TestProviders_Tavily_Live exercises the Tavily provider end-to-end through the
+// real MCP server. Gated only on TAVILY_API_KEY (independent of the Google/Brave/
+// Serper quartet TestProviders_Live needs), so it runs whenever a Tavily key is
+// available. image_search is expected to succeed but return no images (Tavily has
+// no image endpoint — #54), so it is not asserted to have results.
+func TestProviders_Tavily_Live(t *testing.T) {
+	if os.Getenv("TAVILY_API_KEY") == "" {
+		t.Skip("skipping: TAVILY_API_KEY not set")
+	}
+
+	h := newProviderHarness(t, []string{"SEARCH_PROVIDER=tavily"})
+	defer h.shutdown()
+	h.initialize(t)
+
+	t.Run("web_search", func(t *testing.T) {
+		result := h.callTool(t, "web_search", map[string]interface{}{
+			"query":       "Model Context Protocol specification",
+			"num_results": 3,
+		})
+		assertToolSuccess(t, result)
+		assertHasURLs(t, result)
+	})
+
+	t.Run("news_search", func(t *testing.T) {
+		result := h.callTool(t, "news_search", map[string]interface{}{
+			"query":       "artificial intelligence regulation",
+			"num_results": 3,
+		})
+		assertToolSuccess(t, result)
+	})
+
+	// image_search: Tavily returns empty images without error; the tool call
+	// still succeeds (the server handles an empty image set gracefully).
+	t.Run("image_search_empty_no_error", func(t *testing.T) {
+		result := h.callTool(t, "image_search", map[string]interface{}{
+			"query":       "golden gate bridge",
+			"num_results": 3,
+		})
+		assertToolSuccess(t, result)
+	})
+}
+
 // TestProviders_WebSearchWithLens verifies lens routing works with site operators.
 func TestProviders_WebSearchWithLens(t *testing.T) {
 	if os.Getenv("GOOGLE_CUSTOM_SEARCH_API_KEY") == "" {


### PR DESCRIPTION
Closes #54. Supersedes the stale bot PR #39 (which I'm closing — see below).

## What
Adds **Tavily** as a configurable `search.Provider` behind the multi-provider Router — Tavily's AI-optimized search with automatic fallback, selectable via `SEARCH_PROVIDER=tavily`, `SEARCH_ROUTING`, or an explicit `provider:"tavily"`.

- **`internal/search/tavily.go`** — modeled structurally on `brave.go` (breaker-wrapped methods, shared `doRequest`, 5MB `LimitReader`). **Bearer-header auth** (current Tavily method — keeps the key out of the request body, consistent with every other provider's header auth). Single `/search` endpoint; `topic` switches web/news. **`Images` returns `nil,nil`** (empty, no error) per #54 + the DuckDuckGo convention, so `image_search` falls through the Router cleanly. `429 → "tavily API rate limited"` so `isRateLimitError` classifies it.
- **400-char query cap** — rune-safe, and the user-query portion is capped **before** `site:`/lens operators are appended, so a lens's `(site:a OR site:b …)` group always survives intact (caught by the audit).
- Wired through `provider.go` (SupportedProviders + both factories + AvailableProviders) and `config.go` (`TavilyAPIKey` + required-when-selected). **Zero new dependencies** — plain JSON over the shared SSRF-safe client.

## Why fresh, not merge #39
PR #39 (2026-05-21, bot-authored) predated ~6 architectural changes and conflicts with main. It also used legacy body `api_key` auth, **errored** on image search (breaks Router fallback), and lacked the 400-char cap. I lifted its good ideas (endpoint, field shapes, news topic) and reimplemented correctly on current main.

## Verification (every layer)
- **Unit** (`search_test.go`): web/news/empty/429/api-error/images-empty/query-truncation (ASCII + multibyte)/site-operator-survival + the 3 wiring tests.
- **Live integration** (`tavily_live_test.go`, `//go:build live`) and **e2e** (`TestProviders_Tavily_Live`, full MCP server) — **both passing against the real Tavily API**.
- `go test -race ./...`, `golangci-lint` (0), `gosec` (0), `govulncheck` (clean), `gofmt`, drift gates — all green. No stubs/TODOs.

## Docs (zero drift)
`.env.example`, `docs/API_SETUP.md` (+ comparison row), `docs/DEPLOYMENT.md`, `docs/PRIVACY.md` (third-party disclosure), `docs/TOOLS.md`, README, llms-install, and all 6 provider jsonschema enums.

## Process
Designed via a 3-candidate design→synthesis workflow (live-verified Tavily's auth/fields/limits), then a **12-agent competitive audit** → 8 findings, 6 confirmed & **fixed** (incl. the real query-cap-truncates-operator bug), 2 correctly refuted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)