### PR TITLE
fix(release): don't auto-open WinGet upstream PR (unblocks signing/cosign/mcpb)

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -252,11 +252,16 @@ scoops:
 
 # ── WinGet (Windows Package Manager) ─────────────────────────────────────────
 # Generates the WinGet manifest and commits it to a branch on the
-# zoharbabin/winget-pkgs fork; you then open a PR to microsoft/winget-pkgs for
-# Microsoft's automated validation (smooth because our .exe is Azure Trusted
-# Signing-signed with a Microsoft-issued cert). Gated on WINGET_PKGS_GITHUB_TOKEN
-# via skip_upload. Install (once accepted upstream): `winget install
-# zoharbabin.web-researcher-mcp`.
+# zoharbabin/winget-pkgs fork. The maintainer then opens the PR to
+# microsoft/winget-pkgs manually for Microsoft's review (smooth because our .exe
+# is Azure Trusted Signing-signed with a Microsoft-issued cert). Auto-PR is
+# intentionally DISABLED: a fine-grained PAT scoped to the fork can push the
+# branch but cannot open a PR against microsoft/winget-pkgs (the upstream returns
+# "403 Resource not accessible by personal access token"), and Microsoft's first
+# submission requires a manual review regardless — so an auto-PR attempt only
+# fails the release for a step that must be manual anyway. Gated on
+# WINGET_PKGS_GITHUB_TOKEN via skip_upload. Install (once accepted upstream):
+# `winget install zoharbabin.web-researcher-mcp`.
 winget:
   - name: web-researcher-mcp
     publisher: zoharbabin
@@ -270,13 +275,6 @@ winget:
       name: winget-pkgs
       branch: "web-researcher-mcp-{{ .Version }}"
       token: "{{ .Env.WINGET_PKGS_GITHUB_TOKEN }}"
-      pull_request:
-        enabled: true
-        draft: false
-        base:
-          owner: microsoft
-          name: winget-pkgs
-          branch: master
     skip_upload: '{{ if isEnvSet "WINGET_PKGS_GITHUB_TOKEN" }}false{{ else }}true{{ end }}'
 
 # ── Chocolatey (Windows) ─────────────────────────────────────────────────────

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -97,7 +97,7 @@ Signing unlocks the OS package managers — some validate/prefer signed binaries
 |---------|-------------------------|--------|---------------|-------|
 | Homebrew Cask | `homebrew_casks` | `zoharbabin/homebrew-tap` (`Casks/`) | `HOMEBREW_TAP_GITHUB_TOKEN` (shared with the formula) | Ships the **notarized** darwin binary; `brew install --cask zoharbabin/tap/web-researcher-mcp`. `skip_upload: auto` skips prereleases. |
 | Scoop | `scoops` | `zoharbabin/scoop-bucket` (`bucket/`) | `SCOOP_BUCKET_GITHUB_TOKEN` (gates `skip_upload`) | `scoop bucket add zoharbabin …; scoop install web-researcher-mcp`. |
-| WinGet | `winget` | fork `zoharbabin/winget-pkgs` → PR to `microsoft/winget-pkgs` | `WINGET_PKGS_GITHUB_TOKEN` (gates `skip_upload`) | Auto-opens the upstream PR; Microsoft's validation is smooth because the `.exe` is Azure-Trusted-Signing-signed. |
+| WinGet | `winget` | fork `zoharbabin/winget-pkgs` (manual PR to `microsoft/winget-pkgs`) | `WINGET_PKGS_GITHUB_TOKEN` (gates `skip_upload`) | Pushes the manifest to a branch on the fork; the maintainer opens the upstream PR manually (a fork-scoped fine-grained PAT cannot open a PR against `microsoft/winget-pkgs`, and the first submission needs manual Microsoft review anyway). Validation is smooth because the `.exe` is Azure-Trusted-Signing-signed. |
 | Chocolatey | `chocolateys` | chocolatey.org (`push.chocolatey.org`) | `CHOCOLATEY_API_KEY` (workflow installs `choco` + un-`--skip`s the pipe only when set) | `choco install web-researcher-mcp`. The Linux runner gets `choco` via `mono`. |
 
 **Tokens are configured** — `CHOCOLATEY_API_KEY` (account API key), `WINGET_PKGS_GITHUB_TOKEN`, and `SCOOP_BUCKET_GITHUB_TOKEN` are set as GitHub Actions secrets, so the next `v*` tag publishes to all four channels. To rotate or recreate a GitHub PAT (Chocolatey uses an account API key, not a PAT):
@@ -107,7 +107,7 @@ Signing unlocks the OS package managers — some validate/prefer signed binaries
 
 PATs cannot be minted by `gh`/the API (browser-only by design): GitHub → Settings → Developer settings → Fine-grained tokens.
 
-> **First-release note:** the publishers were added after v1.19.0 was tagged, so they activate on the **next** release. WinGet's first push opens a PR to `microsoft/winget-pkgs` that gets a one-time manual Microsoft review; Chocolatey's first package goes through moderation. User-facing install instructions (`winget install` / `scoop install` / `choco install` / `brew install --cask`) are added to the README only once each channel's first package is confirmed live.
+> **First-release note:** the publishers activate on a release where the channel's secret is set. WinGet pushes the manifest to a branch on the `zoharbabin/winget-pkgs` fork; the maintainer then opens the PR to `microsoft/winget-pkgs` manually (fork-scoped PATs cannot open the upstream PR, and the first submission gets a one-time manual Microsoft review regardless). Chocolatey's first package goes through moderation. User-facing install instructions (`winget install` / `scoop install` / `choco install` / `brew install --cask`) are added to the README only once each channel's first package is confirmed live.
 
 ## Local secret convention (maintainer)
 


### PR DESCRIPTION
**Follow-up to the v1.20.0 release.** GoReleaser published the release and pushed binaries, Docker (GHCR + Docker Hub multi-arch), the Homebrew formula + cask, and the Scoop manifest — then aborted at the WinGet step:

```
winget: could not create pull request: POST .../microsoft/winget-pkgs/pulls:
403 Resource not accessible by personal access token
```

A fine-grained PAT scoped to the `zoharbabin/winget-pkgs` **fork** can push the manifest branch (which succeeded — branch `web-researcher-mcp-1.20.0` exists on the fork) but **cannot open a PR against the upstream `microsoft/winget-pkgs`**. Because GoReleaser exited non-zero, every **post-GoReleaser** step was skipped: Windows Authenticode signing, `.mcpb` bundles, cosign signatures, and MCP Registry/Smithery publish.

**Fix:** drop `repository.pull_request` from the `winget` block. GoReleaser still pushes the manifest to the fork branch; the maintainer opens the upstream PR manually — which Microsoft's first-submission review requires anyway. The WinGet step can no longer fail the release. `docs/RELEASE_SIGNING.md` updated to match.

After merge: delete the incomplete v1.20.0 release, move the tag to include this fix, and re-run so the release gets the signed Windows binary, cosign signatures, and `.mcpb` bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)