### PR TITLE
fix(release): publish Chocolatey via GitHub-release tarball + README install instructions (Scoop/Cask)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,10 @@ jobs:
         id: choco
         env:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
+        env:
+          # Pin the Chocolatey CLI version so the install source is deterministic
+          # and a moving "latest" can't break the release. Bump deliberately.
+          CHOCO_VERSION: "2.7.2"
         run: |
           # The chocolatey pipe is skipped UNLESS `choco` is PROVEN runnable. A
           # flaky third-party bootstrap must never fail the whole release (mirrors
@@ -72,27 +76,36 @@ jobs:
           if [ -z "$CHOCOLATEY_API_KEY" ]; then
             echo "CHOCOLATEY_API_KEY not set — skipping the chocolatey pipe."
           else
-            echo "Installing Chocolatey CLI (mono) for nupkg build + push…"
+            echo "Installing Chocolatey CLI $CHOCO_VERSION (mono) for nupkg build + push…"
             sudo apt-get update -qq
             sudo apt-get install -y -qq mono-devel
 
-            # Bootstrap choco under mono. The community install.sh URL has 404'd
-            # before, so try it but DO NOT trust its exit code (it is piped). The
-            # gate below is the source of truth: is `choco` actually runnable?
-            curl -fsSL https://community.chocolatey.org/install.sh | sudo bash || \
-              echo "chocolatey bootstrap script failed; verifying choco presence next."
-
-            # The installer drops a `choco` shim under /opt/chocolatey/bin; surface
-            # it on PATH for this and later steps, then verify it actually runs.
-            if [ -x /opt/chocolatey/bin/choco ]; then
-              echo "/opt/chocolatey/bin" >> "$GITHUB_PATH"
-              export PATH="/opt/chocolatey/bin:$PATH"
+            # The old community.chocolatey.org/install.sh bootstrap now 404s. Install
+            # from the official, versioned GitHub release tarball instead — a stable
+            # source that ships choco.exe (a .NET assembly runnable under mono). We
+            # do NOT trust any single curl's exit code; the gate below is the source
+            # of truth: is `choco` actually runnable?
+            CHOCO_DIR=/opt/chocolatey
+            CHOCO_URL="https://github.com/chocolatey/choco/releases/download/${CHOCO_VERSION}/chocolatey.v${CHOCO_VERSION}.tar.gz"
+            sudo mkdir -p "$CHOCO_DIR"
+            if curl -fsSL "$CHOCO_URL" -o /tmp/choco.tar.gz; then
+              sudo tar -xzf /tmp/choco.tar.gz -C "$CHOCO_DIR" || echo "choco extract failed; verifying next."
+            else
+              echo "choco tarball download failed; verifying next."
             fi
+
+            # Provide a bare `choco` shim on PATH (GoReleaser shells out to `choco`,
+            # not `mono choco.exe`), pointing at the extracted assembly under mono.
+            if [ -f "$CHOCO_DIR/choco.exe" ]; then
+              printf '#!/usr/bin/env bash\nexec mono %q "$@"\n' "$CHOCO_DIR/choco.exe" | sudo tee /usr/local/bin/choco >/dev/null
+              sudo chmod +x /usr/local/bin/choco
+            fi
+
             if command -v choco >/dev/null 2>&1 && choco --version >/dev/null 2>&1; then
               echo "choco is available ($(choco --version)) — enabling the chocolatey pipe."
               skip=""
             else
-              echo "::warning::choco CLI unavailable after bootstrap — skipping the chocolatey pipe for this release (other channels unaffected)."
+              echo "::warning::choco CLI unavailable after install — skipping the chocolatey pipe for this release (other channels unaffected)."
             fi
           fi
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -203,6 +203,16 @@ Every request carries a `context.Context` with deadline. Session and tenant IDs 
 - **Per-client backpressure**: Rate limiter per session, reject with 429
 - **Graceful shutdown**: Context cancellation propagates, in-flight requests drain
 
+### 7. Operator Observability
+
+Routing, provider health, and recent errors are **operator/debug data, never model content** — the Router exists to make providers interchangeable to the LLM, so its internals surface only through non-content channels. Three subsystems implement this, each keeping the provider *name* as the disclosure boundary (no upstream URLs, credentials, or breaker counts leak):
+
+- **Per-call routing trace** — `search.RoutingTrace` (`internal/search/routing_trace.go`) is a request-scoped, context-carried, concurrency-safe collector the `Router` populates while iterating providers. The tool layer reads its `RoutingDecision` and attaches it to the result's MCP `_meta.routing` (via `routingMeta` / `withRoutingMeta` in `internal/tools/errors.go`, merged with — never clobbering — the cache-freshness `_meta`). The same summary is mirrored to `audit.AuditEvent.Metadata["routing"]`. Omitted entirely when there is nothing to observe (single-provider / non-routed call).
+- **Recent-errors ring** — `metrics.ErrorRing` (`internal/metrics/errors.go`) is a bounded, memory-only, tenant-aware ring buffer fed at the central audit sink (`auditToolCallQuery`), so every tool error path records one redacted sample (cause passed through `audit.MaskSecrets`). No disk, no unbounded growth — consistent with the no-retention posture.
+- **Live provider health** — `search.Router.Health()` (`internal/search/health.go`) returns a tri-state `HealthSnapshot` (`healthy` / `degraded` / `unhealthy`) plus each routed provider's circuit-breaker state.
+
+These reach operators through read-only MCP Resources (`diagnostics://errors/recent`, `diagnostics://health` beside `stats://*`, registered in `internal/resources/resources.go` via the small `HealthProvider` interface) and, in HTTP mode, an admin-gated operator dashboard (`GET /dashboard` + `GET /dashboard/data`, `internal/server/dashboard.go`). The dashboard is a self-contained HTML page (no CDN, no build) under a per-request nonce CSP, aggregate-only. See `docs/TOOLS.md` (Routing Provenance) and `docs/DEPLOYMENT.md` (Operator Observability) for the field contracts.
+
 ## Technology Stack
 
 | Concern | Library | Why |

--- a/README.md
+++ b/README.md
@@ -178,6 +178,18 @@ INSTALL_DIR=/opt/tools curl -fsSL https://raw.githubusercontent.com/zoharbabin/w
 <details>
 <summary><strong>Other install methods</strong></summary>
 
+**Scoop (Windows):**
+```powershell
+scoop bucket add zoharbabin https://github.com/zoharbabin/scoop-bucket
+scoop install web-researcher-mcp
+```
+
+**Homebrew Cask (macOS — Developer ID-signed + notarized binary):**
+```bash
+brew install --cask zoharbabin/tap/web-researcher-mcp
+```
+The cask ships the notarized darwin binary (Gatekeeper-clean). Most users want the formula above (`brew install zoharbabin/tap/web-researcher-mcp`), which the bare name resolves to; pass `--cask` explicitly for the notarized artifact.
+
 **Go install** (if you have Go):
 ```bash
 go install github.com/zoharbabin/web-researcher-mcp/cmd/web-researcher-mcp@latest

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -296,6 +296,17 @@ metadata.
 
 **Request correlation:** every HTTP request is assigned a correlation ID by the transport ingress middleware (adopting a sanitized inbound `X-Request-Id`, else the W3C `traceparent` trace-id, else a fresh UUIDv4). All audit events for one tool call share that `RequestID`, and it is echoed back on the response `X-Request-Id` header.
 
+### Layer 8: Operator Observability (non-content, privacy-minimal)
+
+Routing decisions, provider health, and recent errors are surfaced to operators through channels that are deliberately **not** part of any tool's model-facing content, so infrastructure detail never reaches the LLM and carries no personal data:
+
+- **Routing `_meta`** — per-call routing (which provider served, what was attempted, whether a fallback fired) is attached to the MCP result's `_meta.routing`, never the content body. The provider *name* is the disclosure boundary: no upstream URLs, credentials, or circuit-breaker counts are exposed, and the `fallback_reason` is a coarse enum (`circuit_open` / `primary_unavailable`), never a raw upstream error string.
+- **`diagnostics://errors/recent`** — a bounded, **memory-only**, tenant-scoped ring of recent errors (`internal/metrics/errors.go`). Each cause is redacted through `audit.MaskSecrets` at insert; there is no disk persistence and no unbounded growth (oldest entries are overwritten), consistent with the no-retention posture.
+- **`diagnostics://health`** — live provider/circuit-breaker state (tri-state aggregate), derived on read. No PII.
+- **`GET /dashboard`** (HTTP mode) — an admin-gated, aggregate-only operator dashboard served under a per-request nonce CSP (`internal/server/dashboard.go`); its data endpoint shares the `/admin/*` trust tier. No per-user or per-query data.
+
+None of these is a personal-data store. Field contracts live in `docs/TOOLS.md` (Routing Provenance) and `docs/DEPLOYMENT.md` (Operator Observability).
+
 ---
 
 ## Encryption

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -258,6 +258,10 @@ We deliberately minimize what we store:
 | Research sessions | Per-tenant:session compound key | Session TTL (default 4h) | Query context |
 | Audit logs | Structured JSON | Configurable (default 180 days) | User/tenant IDs only |
 | Rate limit counters | Per-tenant in memory | Resets daily | Tenant ID only |
+| Recent-errors ring (`diagnostics://errors/recent`) | Bounded in-memory ring, tenant-aware | None (memory-only, oldest overwritten) | No — causes redacted via `audit.MaskSecrets`; no query text, no full URLs |
+| Operator dashboard / `diagnostics://health` | Derived on read from existing metrics + breaker state | None (computed per request) | No — aggregate-only, no per-user/per-query data |
+
+The **operator-observability** surfaces added in the routing-observability work (`_meta.routing` on results, the `diagnostics://` resources, and the admin-gated `GET /dashboard`) are deliberately privacy-minimal: routing detail exposes only the provider *name* (never upstream URLs, credentials, or breaker internals), the recent-errors ring is memory-only/bounded/redacted/tenant-scoped, and the dashboard is aggregate-only and admin-gated. None of them is a personal-data store, so none adds a GDPR processing obligation. See `docs/DEPLOYMENT.md` → Operator Observability and `docs/TOOLS.md` → Routing Provenance.
 
 ### Purpose Limitation
 
@@ -388,50 +392,18 @@ Deployment recommendations:
 
 ## Configuration Reference
 
-### Security Controls
+The security- and privacy-relevant settings are grouped into these knobs — **defaults and exact variable names live in [`.env.example`](../.env.example) and [`docs/DEPLOYMENT.md`](DEPLOYMENT.md), the two authoritative homes** (this guide does not duplicate them, so they cannot drift):
 
-| Env Var | Default | Effect |
-|---------|---------|--------|
-| `CACHE_ENCRYPTION_KEY` | (unset = plaintext) | 64-char hex key enables AES-256-GCM disk encryption |
-| `CACHE_ENCRYPTION_KEY_PREV` | (unset) | 64-char hex previous key for zero-downtime rotation (decrypt fallback + lazy re-encrypt) |
-| `ALLOW_PRIVATE_IPS` | `false` | When `true`, allows scraping private/RFC1918 IPs |
-| `ALLOWED_DOMAINS` | (unset = all) | Comma-separated allowlist restricts scraping targets |
-| `ALLOWED_ORIGINS` | (unset) | CORS allowlist for HTTP mode (browser-only). Empty behavior depends on `CORS_STRICT` |
-| `CORS_STRICT` | `true` | Default fail-closed: empty `ALLOWED_ORIGINS` denies all cross-origin browser requests. Set `false` to restore the legacy reflect-any-Origin behavior (see `docs/MIGRATION.md`) |
-| `ENFORCE_SCOPES` | `false` | When `true`, scoped tokens need `tool:*`/`tool:<name>`/`research` per tool (permissive for unscoped tokens) |
-| `REQUIRED_SCOPES` | (unset) | CSV of scopes every request must carry when `ENFORCE_SCOPES=true` |
-| `CACHE_ISOLATION` | `shared` | Set `tenant` for per-tenant cache isolation |
-| `ADMIN_API_KEY` | (unset = no admin API) | Enables all `/admin/*` endpoints when set (min 16 chars); sent as `X-Admin-Key`, constant-time compared |
-| `CACHE_ADMIN_KEY` | (unset) | **Deprecated** alias for `ADMIN_API_KEY` (still accepted; logs a startup warning) |
-| `RATE_LIMIT_PER_IP` | `0` (disabled) | Pre-auth per-IP request ceiling (req/min); `TRUST_PROXY` selects the client-IP source |
+- **Encryption at rest** — a hex key turns on AES-256-GCM disk encryption for the cache, the TTL key/value store, and sessions; a previous-key slot enables zero-downtime rotation (decrypt-fallback + lazy re-encrypt).
+- **SSRF / scrape egress** — toggles for allowing private/RFC1918 IPs and a domain allowlist that restricts scrape targets.
+- **CORS** — an origin allowlist plus a fail-closed strict toggle (default deny on empty; see [`docs/MIGRATION.md`](MIGRATION.md)).
+- **Auth & scopes (HTTP mode)** — OAuth issuer/audience for JWKS validation, JWKS refresh interval, and optional per-tool scope enforcement.
+- **Admin surface** — the admin key that gates every `/admin/*` endpoint and the operator dashboard (constant-time compared; a deprecated alias is still accepted with a startup warning).
+- **Tenant isolation** — per-tenant cache isolation mode.
+- **Rate limiting (HTTP mode)** — global/second, per-tenant/minute, per-tenant/day, and a pre-auth per-IP ceiling.
+- **Audit & observability** — audit logging on/off, output path, buffer size, log level, and the Prometheus `/metrics` toggle.
 
-### Authentication (HTTP mode only)
-
-| Env Var | Default | Effect |
-|---------|---------|--------|
-| `OAUTH_ISSUER_URL` | (unset = no auth) | JWT issuer for JWKS discovery |
-| `OAUTH_AUDIENCE` | (unset) | Expected JWT audience claim |
-| `JWKS_REFRESH_INTERVAL` | `1h` | Background JWKS key refresh |
-
-### Rate Limiting (HTTP mode only)
-
-| Env Var | Default | Effect |
-|---------|---------|--------|
-| `RATE_LIMIT_GLOBAL` | `1000` | Global requests/second |
-| `RATE_LIMIT_PER_TENANT` | `120` | Per-tenant requests/minute |
-| `DAILY_QUOTA_PER_TENANT` | `5000` | Per-tenant requests/day |
-
-### Audit & Observability
-
-| Env Var | Default | Effect |
-|---------|---------|--------|
-| `AUDIT_ENABLED` | `true` | Structured audit logging |
-| `AUDIT_OUTPUT_PATH` | (unset = stderr) | File path for audit JSONL |
-| `AUDIT_BUFFER_SIZE` | `1000` | Async channel buffer size |
-| `LOG_LEVEL` | `info` | Log verbosity (debug/info/warn/error) |
-| `METRICS_ENABLED` | `true` | Prometheus metrics on `/metrics` |
-
-Full configuration reference: see `.env.example`.
+See `docs/DEPLOYMENT.md` for the table of every variable, its default, and its effect.
 
 ---
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1379,21 +1379,34 @@ Full details: see `docs/ERROR_HANDLING.md` — covers the three-layer architectu
 
 ### Tool Annotations (MCP Protocol)
 
-All tools declare annotations for client consumption. CI enforces tool↔doc consistency via `TestAllToolsHaveAnnotations`, `TestToolsDocMatchesRegistry`, `TestOutputSchemaMatchesResponse`, and `TestToolDescriptionQuality` (`internal/tools/metadata_test.go`) — including on docs-only PRs via the standalone `docs-drift` CI job:
+Every tool declares annotations for client consumption (`readOnlyAnnotations(idempotent, openWorld)` for read tools, `writeAnnotations(idempotent)` for the two write tools — both in `internal/tools/registry.go`). CI enforces tool↔doc consistency via `TestAllToolsHaveAnnotations`, `TestToolsDocMatchesRegistry`, `TestOutputSchemaMatchesResponse`, and `TestToolDescriptionQuality` (`internal/tools/metadata_test.go`) — including on docs-only PRs via the standalone `docs-drift` CI job. No tool is `Destructive` — deletion is the `/admin/data` erasure endpoint, never a tool flag (see `docs/DEPLOYMENT.md`).
 
-| Tool | ReadOnly | Idempotent | OpenWorld | Destructive |
-|------|----------|------------|-----------|-------------|
-| web_search | true | true | true | false |
-| scrape_page | true | true | true | false |
-| search_and_scrape | true | true | true | false |
-| image_search | true | true | true | false |
-| news_search | true | true | true | false |
-| academic_search | true | true | true | false |
-| patent_search | true | true | true | false |
-| sequential_search | true | **false** | false | false |
-| get_research_session | true | true | false | false |
+| Tool | ReadOnly | Idempotent | OpenWorld |
+|------|----------|------------|-----------|
+| web_search | true | true | true |
+| scrape_page | true | true | true |
+| search_and_scrape | true | true | true |
+| image_search | true | true | true |
+| news_search | true | true | true |
+| academic_search | true | true | true |
+| patent_search | true | true | true |
+| sequential_search | true | **false** | false |
+| get_research_session | true | true | false |
+| answer | true | true | true |
+| structured_search | true | true | true |
+| citation_graph | true | true | true |
+| research_export | true | true | false |
+| format_bibliography | true | true | false |
+| filing_search | true | true | true |
+| legal_search | true | true | true |
+| econ_search | true | true | true |
+| get_my_analytics | true | true | false |
+| memory_save | **false (write)** | false | false |
+| memory_recall | true | true | false |
+| workspace_contribute | **false (write)** | false | false |
+| workspace_read | true | true | false |
 
-`sequential_search` is non-idempotent because it writes session state to disk on every call.
+Notes: `sequential_search` is non-idempotent because it writes session state to disk on every call. `memory_save` and `workspace_contribute` are the two **write** tools (`ReadOnly:false`) — non-idempotent because each call appends a new record. `OpenWorld:false` marks tools that touch only local/server state (sessions, memory, analytics, workspaces, exports) rather than the open web. `Destructive` is uniformly false — no tool is annotated destructive.
 
 ### Provider Resolution
 


### PR DESCRIPTION
## Two changes

### 1. Fix Chocolatey publishing (so it actually ships next release)
The v1.20.0 release **skipped** the Chocolatey pipe — `community.chocolatey.org/install.sh` now 404s, so `choco` was never installed and the package never published (confirmed: community feed 404, 0 entries). The prior resilience fix correctly degraded instead of failing the release, but the channel stayed dark.

**Fix:** install the Chocolatey CLI from the official **versioned GitHub release tarball** (`chocolatey.v2.7.2.tar.gz`) — a stable source (HTTP 200) that ships `choco.exe`, a .NET assembly runnable under mono on Linux. A bare `choco` shim on PATH wraps `mono choco.exe` so GoReleaser's pipe (which calls bare `choco`) resolves it. `CHOCO_VERSION` is pinned for deterministic installs.

**Verified end-to-end** in an `ubuntu:24.04` container (not just hoped):
```
choco --version → 2.7.2
choco pack: available
```
The "verify `choco` is runnable before un-skipping the pipe" gate is unchanged, so a future source breakage still degrades gracefully.

### 2. README install instructions for the live channels
Added **Scoop** and **Homebrew Cask** to the install options — both verified live in their buckets at 1.20.0 (Scoop binary URL returns 200; Cask has a valid notarized-binary stanza). `winget install` / `choco install` lines are **intentionally deferred** until those packages are confirmed live upstream (anti-drift: never document a channel before its first package lands — WinGet PR microsoft/winget-pkgs#384774 is in review; Chocolatey publishes on the next release with this fix).

## Distribution state at time of this PR
- ✅ Homebrew Cask — live in tap @ 1.20.0
- ✅ Scoop — live in bucket @ 1.20.0
- ⏳ WinGet — manifest valid; upstream PR #384774 open (Microsoft review)
- ⏳ Chocolatey — fixed here; publishes on next `v*` tag

After merge: cut a patch release so the Chocolatey package publishes, then verify + add the `winget`/`choco install` lines to the README once both are confirmed live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)