### PR TITLE
fix(release): merge duplicate env key that broke v1.20.1 release startup

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,6 @@ jobs:
         id: choco
         env:
           CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
-        env:
           # Pin the Chocolatey CLI version so the install source is deterministic
           # and a moving "latest" can't break the release. Bump deliberately.
           CHOCO_VERSION: "2.7.2"


### PR DESCRIPTION
The v1.20.1 release run **failed at startup with zero jobs** ("This run likely failed because of a workflow file issue") — nothing published.

**Cause:** the Chocolatey-install fix (PR #149) added a *second* `env:` block to the "Set up Chocolatey" step rather than extending the existing one:
```yaml
        env:
          CHOCOLATEY_API_KEY: ${{ secrets.CHOCOLATEY_API_KEY }}
        env:                      # ← duplicate key
          CHOCO_VERSION: "2.7.2"
```
YAML parsers silently keep the last duplicate (so local `yaml.safe_load` and PR CI both passed), but GitHub Actions rejects a duplicated mapping key at workflow-load time. Caught now by **actionlint** (`key "env" is duplicated`).

**Fix:** merge both vars into one `env:` block. actionlint is clean across all workflows.

**Gap this exposed:** `release.yml` validity is only exercised on tag push, never by PR CI — which is why #149 merged green and the breakage only surfaced at release time. actionlint in the lint job would catch this class pre-merge (noted in the commit; can follow up).

After merge: re-point the v1.20.1 tag to include this fix and the release re-runs cleanly (the failed run published nothing, so no cleanup needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)