### PR TITLE
docs(readme): pull premature Scoop install line (manifest hash broken)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,12 +178,6 @@ INSTALL_DIR=/opt/tools curl -fsSL https://raw.githubusercontent.com/zoharbabin/w
 <details>
 <summary><strong>Other install methods</strong></summary>
 
-**Scoop (Windows):**
-```powershell
-scoop bucket add zoharbabin https://github.com/zoharbabin/scoop-bucket
-scoop install web-researcher-mcp
-```
-
 **Homebrew Cask (macOS — Developer ID-signed + notarized binary):**
 ```bash
 brew install --cask zoharbabin/tap/web-researcher-mcp


### PR DESCRIPTION
While verifying the package-manager channels I found a real release-pipeline bug: the **Scoop and WinGet manifests carry the hash of the *unsigned* Windows zip, but the published zip is the *signed* one** — so `scoop install` fails its hash check and WinGet validation rejects with `Error-Hash-Mismatch`.

This PR pulls the Scoop instruction from the README (it was added prematurely in #149 before this was discovered). Homebrew Cask stays — it ships the darwin tarball and is unaffected.

The pipeline fix (compute Scoop/WinGet manifest hashes from the signed artifact) is tracked separately and will restore the Scoop line once landed + verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)