### PR TITLE
docs(readme): restore Scoop install line (hash fixed in v1.20.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,12 @@ INSTALL_DIR=/opt/tools curl -fsSL https://raw.githubusercontent.com/zoharbabin/w
 <details>
 <summary><strong>Other install methods</strong></summary>
 
+**Scoop (Windows):**
+```powershell
+scoop bucket add zoharbabin https://github.com/zoharbabin/scoop-bucket
+scoop install web-researcher-mcp
+```
+
 **Homebrew Cask (macOS — Developer ID-signed + notarized binary):**
 ```bash
 brew install --cask zoharbabin/tap/web-researcher-mcp


### PR DESCRIPTION
The signing-in-GoReleaser fix (PR #153, v1.20.2) makes the Scoop manifest hash match the published signed zip — verified live (manifest == checksums.txt == zip = `c8c7e662…`). `scoop install` passes its checksum now, so the install line is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)