### PR TITLE
fix(release): make Chocolatey push non-fatal so it can't abort the release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,10 +105,29 @@ jobs:
             # shim running bare `mono`). The path has no spaces, so plain
             # interpolation into the wrapper body is safe; $@ is escaped so it
             # expands at shim-run time, not now.
+            # CRITICAL: the `push` subcommand is made NON-FATAL. The Chocolatey
+            # community feed can reject a push for reasons outside this release's
+            # control (e.g. a moderated/new-maintainer account cannot push a new
+            # version while a prior submission is still pending — a 403). GoReleaser
+            # runs the chocolatey pipe LAST, but its non-zero exit aborts the whole
+            # run (skipping the post-GoReleaser signing/cosign/mcpb/registry steps).
+            # So a choco push failure must DEGRADE, not block — like the
+            # AZURE_SIGNING_ENABLED gate. `choco push` runs, its real result is
+            # surfaced as a ::warning::, but the shim exits 0. Every other subcommand
+            # (pack, --version) passes its real exit code through.
             if [ -f "$CHOCO_DIR/choco.exe" ]; then
               printf '%s\n' \
                 '#!/usr/bin/env bash' \
-                "exec mono \"$CHOCO_DIR/choco.exe\" \"\$@\"" \
+                "CHOCO_EXE=\"$CHOCO_DIR/choco.exe\"" \
+                'if [ "$1" = "push" ]; then' \
+                '  if mono "$CHOCO_EXE" "$@"; then' \
+                '    echo "::notice::chocolatey push succeeded"' \
+                '  else' \
+                '    echo "::warning::chocolatey push failed (e.g. 403 from a pending-moderation account) — skipping this channel; the rest of the release is unaffected."' \
+                '  fi' \
+                '  exit 0' \
+                'fi' \
+                'exec mono "$CHOCO_EXE" "$@"' \
                 | sudo tee /usr/local/bin/choco >/dev/null
               sudo chmod +x /usr/local/bin/choco
             fi


### PR DESCRIPTION
## Problem

The **v1.21.0** release run ([27145284249](https://github.com/zoharbabin/web-researcher-mcp/actions/runs/27145284249)) failed at the Chocolatey push:

```
chocolatey packages: failed to push chocolatey package: exit status 1:
Response status code does not indicate success: 403 (Forbidden).
```

The 403 is an **external account-state** issue: a new-maintainer Chocolatey account can't push a new version while a prior submission (v1.20.2) is still in moderation. Not fixable in code.

The real bug is structural: GoReleaser runs the chocolatey pipe **last**, but its non-zero exit **aborts the whole run**, skipping the post-GoReleaser steps. So the GitHub release published with only binaries + per-archive SBOMs — **no .mcpb bundles, no aggregate SBOM, no cosign signatures**.

This is the same "one publisher fails → release incomplete" class already fixed for the choco bootstrap (#147) and the winget auto-PR (#148).

## Fix

The `choco` shim already wraps every GoReleaser invocation. Make **only the `push` subcommand non-fatal**: it runs, surfaces its real result as a `::warning::`, but exits `0` — so GoReleaser always reaches its post-build signing/cosign/mcpb steps. Every other subcommand (`pack`, `--version`) passes its real exit code through, so a genuinely broken CLI still skips the pipe via the existing `choco --version` gate.

Mirrors the `AZURE_SIGNING_ENABLED` / `MACOS_SIGN_P12` **"degrade, never block"** gating philosophy already used across this workflow.

## After merge

Delete the incomplete v1.21.0 release, force-move the tag to the merge commit, and re-run — the full artifact set (bundles, SBOM, cosign sigs) will publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)