### PR TITLE
docs(migration): lead with the no-new-runtime install for npm migrants (#161)

### DIFF
--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -48,25 +48,31 @@ Delete the `google-researcher` entry from your MCP configuration file:
 
 ### 2. Install the new server
 
-The fastest path is the **one-line swap**: if you ran the old server with `npx`, just switch to `uvx` (from [Astral's uv](https://docs.astral.sh/uv/), the standard Python runner). It fetches the right prebuilt binary for your platform — no Node, no Go, no compile:
+Coming from `npx google-researcher-mcp`, the **lowest-friction path needs no new runtime** — the installer drops a single signed binary on your PATH and (when the `claude` CLI is present) registers it with Claude Code automatically:
 
 ```bash
-# Recommended: one-line swap from npx → uvx (no toolchain)
-uvx web-researcher-mcp
-# or install it as a persistent tool:
-uv tool install web-researcher-mcp
-# or:
-pip install web-researcher-mcp
+# macOS / Linux — one line, no Node, no Python, no compile:
+curl -fsSL https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/install.sh | sh
+
+# Windows (PowerShell):
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/install.ps1 | iex"
 ```
 
-Prefer a native install? Any of these also work:
+**Python users** — if you have (or want) [`uv`](https://docs.astral.sh/uv/), the `npx`→`uvx` shape is a direct swap (it installs `uv` once, then fetches the prebuilt binary):
+
+```bash
+uvx web-researcher-mcp                 # run on demand
+uv tool install web-researcher-mcp     # or install as a persistent tool
+pip install web-researcher-mcp         # or via pip
+```
+
+Prefer a package manager or container? Any of these also work:
 
 ```bash
 # Homebrew (macOS)
 brew install zoharbabin/tap/web-researcher-mcp
 
-# Pre-built binary
-# Visit https://github.com/zoharbabin/web-researcher-mcp/releases
+# Pre-built binary — https://github.com/zoharbabin/web-researcher-mcp/releases
 
 # Docker
 docker pull zoharbabin/web-researcher-mcp:latest


### PR DESCRIPTION
Resolves the open design decision in #161. A user migrating from `npx google-researcher-mcp` has **Node, not `uv`** — so leading the migration with `uvx` asks them to install a *new* runtime, which isn't the frictionless swap it appears to be.

`docs/MIGRATION.md` now:
- **Leads with the curl / PowerShell installer** — no Node, no Python, no compile, and it auto-registers with Claude Code (the genuinely lowest-friction path for a Node user).
- Presents **`uvx` / `uv tool` / `pip`** as the explicit "Python users" option, noting `uv` is a one-time install.
- Keeps Homebrew / Docker / `go install` below.

**No new npm shim package** — building+maintaining a whole `npx web-researcher-mcp` channel is disproportionate for this audience's size (~tens/month); the installer already gives Node users a one-line, runtime-free path.

Part of closing #161. (The old-repo README banner is already pushed; the `npm deprecate` message update is the one remaining maintainer-credential step — see the issue.)