### PR TITLE
chore: #182 lead plugin directory keywords with the trust differentiator

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -10,11 +10,13 @@
   "repository": "https://github.com/zoharbabin/web-researcher-mcp",
   "license": "MIT",
   "keywords": [
-    "research",
-    "search",
-    "web",
+    "citation-verification",
+    "anti-hallucination",
+    "retraction-check",
+    "bibliography-audit",
+    "research-integrity",
     "academic",
-    "citations",
+    "web-search",
     "patents",
     "news"
   ],


### PR DESCRIPTION
Part of #182 ("lead directory copy with trust"). The Claude Plugin Directory surfaces the `keywords` from `.claude-plugin/plugin.json`; they previously led with the crowded generic terms (`research`/`search`/`web`), burying the anti-hallucination moat at the point of decision.

Reordered to lead with the differentiator — `citation-verification`, `anti-hallucination`, `retraction-check`, `bibliography-audit`, `research-integrity` — keeping `academic`/`web-search`/`patents`/`news` secondary.

No behavior change; `scripts/sync-version.sh` only patches `.version`, so this is safe from version-sync clobber. The remaining #182 items (Cline Marketplace submission, recording the anti-hallucination demo, external directory-listing copy) are off-repo ops/marketing actions tracked in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)