### PR TITLE
docs: zero-drift audit + EXTENSION_GUIDE

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -14,7 +14,7 @@ This is the architecture reference for web-researcher-mcp — the tool that give
 
 1. **Explicit over implicit** — No magic. Dependencies injected, not imported globally.
 2. **Fail loud, fail fast** — Return errors, don't swallow them. Validate at boundaries.
-3. **Zero global state** — All state lives in structs passed via `context.Context` or constructor injection.
+3. **Zero global state** — All deps flow through the `tools.Dependencies` struct (constructed in `main.go` and injected at registration time). Request-scoped state (tenant ID, trace) travels in `context.Context`.
 4. **Interface-driven** — Every external dependency (search API, cache, browser) is behind an interface for testing and swapping.
 5. **Bounded concurrency** — Goroutines are cheap, but external APIs are not. Explicit semaphores everywhere.
 6. **Defense in depth** — SSRF, rate limiting, content sanitization, session isolation at every layer.
@@ -98,7 +98,7 @@ web-researcher-mcp/
 │   ├── server/                   # MCP server lifecycle (STDIO + HTTP)
 │   ├── tools/                    # Tool handlers (one file per tool)
 │   ├── search/                   # Pluggable providers + router + lens routing
-│   ├── scraper/                  # 4-tier pipeline (markdown → stealth → HTML → browser) + SPA fast-path + SSRF protection + optional Exa 5th tier
+│   ├── scraper/                  # Tiered pipeline (markdown → stealth → HTML → browser) + SPA fast-path + SSRF protection + optional paid Exa final tier
 │   ├── documents/                # PDF, DOCX, PPTX parsing
 │   ├── cache/                    # Hybrid cache (memory L1 + optional Redis L2 + disk L3)
 │   ├── auth/                     # OAuth 2.1 middleware (JWT/JWKS)
@@ -106,7 +106,7 @@ web-researcher-mcp/
 │   ├── session/                  # Per-tenant session persistence — Manager interface (memory+disk or Redis)
 │   ├── content/                  # Sanitize, dedup, truncate, quality, typed source classification, claim evidence, citation extraction, bibliography read/write (APA/MLA/BibTeX/RIS/CSL-JSON round-trip), recommendations + auto-formatted components
 │   ├── metrics/                  # Prometheus metrics + per-tenant aggregate analytics
-│   ├── ratelimit/                # Three-tier rate limiting + optional atomic cross-pod daily quota
+│   ├── ratelimit/                # Four-tier rate limiting (per-IP, per-tenant, global, daily quota) + optional atomic cross-pod daily quota
 │   ├── circuit/                  # Circuit breaker
 │   ├── persist/                  # TTL key/value store (memory or AES-256-GCM disk) backing token revocation + rate quotas
 │   ├── redisbackend/             # Sole go-redis importer: Redis impls of cache/persist/session (opt-in, HTTP-only, encrypted)
@@ -189,7 +189,7 @@ type Pipeline struct {
 func (p *Pipeline) Scrape(ctx context.Context, url string, maxLength int) (*ScrapeResult, error)
 ```
 
-The pipeline routes specialized content (YouTube, Hacker News threads, PDF/DOCX/PPTX) via early-return detection, then falls back through tiers in order: markdown → stealth → HTML → browser (go-rod). Each tier is a private method with the same signature; the pipeline tries each in sequence and promotes the first result that meets a quality threshold. When `EXA_API_KEY` is set, a fifth, **paid** tier (Exa `/contents`) is appended as the last resort — it runs only after every free tier fails, so the common path never incurs cost. The winning tier is surfaced to the caller as `extractedBy` (e.g. `stealth`, `exa:cached`).
+The pipeline routes specialized content (YouTube, Hacker News threads, PDF/DOCX/PPTX) via early-return detection, then falls back through tiers in order: markdown → stealth → HTML → browser (go-rod). Each tier is a private method with the same signature; the pipeline tries each in sequence and promotes the first result that meets a quality threshold. When `EXA_API_KEY` is set, a **paid** final tier (Exa `/contents`) is appended as the last resort — it runs only after every preceding tier fails to extract more than 100 bytes, so the common path never incurs cost. The winning tier is surfaced to the caller as `extractedBy` (e.g. `stealth`, `exa:cached`).
 
 **SPA fast-path:** When the URL matches a known SPA domain (`isSPADomain` in `internal/scraper/`), the pipeline skips directly to the browser tier rather than spending time on the markdown/stealth/HTML tiers that would return JS shells. This avoids wasted round-trips and the associated latency for single-page apps.
 
@@ -206,8 +206,8 @@ Every request carries a `context.Context` with deadline. Session and tenant IDs 
 ### 6. Concurrency Model
 
 - **Per-tool timeout**: Context with deadline on every tool call
-- **Bounded parallelism**: Semaphore channel for concurrent scrapes (max 5)
-- **Per-client backpressure**: Rate limiter per session, reject with 429
+- **Bounded parallelism**: Semaphore channel for concurrent scrapes (default 5, configurable via `MAX_SCRAPE_CONCURRENCY`)
+- **Per-client backpressure**: Rate limiter per tenant (+ per-IP pre-auth), reject with 429
 - **Graceful shutdown**: Context cancellation propagates, in-flight requests drain
 
 ### 7. Operator Observability
@@ -250,7 +250,7 @@ For exact versions, see `go.mod`. All dependencies use MIT, Apache 2.0, or BSD l
 | Scrape (browser) | 2-10s | go-rod headless, bounded to MaxConcurrency |
 | YouTube transcript | 1-5s | 3-strategy: captions → timedtext API → description |
 | Hacker News item/list/user | 200-700ms | Native HN Firebase REST; story + top comments fetched in parallel |
-| search_and_scrape | 2-15s | Parallel scrape (semaphore=5) |
+| search_and_scrape | 2-15s | Parallel scrape (semaphore, default 5) |
 
 ## Concurrency Limits
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,10 +8,10 @@ An MCP server in Go that gives AI assistants web search, content extraction, and
 go build -o web-researcher-mcp ./cmd/web-researcher-mcp    # Build
 go test ./...                                               # Unit + integration tests
 go test -race ./...                                         # Race detector
-go test -v ./tests/e2e/...                                  # E2E (needs API keys)
+go test -tags=e2e -count=1 ./tests/e2e/...                  # E2E (needs e2e build tag)
 go tool golangci-lint run                                   # Lint (pinned version)
 go tool govulncheck ./...                                    # Vulnerability scan (pinned version)
-make verify                                                  # fmt-check + vet + lint + gosec + vuln + validate-lenses + test-race + test-e2e + check-python-drift + test-python + build (CI gate; `make all` aliases it)
+make verify                                                  # fmt-check + vet + lint + sec + vuln + validate-lenses + test-race + test-e2e + check-python-drift + test-python + build (CI gate; `make all` aliases it)
 make test-python                                             # Python SDK unit + integration tests (no binary; mock HTTP server)
 make test-python-live                                        # Python SDK live E2E tests (builds Go binary; needs internet)
 ```
@@ -81,13 +81,13 @@ Registry/manifest files (root, each read by a different external tool): `server.
 ## Design Rules
 
 1. **Zero global state** — all deps flow through `tools.Dependencies` struct (constructed in `main.go`)
-2. **Interface-driven** — `cache.Cache`, `search.Provider`, `audit.Auditor` are interfaces; swap implementations without touching callers. Specialized capability interfaces (each a `…Searcher` + `…Provider` pair): `search.PatentSearcher`/`PatentProvider`, `search.AcademicSearcher`/`AcademicProvider`, `search.CitationSearcher` (on academic providers), `search.AnswerSearcher`/`AnswerProvider`, `search.StructuredSearcher`/`StructuredProvider`, and the structured-domain set `search.FilingSearcher`/`FilingProvider`, `search.CaseSearcher`/`CaseProvider`, `search.EconSearcher`/`EconProvider`, `search.TrialSearcher`/`TrialProvider` (`internal/search/structured_domains.go`). Enrichment resolver interfaces: `search.DOIResolver` (exact-entity DOI lookup, `domain.go`), `search.OAResolver` (Unpaywall open-access enrichment, `unpaywall.go`), `search.RetractionResolver` (Crossref retraction status, `retraction.go`)
+2. **Interface-driven** — `cache.Cache`, `search.Provider`, `audit.Auditor` are interfaces; swap implementations without touching callers. Specialized capability interfaces (each a `…Searcher` + `…Provider` pair): `search.PatentSearcher`/`PatentProvider`, `search.AcademicSearcher`/`AcademicProvider`, `search.CitationSearcher` (on academic providers), `search.AnswerSearcher`/`AnswerProvider`, `search.StructuredSearcher`/`StructuredProvider`, and the structured-domain set `search.FilingSearcher`/`FilingProvider`, `search.CaseSearcher`/`CaseProvider`, `search.EconSearcher`/`EconProvider`, `search.TrialSearcher`/`TrialProvider` (`internal/search/structured_domains.go`). Enrichment resolver interfaces: `search.DOIRegistry` (cross-registrar DOI existence check, `doi_registry.go`), `search.DOIResolver` (exact-entity DOI lookup, `domain.go`), `search.OAResolver` (Unpaywall open-access enrichment, `unpaywall.go`), `search.RetractionResolver` (Crossref retraction status, `retraction.go`)
 3. **Errors are values** — tool handlers return `toolError("message")` which sets `IsError: true` on the MCP result; never panic. Upstream errors use `upstreamErrorResponse()`. Scrape errors use typed `ScrapeError{Kind}`. Full error architecture: see `docs/ERROR_HANDLING.md`
 4. **Bounded concurrency** — scraping semaphore (5 slots), mutex-serialized browser, per-tenant rate limits
 5. **Lens routing** — if `lens` is set, `site:` operators are injected and routed to the configured provider; lenses with a dedicated `cx` route directly to that Google PSE engine
 6. **Multi-provider routing** — when `SEARCH_ROUTING` is set, the Router wraps all available providers with per-provider circuit breakers and priority-ordered fallback; transparent to tools via the `search.Provider` interface
 7. **Explicit provider honoring** — when a user explicitly requests a provider via the `provider` field, that provider is used exclusively; if it returns empty results (e.g., USPTO for non-US patents), the tool returns empty — no silent fallback
-8. **Provider maps** — `deps.SearchProviders`, `deps.PatentProviders`, `deps.AcademicProviders`, `deps.AnswerProviders`, `deps.StructuredProviders` hold all configured providers by name; built at startup via `Available…Providers()`, independent of routing config
+8. **Provider maps** — `deps.SearchProviders`, `deps.PatentProviders`, `deps.AcademicProviders`, `deps.AnswerProviders`, `deps.StructuredProviders`, `deps.FilingProviders`, `deps.CaseProviders`, `deps.EconProviders`, `deps.TrialProviders`, `deps.LocalProviders`, `deps.ContextProviders` hold all configured providers by name; built at startup via `Available…Providers()`, independent of routing config
 
 ## How to Add a Tool
 
@@ -118,7 +118,7 @@ Registry/manifest files (root, each read by a different external tool): `server.
 - **Audit**: every tool call logs `audit.AuditEvent{ToolName, Duration, Success, Metadata, ...}` via `deps.Auditor.Log()`
 - **SSRF protection**: `scraper.NewSSRFSafeClient()` validates all resolved IPs before connecting
 - **Content pipeline**: raw HTML → sanitize (bluemonday) → dedup (paragraph hashing) → truncate (sentence boundary) → quality score
-- **Tool annotations**: read tools use `readOnlyAnnotations(idempotent, openWorld)`; the rare write tool uses `writeAnnotations(idempotent)` (never destructive) — both enforced by `TestAllToolsHaveAnnotations` in CI
+- **Tool annotations**: read tools use `readOnlyAnnotations(idempotent, openWorld)`; write tools (`memory_save`, `archive_source`, `workspace_contribute`) use `writeAnnotations(idempotent)` (never destructive) — both enforced by `TestAllToolsHaveAnnotations` in CI
 - **Consent gate (regulated tools)**: `deps.Consent.HasConsent(ctx, consent.PurposeMemory|PurposeAnalytics|PurposeWorkspace)` is fail-closed; subject identity comes from `auth.UserIDFromContext`/`auth.TenantIDFromContext`, never a tool param
 - **Data-subject rights**: per-user stores register an `Exporter`/`Eraser` in `internal/datasubject` (keyed `(tenantID,userID)`) so `/admin/data` export+erasure reaches them
 - **Redis isolation**: `internal/redisbackend` is the ONLY package importing go-redis; constructed in one gated place in `main.go` (`Port>0 && REDIS_URL!=""`), fail-fast, encryption-mandatory
@@ -145,7 +145,7 @@ Push a `v*` tag → CI runs GoReleaser → cross-platform binaries + Docker mult
 
 ## Documentation Guidelines
 
-**TOP RULE — accuracy above all:** every doc (file *and* inline comment) must reflect the current codebase exactly. No drift, no hallucinations, no stale claims. Every feature, config, architecture flow, and business workflow must be documented, easy to start with, easy to follow, and easy to extend. Never include secrets, private data, or real keys — placeholders only.
+**TOP RULE — accuracy above all:** every doc (file *and* inline comment) must reflect the current codebase exactly. No drift, no hallucinations, no stale claims. Every feature, config, architecture flow, and business workflow must be documented — quick to start, clear to follow, and built to extend. Never include secrets, private data, or real keys — placeholders only.
 
 ### Write docs for an agent (structure):
 1. **One-line description** at the top — the reader knows what this is without reading further
@@ -198,7 +198,7 @@ Non-negotiable rules for all code changes (human or AI agent):
 8. **Constant-time comparison for secrets** — use `subtle.ConstantTimeCompare()`, never `==` for auth tokens/keys.
 9. **Encrypt sensitive persistent data** — reuse existing AES-256-GCM disk infrastructure when storing to disk: `cache.DiskCache` for cached responses, `persist.DiskStore` for TTL key/value state (token revocation, rate quotas), `session` store for research sessions.
 10. **Minimal dependencies** — prefer Go stdlib. Each new dependency is a supply chain risk. Justify in PR.
-11. **Annotate all tools** — every tool must declare `readOnlyAnnotations(idempotent, openWorld)`. CI test enforces this.
+11. **Annotate all tools** — every tool must declare `readOnlyAnnotations(idempotent, openWorld)` or `writeAnnotations(idempotent)` as appropriate. CI test enforces this.
 
 Security-sensitive changes (auth, SSRF, cache keys, Dockerfile, CI) require focused review.  
 Full security and compliance guidelines: see `docs/SECURITY_AND_COMPLIANCE.md`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,6 +185,7 @@ Every doc and inline comment must reflect the current codebase exactly. No drift
 | File | When to read |
 |---|---|
 | `ARCHITECTURE.md` | Design decisions, tech stack, concurrency model |
+| `docs/EXTENSION_GUIDE.md` | When to add a tool vs. provider vs. lens vs. enrichment vs. prompt vs. resource |
 | `CONTRIBUTING.md` | Code style, commit format, PR process, adding tools/providers |
 | `docs/TOOLS.md` | Tool parameter schemas and behavior contracts |
 | `docs/ERROR_HANDLING.md` | Error taxonomy, LLM-facing messages, contributor patterns |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,35 +8,34 @@ An MCP server in Go that gives AI assistants web search, content extraction, and
 go build -o web-researcher-mcp ./cmd/web-researcher-mcp    # Build
 go test ./...                                               # Unit + integration tests
 go test -race ./...                                         # Race detector
-go test -tags=e2e -count=1 ./tests/e2e/...                  # E2E (needs e2e build tag)
+go test -tags=e2e -count=1 ./tests/e2e/...                  # E2E (needs e2e build tag + API keys)
+go test -tags=live ./...                                    # Live external-API tests (needs API keys)
 go tool golangci-lint run                                   # Lint (pinned version)
-go tool govulncheck ./...                                    # Vulnerability scan (pinned version)
-make verify                                                  # fmt-check + vet + lint + sec + vuln + validate-lenses + test-race + test-e2e + check-python-drift + test-python + build (CI gate; `make all` aliases it)
-make test-python                                             # Python SDK unit + integration tests (no binary; mock HTTP server)
-make test-python-live                                        # Python SDK live E2E tests (builds Go binary; needs internet)
+go tool govulncheck ./...                                   # Vulnerability scan (pinned version)
+make verify                                                 # Full CI gate: fmt-check + vet + lint + sec + vuln + validate-lenses + test-race + test-e2e + check-python-drift + test-python + build
+make test-python                                            # Python SDK unit + integration tests (mock HTTP server, no binary)
+make test-python-live                                       # Python SDK live E2E tests (builds Go binary; needs internet)
+make rebuild-local                                          # Clear caches + rebuild + reinstall (macOS-SIGKILL-safe); ARGS="--no-install" to build only
 ```
 
-### Local rebuild for IRL testing
+Prefer `make` for CI-gated targets — they carry the right flags, pinned tools, and correct sequencing. Use raw `go` commands for one-off interactive use only.
 
-`make rebuild-local` (or `scripts/rebuild-local.sh`, or the `/rebuild-local` slash command) does the full **clear-caches → rebuild → reinstall** flow deterministically in one shell call — no LLM roundtrips. Use it after a scraper/server change before restarting the MCP client to test live.
+## Contribution Rules
 
-```bash
-make rebuild-local                      # clear caches + build + reinstall over the binary on PATH
-make rebuild-local ARGS="--no-install"  # build only
-make rebuild-local ARGS="--help"        # flags + INSTALL_PATH/CACHE_DIR env overrides
-```
-
-It clears the Go build cache (from-scratch compile) and the MCP **response** cache (`*.cache` + `.version`) so a live tool call hits the network fresh, then rebuilds with version ldflags and reinstalls using the macOS-SIGKILL-safe `rm`+`cp`+`codesign` sequence. It deliberately **never** touches personal-data dirs under the cache root (`sessions/`, `persist/`). Restart the MCP client afterward to load the new binary.
+- **Never push directly to `main`.** All changes go through a branch and a pull request — no exceptions, including chore commits and one-liners.
+- **Commit format**: `type(scope): subject [(#PR)]` — types: `feat`, `fix`, `chore`, `docs`, `refactor`, `test`, `ci`. Examples: `fix(config): validate CACHE_ENCRYPTION_KEY` · `chore: bump VERSION to 1.36.4` · `docs: full zero-drift audit`.
+- **After any edit to `lenses/`**: run `make sync-lenses` before committing — copies changes into `internal/search/lenses_embed/`. `TestEmbeddedLensesMatchRoot` fails CI if they diverge.
+- **After any tool schema change**: run `make gen-python-client`, then stage and commit the regenerated `python/web_researcher_mcp/{models.py,client.py,__init__.py}` in the same commit. The `python-drift` CI job and the pre-commit hook both fail if you skip this.
 
 ## Architecture
 
 ```text
 cmd/web-researcher-mcp/main.go   # Wiring only — constructs deps, starts server
-cmd/gen-python-client/  # Emits Go tool schemas as JSON; piped through scripts/gen_python_client.py to regenerate the Python client
+cmd/gen-python-client/           # Emits Go tool schemas as JSON → piped through scripts/gen_python_client.py to regenerate the Python client
 internal/
 ├── tools/        # One file per tool, typed input structs, registered in registry.go; large-payload resource_link store (artifacts.go: research://artifact/{id})
 ├── search/       # Provider interface + adapters + Router (multi-provider fallback); DOI enrichment: open-access (Unpaywall) + retraction status (Crossref Retraction Watch); custom/validated lenses
-├── scraper/      # 4-tier pipeline: markdown → stealth → HTML → browser (go-rod); SSRF-safe client; link verifier (liveness + Wayback archive)
+├── scraper/      # 4-tier pipeline by default (markdown → stealth → HTML → browser/go-rod), optional 5th Exa tier when EXA_API_KEY is set; SSRF-safe client; link verifier (liveness + Wayback archive)
 ├── documents/    # PDF, DOCX, PPTX extraction
 ├── cache/        # Cache interface + hybrid impl (memory + AES-encrypted disk)
 ├── persist/      # Generic TTL key/value Store (memory or AES-256-GCM disk) — backs token revocation + rate-quota durability
@@ -46,7 +45,7 @@ internal/
 ├── server/       # MCP server lifecycle (STDIO + Streamable HTTP) + admin endpoints (cache/session flush, /admin/data, /admin/consent, /admin/analytics, /admin/workspace/members) + operator dashboard (/dashboard HTML + admin-gated /dashboard/data, nonce-CSP)
 ├── auth/         # OAuth 2.1 middleware (JWKS, audience/issuer validation)
 ├── audit/        # Auditor interface + structured JSON logging (PodID for cross-pod correlation)
-├── session/      # Per-tenant session persistence — Manager interface (memory+disk default, or Redis impl)
+├── session/      # Per-tenant session persistence — Manager interface (disk-backed default, or Redis impl)
 ├── consent/      # Consent record-verify-honor for regulated features (Checker + typed purposes + Noop default)
 ├── datasubject/  # GDPR access/erasure registry: (tenantID,userID) Exporter/Eraser fan-out across all personal-data stores
 ├── useranalytics/# Opt-in consent-gated per-user usage analytics (Recorder + Noop)
@@ -56,34 +55,29 @@ internal/
 ├── ratelimit/    # Token bucket (per-tenant + global) + optional atomic cross-pod daily quota (Redis)
 ├── circuit/      # Circuit breaker for external APIs
 └── resources/    # MCP Resources (stats:// + diagnostics:// errors/health + lenses://catalog + research://artifact/{id}) + Prompts (research templates) + completion/complete handler (lens/provider/enum arg autocompletion, DI suppliers)
-lenses/           # JSON files defining domain lists for site-restricted search (CANONICAL source; go:embed'd into the binary via internal/search/lenses_embed/ so lenses work from any CWD/install — keep in sync with `make sync-lenses`, guarded by TestEmbeddedLensesMatchRoot)
-tests/e2e/        # Full process E2E tests
+lenses/           # JSON files defining domain lists for site-restricted search (CANONICAL source; go:embed'd into the binary via internal/search/lenses_embed/ — keep in sync with `make sync-lenses`, guarded by TestEmbeddedLensesMatchRoot)
+tests/e2e/        # Full-process E2E tests (build tag: e2e)
 tests/benchmark/  # Performance benchmarks
-```
-
-Non-obvious top-level dirs (so they're not mistaken for clutter or duplicates):
-
-```text
+# non-obvious top-level dirs
 docs/             # Published docs (mkdocs site); docs/internal/ = local-only working docs (gitignored, never published)
-decks/            # Marp presentation decks (source + self-contained html/pdf), one folder per deck — published to the site under /decks/<name>/ by docs.yml (see decks/README.md)
-assets/           # Logos, social-preview, favicon, ProductHunt gallery — consumed by README, the docs site, and registries
-scripts/          # Build/release helpers (build-mcpb, build_wheels.py [PyPI wheels], gen_python_client.py [Python client codegen], docker-smoke, sync-version, rebuild-local, sign-windows) — wired into Makefile/CI
+decks/            # Marp presentation decks (source + self-contained html/pdf) — published to /decks/<name>/ by docs.yml
+assets/           # Logos, social-preview, favicon, ProductHunt gallery
+scripts/          # Build/release helpers (build-mcpb, build_wheels.py, gen_python_client.py, docker-smoke, sync-version, rebuild-local, sign-windows)
 .githooks/        # Git pre-commit hook (enabled via `make hooks`) — fmt/lint/vet on staged Go files
 hooks/            # Claude Code PLUGIN hook manifest (hooks.json) — NOT a git hook; runs bin/install.sh on session start
 bin/              # Claude Code plugin installer (bin/install.sh) — distinct from the root curl installer install.sh
-.claude-plugin/   # Claude Code plugin manifest
+.claude-plugin/   # Claude Code plugin manifest — do not modify without understanding the plugin bootstrap
 mcpb/             # .mcpb bundle manifest template (consumed by scripts/build-mcpb.sh at release)
-overrides/        # mkdocs-material theme overrides (main.html — OG/Twitter card meta)
 ```
 
-Registry/manifest files (root, each read by a different external tool): `server.json` (MCP registry), `smithery.yaml` (Smithery), `glama.json` (Glama), `.mcp.json` (local MCP client config), `VERSION` (source of truth, synced by `scripts/sync-version.sh` into server.json + .claude-plugin). Two Dockerfiles are intentional: `Dockerfile` (local/Makefile) and `Dockerfile.release` (GoReleaser). Two installers are intentional: root `install.sh`/`install.ps1` (curl installers) and `bin/install.sh` (plugin hook).
+Registry/manifest files (root, each read by a different external tool): `server.json` (MCP registry), `smithery.yaml` (Smithery), `glama.json` (Glama), `.mcp.json` (local MCP client config — edit this to wire env vars for local testing), `VERSION` (source of truth, synced by `scripts/sync-version.sh`). Two Dockerfiles are intentional: `Dockerfile` (local/Makefile) and `Dockerfile.release` (GoReleaser). Two installers are intentional: root `install.sh`/`install.ps1` (curl installers) and `bin/install.sh` (plugin hook).
 
 ## Design Rules
 
 1. **Zero global state** — all deps flow through `tools.Dependencies` struct (constructed in `main.go`)
 2. **Interface-driven** — `cache.Cache`, `search.Provider`, `audit.Auditor` are interfaces; swap implementations without touching callers. Specialized capability interfaces (each a `…Searcher` + `…Provider` pair): `search.PatentSearcher`/`PatentProvider`, `search.AcademicSearcher`/`AcademicProvider`, `search.CitationSearcher` (on academic providers), `search.AnswerSearcher`/`AnswerProvider`, `search.StructuredSearcher`/`StructuredProvider`, and the structured-domain set `search.FilingSearcher`/`FilingProvider`, `search.CaseSearcher`/`CaseProvider`, `search.EconSearcher`/`EconProvider`, `search.TrialSearcher`/`TrialProvider` (`internal/search/structured_domains.go`). Enrichment resolver interfaces: `search.DOIRegistry` (cross-registrar DOI existence check, `doi_registry.go`), `search.DOIResolver` (exact-entity DOI lookup, `domain.go`), `search.OAResolver` (Unpaywall open-access enrichment, `unpaywall.go`), `search.RetractionResolver` (Crossref retraction status, `retraction.go`)
 3. **Errors are values** — tool handlers return `toolError("message")` which sets `IsError: true` on the MCP result; never panic. Upstream errors use `upstreamErrorResponse()`. Scrape errors use typed `ScrapeError{Kind}`. Full error architecture: see `docs/ERROR_HANDLING.md`
-4. **Bounded concurrency** — scraping semaphore (5 slots), mutex-serialized browser, per-tenant rate limits
+4. **Bounded concurrency** — scraping semaphore (default 5 slots, configurable via `MAX_SCRAPE_CONCURRENCY`), mutex-serialized browser, per-tenant rate limits
 5. **Lens routing** — if `lens` is set, `site:` operators are injected and routed to the configured provider; lenses with a dedicated `cx` route directly to that Google PSE engine
 6. **Multi-provider routing** — when `SEARCH_ROUTING` is set, the Router wraps all available providers with per-provider circuit breakers and priority-ordered fallback; transparent to tools via the `search.Provider` interface
 7. **Explicit provider honoring** — when a user explicitly requests a provider via the `provider` field, that provider is used exclusively; if it returns empty results (e.g., USPTO for non-US patents), the tool returns empty — no silent fallback
@@ -96,124 +90,108 @@ Registry/manifest files (root, each read by a different external tool): `server.
    - Write a `register<Name>(srv *mcp.Server, deps Dependencies)` function
    - Use `deps.Cache` for caching, `deps.Metrics` for telemetry, `deps.Auditor` for audit
    - Return validation errors via `toolError(msg)`, upstream errors via `upstreamErrorResponse(toolName, err)`, success via `structuredResult(jsonBytes)`
-   - Add `Annotations: readOnlyAnnotations(idempotent, openWorld)` to the tool definition. **Write tools** (mutate state or create an external artifact, e.g. `memory_save` or `archive_source` which triggers an Internet-Archive capture) use `writeAnnotations(idempotent)` instead — `ReadOnlyHint:false`, `DestructiveHint:false` (deletion is the `/admin/data` erasure endpoint, never a tool flag); add a `case` for the tool in `TestAllToolsHaveAnnotations`.
-2. Add `register<Name>(srv, deps)` to `RegisterAll()` in `internal/tools/registry.go`. **Regulated/opt-in tools** register conditionally (only when their feature dep is non-Noop) and gate every personal-data operation on `deps.Consent.HasConsent(ctx, consent.Purpose…)`; register the store's `Exporter`/`Eraser` into the `datasubject` registry in `main.go`.
-3. Add tests to `internal/tools/tools_test.go`; add the tool name to `expectedTools` (`metadata_test.go`). For a conditionally-registered tool, also wire its feature dep into `setupTestDeps()` so the drift gates exercise it.
-4. Document the schema in `docs/TOOLS.md` as a `## Tool N: \`name\`` section (the drift test parses these headers).
-5. Run `make gen-python-client` — regenerates `python/web_researcher_mcp/{models.py,client.py,__init__.py}` from the live Go schemas. Stage and commit the result. The `python-drift` CI job and the pre-commit hook both fail if you skip this step.
+   - Add `Annotations: readOnlyAnnotations(idempotent, openWorld)` to the tool definition. **Write tools** (mutate state or create an external artifact, e.g. `memory_save` or `archive_source`) use `writeAnnotations(idempotent)` instead — `ReadOnlyHint:false`, `DestructiveHint:false`; add a `case` for the tool in `TestAllToolsHaveAnnotations`.
+2. Add `register<Name>(srv, deps)` to `RegisterAll()` in `internal/tools/registry.go`. **Regulated/opt-in tools** register conditionally (only when their feature dep is non-Noop) and gate every personal-data operation on `deps.Consent.HasConsent(ctx, consent.PurposeMemory)` (single purpose per call site); register the store's `Exporter`/`Eraser` into the `datasubject` registry in `main.go`. `filing_search` is the one always-conditionally-registered structured-domain tool — it only registers when `EDGAR_CONTACT_EMAIL` or `OPENALEX_EMAIL` is set; mirror this pattern (not `legal_search`) for any new tool with a required email contact.
+3. Add tests to `internal/tools/tools_test.go`; add the tool name to `expectedTools` in `metadata_test.go`. For a conditionally-registered tool, also wire its feature dep into `setupTestDeps()` (in `tools_test.go`) so the drift gates exercise it.
+4. Document the schema in `docs/TOOLS.md` as a `## Tool N: \`name\`` section (the drift test parses these headers). **When modifying an existing tool** (renaming params, changing descriptions, adding/removing fields), update the matching `docs/TOOLS.md` section in the same commit — `TestToolsDocMatchesRegistry` fails CI on any drift, including edits to existing tools.
+5. Run `make gen-python-client`, then stage and commit the result. The `python-drift` CI job and the pre-commit hook both fail if you skip this.
 
 ## How to Add a Search Provider
 
-1. Create `internal/search/<name>.go` implementing `search.Provider` interface (Web, Images, News, Name methods); add a `var _ Provider = (*XProvider)(nil)` assertion. Return `(nil, nil)` from any unsupported sub-capability (e.g. Images) — never an error (that would trip the breaker).
-2. Add the name to `search.SupportedProviders` and a case to `NewProvider()`/`NewProviderByName()` in `internal/search/provider.go`. `AvailableProviders()` ranges over `SupportedProviders`, so no edit there.
+1. Create `internal/search/<name>.go` implementing `search.Provider` (Web, Images, News, Name methods); add `var _ Provider = (*XProvider)(nil)`. Return `(nil, nil)` from unsupported sub-capabilities (e.g. Images) — never an error (that would trip the breaker).
+2. Add the name to `search.SupportedProviders` and a case to `NewProvider()`/`NewProviderByName()` in `internal/search/provider.go`. `AvailableProviders()` ranges over `SupportedProviders` — no edit there.
 3. Add the env var to `internal/config/config.go` (field + required-when-selected check) and `.env.example`.
-4. To also offer a specialized capability (academic / answer / structured / citation / filing / case / econ / trial), implement the matching `…Provider` interface and register the name in its `Supported…Providers` list + `New…ProviderByName` switch + `Available…Providers` constructor: `internal/search/domain.go` for academic + citation, `synthesis.go` for answer/structured, `structured_domains.go` for the filing/case/econ/trial set (EDGAR/CourtListener/FRED+WorldBank/ClinicalTrials.gov). The matching tool (`academic_search`/`answer`/`structured_search`/`citation_graph`/`filing_search`/`legal_search`/`econ_search`/`clinical_search`) then picks it up with no tool-layer change. A new provider behind an existing interface (e.g. World Bank under `EconProvider`) needs only its `Supported…`/`New…ByName` entry — no tool change. Every provider gets its own `circuit.New(...)` breaker via the `Available…Providers` constructor.
+4. For specialized capabilities (academic / answer / structured / citation / filing / case / econ / trial): implement the matching `…Provider` interface and register in its `Supported…Providers` list + `New…ProviderByName` switch + `Available…Providers` constructor — `internal/search/domain.go` (academic + citation), `synthesis.go` (answer/structured), `structured_domains.go` (filing/case/econ/trial). The matching tool picks it up with no tool-layer change. Every provider gets its own `circuit.New(...)` breaker via the `Available…Providers` constructor.
 
 ## Key Patterns
 
 - **Tool handler signature**: `func(ctx context.Context, req *mcp.CallToolRequest, input T) (*mcp.CallToolResult, any, error)`
-- **Error responses**: `structuredError(msg, ToolError{})` for dual-format errors (text + JSON); `toolError(msg)` for validation-only; `upstreamErrorResponse(toolName, err)` for provider failures; `scrapeErrorResponse(err, url)` for scrape failures. Defined across `internal/tools/errors.go` (`structuredError`), `search.go` (`toolError`, `upstreamErrorResponse`, `structuredResult`), and `scrape.go` (`scrapeErrorResponse`).
-- **Provider resolution**: `resolveProvider()` for web search; `resolvePatentSearcher()` for patents; `resolveAcademicSearcher()` for academic; `resolveAnswerSearcher()`/`resolveStructuredSearcher()` for the synthesis tools — all return `*mcp.CallToolResult` errors with full provider list on unknown provider
+- **Error responses**: `structuredError(msg, ToolError{})` for dual-format errors (text + JSON); `toolError(msg)` for validation-only; `upstreamErrorResponse(toolName, err)` for provider failures; `scrapeErrorResponse(err, url)` for scrape failures. Defined across `internal/tools/errors.go` (`structuredError`), `search.go` (`toolError`, `upstreamErrorResponse`, `structuredResult`), `scrape.go` (`scrapeErrorResponse`).
+- **Provider resolution**: `resolveProvider()` for web search; `resolvePatentSearcher()` for patents; `resolveAcademicSearcher()` for academic; `resolveAnswerSearcher()`/`resolveStructuredSearcher()` for synthesis tools — all return `*mcp.CallToolResult` errors with full provider list on unknown provider
 - **Cache key**: SHA-256 of deterministic params → `deps.Cache.Get/Set`
 - **Audit**: every tool call logs `audit.AuditEvent{ToolName, Duration, Success, Metadata, ...}` via `deps.Auditor.Log()`
 - **SSRF protection**: `scraper.NewSSRFSafeClient()` validates all resolved IPs before connecting
 - **Content pipeline**: raw HTML → sanitize (bluemonday) → dedup (paragraph hashing) → truncate (sentence boundary) → quality score
-- **Tool annotations**: read tools use `readOnlyAnnotations(idempotent, openWorld)`; write tools (`memory_save`, `archive_source`, `workspace_contribute`) use `writeAnnotations(idempotent)` (never destructive) — both enforced by `TestAllToolsHaveAnnotations` in CI
-- **Consent gate (regulated tools)**: `deps.Consent.HasConsent(ctx, consent.PurposeMemory|PurposeAnalytics|PurposeWorkspace)` is fail-closed; subject identity comes from `auth.UserIDFromContext`/`auth.TenantIDFromContext`, never a tool param
+- **Tool annotations**: read tools use `readOnlyAnnotations(idempotent, openWorld)`; write tools (`memory_save`, `archive_source`, `workspace_contribute`) use `writeAnnotations(idempotent)` — both enforced by `TestAllToolsHaveAnnotations` in CI
+- **Consent gate (regulated tools)**: `deps.Consent.HasConsent(ctx, consent.PurposeMemory)` (pass one `Purpose` constant per call site) is fail-closed; subject identity comes from `auth.UserIDFromContext`/`auth.TenantIDFromContext`, never a tool param
 - **Data-subject rights**: per-user stores register an `Exporter`/`Eraser` in `internal/datasubject` (keyed `(tenantID,userID)`) so `/admin/data` export+erasure reaches them
-- **Redis isolation**: `internal/redisbackend` is the ONLY package importing go-redis; constructed in one gated place in `main.go` (`Port>0 && REDIS_URL!=""`), fail-fast, encryption-mandatory
+- **Redis isolation**: `internal/redisbackend` is the ONLY package importing go-redis; constructed in one gated place in `main.go` (`Port>0 && REDIS_URL!=""`) — fail-fast, encryption-mandatory
+- **Regulated-feature env var naming**: shell/`.zshenv` uses `WEB_RESEARCHER_MCP_` prefix (`WEB_RESEARCHER_MCP_MEMORY_ENABLED`, `WEB_RESEARCHER_MCP_STDIO_USER_ID`, etc.); `.mcp.json` maps these to unprefixed names inside the process. `STDIO_USER_ID` is required for memory/analytics/workspaces to function in STDIO mode.
 
 ## Environment
 
-Required: None — DuckDuckGo works as zero-config fallback (no API key needed).  
-For better results: `GOOGLE_CUSTOM_SEARCH_API_KEY`, `GOOGLE_CUSTOM_SEARCH_ID`  
-Optional: `SEARCH_PROVIDER` (google|brave|serper|searxng|searchapi|duckduckgo|tavily|exa|hackernews), `SEARCH_ROUTING`, `BRAVE_API_KEY`, `SEARCHAPI_API_KEY`, `TAVILY_API_KEY`, `EXA_API_KEY`, `PORT` (enables HTTP)  
-Full list: see `.env.example`
-
-## Release Process
-
-Push a `v*` tag → CI runs GoReleaser → cross-platform binaries + Docker multi-arch (GHCR + Docker Hub) + .mcpb bundles + SBOM + cosign signatures. Downstream gated jobs (each `needs: release`, off the critical path so a publisher failure can't abort the core release): Docker signing, MCP Registry, Smithery (`SMITHERY_ENABLED`), and PyPI platform wheels for uvx/uv/pip (`PYPI_PUBLISH_ENABLED`, Trusted Publishing OIDC). All automated via `.github/workflows/release.yml` + `.goreleaser.yml`.
+Required: none — DuckDuckGo works as zero-config fallback (no API key needed).  
+For better results: set `GOOGLE_CUSTOM_SEARCH_API_KEY` + `GOOGLE_CUSTOM_SEARCH_ID`.  
+Full list: `.env.example` (authoritative) and `docs/DEPLOYMENT.md`.
 
 ## Testing
 
 - Unit tests (no network): mock interfaces, table-driven, `t.Parallel()`
 - Integration tests: `httptest` servers, real components, mock external APIs
-- E2E tests: real binary, real MCP transport, require API keys
-- Live tests (`//go:build live`, `make test-live`): hit real provider APIs; skip when creds absent
-- Trust-suite accuracy eval (`make test-eval`, `internal/tools/trust_eval_live_test.go`): labeled gold set (fabricated/retracted/real/mischaracterized) → precision/recall per signal; fails on any false positive (mislabeling a legitimate source)
+- E2E tests (`-tags=e2e`): real binary, real MCP transport, require API keys
+- Live tests (`-tags=live`, `make test-live`): hit real provider APIs; skip when creds absent
+- Trust-suite accuracy eval (`make test-eval`, `internal/tools/trust_eval_live_test.go`): labeled gold set → precision/recall per signal; fails on any false positive
 - Always run `go test -race ./...` before submitting
 
-## Documentation Guidelines
+## Release Process
 
-**TOP RULE — accuracy above all:** every doc (file *and* inline comment) must reflect the current codebase exactly. No drift, no hallucinations, no stale claims. Every feature, config, architecture flow, and business workflow must be documented — quick to start, clear to follow, and built to extend. Never include secrets, private data, or real keys — placeholders only.
-
-### Write docs for an agent (structure):
-1. **One-line description** at the top — the reader knows what this is without reading further
-2. **Commands** are copy-paste ready — no prose to parse
-3. **Architecture as a map, not a lecture** — each package gets a single-line purpose annotation so the reader navigates to the right file in one step
-4. **Design Rules are mechanical constraints**, not aspirations — "if `lens` is set, inject `site:` and route to the PSE", not "we value flexibility"
-5. **How-to sections give exact file paths + function names** — the reader opens the right file and follows the pattern without grepping
-6. **Key Patterns show real signatures** — the actual helper names, handler signature, and pipeline stages the reader will encounter
-7. **Environment says required vs optional** in one or two lines, then defers to `.env.example` for the full list
-8. **Reference Docs table has a "when to read" column** — the reader opens the one doc relevant to the task
-
-### Tool-doc correctness (verified in CI):
-- Tool descriptions match code, including side effects; read-only/idempotency explicitly marked
-- Output schemas surface freshness/provenance where relevant (`source`, `citation`, cache `_meta`)
-- Destructive operations are **separate tools**, never a flag on a read tool
-- Auth/tenant scope is visible in the result or audit receipt (`tenant_id`, `user_id`)
-- `internal/tools/metadata_test.go` fails CI on drift: `TestToolsDocMatchesRegistry` (docs/TOOLS.md ↔ registry), `TestAllToolsHaveAnnotations`, `TestOutputSchemaMatchesResponse`, `TestToolDescriptionQuality`. These run in the full `test` job AND in a standalone always-run `docs-drift` job (`.github/workflows/ci.yml`) so they fire even on **docs-only** PRs — a `docs/TOOLS.md` edit that drifts from the registry fails CI even when no `.go` file changed.
-
-### Deliberately EXCLUDE (these change → they drift):
-- No hardcoded counts (tool/provider count — `registry.go` / `search.SupportedProviders` are the truth)
-- No version numbers (`go.mod` is the truth)
-- No line counts
-- No env var tables outside `.env.example` + `docs/DEPLOYMENT.md` (those are authoritative)
-- No dependency lists (`go.mod` is the truth)
-- No architecture diagram duplicated from `ARCHITECTURE.md` (one home, too large to maintain twice)
-- No inlined code that mirrors source — describe the pattern, point to the canonical file
-
-### Drift-resistant by design:
-- Reference structural file paths and function names (unlikely to change)
-- Reference interfaces by name (stable contracts)
-- Point to other docs for detail instead of duplicating
-
-### Markdown (GitHub compliance):
-- Valid GFM; blank lines between block elements (headings, paragraphs, lists, tables, code blocks)
-- Two trailing spaces or `<br>` for intra-paragraph line breaks (bare newlines do NOT break on GitHub)
-- Tables have a header separator row (`|---|---|`); fenced code blocks carry a language identifier
-- No trailing whitespace except intentional line breaks; standard `[text](url)` / `![alt](url)` links
+Push a `v*` tag → CI runs GoReleaser → cross-platform binaries + Docker multi-arch (GHCR + Docker Hub) + .mcpb bundles + SBOM + cosign signatures. Downstream gated jobs (each `needs: release`): Docker signing, MCP Registry, Smithery, and PyPI platform wheels (Trusted Publishing OIDC). All automated via `.github/workflows/release.yml` + `.goreleaser.yml`.
 
 ## Security Rules
 
-Non-negotiable rules for all code changes (human or AI agent):
+Non-negotiable for all code changes:
 
 1. **No OWASP Top 10 vulnerabilities** — no command injection, XSS, SQL injection, SSRF, path traversal. If unsure, ask.
 2. **Use `scraper.NewSSRFSafeClient()`** for all outbound HTTP fetching user-specified URLs. Never `http.DefaultClient`.
 3. **Never log secrets** — API keys, tokens, encryption keys must never appear in logs or error messages, even at debug level.
 4. **Errors are values, never panics** — return `toolError()` / `upstreamErrorResponse()` / `structuredError()`. No `panic()` in production paths.
 5. **Validate at system boundaries** — tool inputs, HTTP params, env vars, scraped content. Trust within, validate at the edge.
-6. **Respect tenant boundaries** — any new shared state must consider: "Can tenant A see tenant B's data?" Answer must be no.
-7. **Don't accumulate data** — new features should not store data beyond the request lifecycle without TTLs and explicit opt-in.
+6. **Respect tenant boundaries** — any new shared state must answer "Can tenant A see tenant B's data?" with no.
+7. **Don't accumulate data** — new features must not store data beyond the request lifecycle without TTLs and explicit opt-in.
 8. **Constant-time comparison for secrets** — use `subtle.ConstantTimeCompare()`, never `==` for auth tokens/keys.
-9. **Encrypt sensitive persistent data** — reuse existing AES-256-GCM disk infrastructure when storing to disk: `cache.DiskCache` for cached responses, `persist.DiskStore` for TTL key/value state (token revocation, rate quotas), `session` store for research sessions.
-10. **Minimal dependencies** — prefer Go stdlib. Each new dependency is a supply chain risk. Justify in PR.
-11. **Annotate all tools** — every tool must declare `readOnlyAnnotations(idempotent, openWorld)` or `writeAnnotations(idempotent)` as appropriate. CI test enforces this.
+9. **Encrypt sensitive persistent data** — reuse existing AES-256-GCM disk infrastructure: `cache.DiskCache` for cached responses, `persist.DiskStore` for TTL key/value state, `session` store for research sessions.
+10. **Minimal dependencies** — Go stdlib preferred. Each new dependency is a supply chain risk. Justify in PR.
+11. **Annotate all tools** — every tool must declare `readOnlyAnnotations(idempotent, openWorld)` or `writeAnnotations(idempotent)`. CI test `TestAllToolsHaveAnnotations` enforces this.
+12. **Consent-gate all personal-data access** — any feature that stores or reads per-user data (memory, analytics, workspace) must call `deps.Consent.HasConsent(ctx, consent.Purpose…)` before touching the store. Fail-closed: no consent record means no access. Never infer consent from a non-Noop dep or an env var.
 
 Security-sensitive changes (auth, SSRF, cache keys, Dockerfile, CI) require focused review.  
-Full security and compliance guidelines: see `docs/SECURITY_AND_COMPLIANCE.md`.
+Full security and compliance guidelines: `docs/SECURITY_AND_COMPLIANCE.md`.
+
+## Documentation Guidelines
+
+Every doc and inline comment must reflect the current codebase exactly. No drift, no stale claims. Never include secrets or real keys — placeholders only.
+
+### Structure (for agent-readable docs):
+
+1. **One-line description** at the top — the reader knows what this is without reading further
+2. **Commands** are copy-paste ready — no prose to parse
+3. **Architecture as a map** — each package gets a single-line annotation so the reader navigates without grepping
+4. **Design Rules are mechanical constraints**, not aspirations
+5. **How-to sections give exact file paths + function names**
+6. **Key Patterns show real signatures** — actual helper names, handler signature, pipeline stages
+7. **Environment says required vs optional** in one or two lines, then defers to `.env.example`
+8. **Reference Docs table has a "when to read" column**
+
+### Constraints (verified in CI):
+
+- Tool descriptions match code including side effects; read-only/idempotency explicitly marked
+- `internal/tools/metadata_test.go` fails CI on drift: `TestToolsDocMatchesRegistry` (docs/TOOLS.md ↔ registry), `TestAllToolsHaveAnnotations`, `TestOutputSchemaMatchesResponse`, `TestToolDescriptionQuality`. These also run in a standalone `docs-drift` CI job on docs-only PRs.
+- **Deliberately exclude**: hardcoded tool/provider counts, version numbers, line counts, env var tables (`.env.example` + `docs/DEPLOYMENT.md` are authoritative), dependency lists, architecture diagrams duplicated from `ARCHITECTURE.md`, inlined code that mirrors source
+- **Drift-resistant**: reference structural paths and function names (stable); reference interfaces by name; point to other docs for detail instead of duplicating
+- **Markdown/GFM**: blank lines between block elements; two trailing spaces or `<br>` for intra-paragraph line breaks; tables have a header separator row; fenced code blocks carry a language identifier
 
 ## Reference Docs
 
 | File | When to read |
-|------|--------------|
-| `ARCHITECTURE.md` | Understanding design decisions, tech stack, concurrency model |
+|---|---|
+| `ARCHITECTURE.md` | Design decisions, tech stack, concurrency model |
 | `CONTRIBUTING.md` | Code style, commit format, PR process, adding tools/providers |
 | `docs/TOOLS.md` | Tool parameter schemas and behavior contracts |
-| `docs/ERROR_HANDLING.md` | Error taxonomy, LLM-facing messages, GitHub issue guidance, contributor patterns |
-| `docs/SECURITY_AND_COMPLIANCE.md` | **Comprehensive security, privacy & compliance guide** (all audiences) |
-| `docs/SECURITY.md` | Detailed technical security architecture (threat model, defense layers) |
+| `docs/ERROR_HANDLING.md` | Error taxonomy, LLM-facing messages, contributor patterns |
+| `docs/SECURITY_AND_COMPLIANCE.md` | Security, privacy & compliance guide (all audiences) |
+| `docs/SECURITY.md` | Technical security architecture (threat model, defense layers) |
 | `docs/DEPLOYMENT.md` | Docker, K8s, client configs, env vars, admin endpoints, scaling |
-| `docs/API_SETUP.md` | Getting API keys for each provider (step-by-step) |
-| `docs/PROVIDERS.md` | Provider comparison: index classification, capability matrix, free tiers, quick-pick guide |
+| `docs/API_SETUP.md` | Getting API keys for each provider |
+| `docs/PROVIDERS.md` | Provider comparison: capability matrix, free tiers, quick-pick guide |
 | `docs/EXAMPLES.md` | Example tool calls and expected response shapes |
+| `.github/workflows/release.yml` + `.goreleaser.yml` | Cutting a release |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,8 +1,8 @@
 # Contributing to web-researcher-mcp
 
-Thank you for your interest in contributing to web-researcher-mcp! This project aims to provide reliable, high-quality research tools for AI assistants via the Model Context Protocol, and we welcome contributions from everyone.
+Thanks for contributing to web-researcher-mcp! We build reliable research tools for AI assistants via the Model Context Protocol, and every contribution makes a difference.
 
-Whether you're fixing a typo, adding a search provider, improving documentation, or proposing a new tool — your help makes this project better.
+Whether you're fixing a typo, adding a search provider, improving docs, or proposing a new tool — your help matters.
 
 ## Table of Contents
 
@@ -82,11 +82,13 @@ go test ./...
 # With race detector (recommended before submitting)
 go test -race ./...
 
-# E2E tests (requires API keys)
-go test -v ./tests/e2e/...
+# E2E tests (requires API keys and the e2e build tag)
+go test -tags=e2e -count=1 -v ./tests/e2e/...
 
-# Benchmarks
-go test -bench=. ./tests/benchmark/
+# Benchmarks (with memory allocation stats)
+make test-bench
+# Or directly:
+go test -bench=. -benchmem ./tests/benchmark/
 
 # Specific package
 go test ./internal/scraper/...
@@ -369,7 +371,7 @@ Most tools are read-only. For the rare tool that mutates server-side state (e.g.
 Web search providers implement the `search.Provider` interface (`Web`, `Images`, `News`, `Name`) — the core extension path.
 
 1. **Implement** `search.Provider` in `internal/search/<name>.go` (add a `var _ Provider = (*XProvider)(nil)` assertion; return `(nil, nil)` from any unsupported sub-capability such as `Images` — never an error, which would trip the breaker).
-2. **Wire the factory** — add a `case` to both `NewProvider()` and `NewProviderByName()` in `internal/search/provider.go`. The credential check lives in the `NewProviderByName()` case (return the provider only when its key is set).
+2. **Wire the factory** — add a `case` to both `NewProvider()` and `NewProviderByName()` in `internal/search/provider.go`. These are separate switch statements, so both need a new case. The credential check lives in the `NewProviderByName()` case (return the provider only when its key is set).
 3. **Add the credential/config** env var to `internal/config/config.go` and document it in `.env.example`.
 4. **Make it discoverable** — add the name to `search.SupportedProviders`. `AvailableProviders()` ranges over that list (constructing each via `NewProviderByName()`), so no edit there — the Router picks it up automatically.
 
@@ -415,7 +417,7 @@ func (p *MyProvider) Patents(ctx context.Context, params PatentSearchParams) ([]
 }
 ```
 
-2. **Register it** — add a case to `NewPatentProviderByName()` in `internal/search/domain.go` and add the env var to `internal/config/config.go`.
+2. **Register it** — add a case to `NewPatentProviderByName()` in `internal/search/domain.go` and add the provider name to `SupportedPatentProviders` in the same file. `AvailablePatentProviders()` iterates that slice, so both edits are required. Add the env var to `internal/config/config.go`.
 
 3. **Add tests** — create `internal/search/<provider>_test.go` with httptest mocks and a `_live_test.go` that skips without credentials.
 
@@ -428,7 +430,7 @@ The `ProviderMeta.Regions` field controls intelligent routing — set it to the 
 New structured-research domains (financial filings, case law, economic data, …) follow one repeatable pattern, proven by the SEC EDGAR / CourtListener / FRED trio in `internal/search/structured_domains.go`. Unlike web providers, these are **not** Router-routed — they resolve directly from the `Dependencies` maps in the tool layer, like the synthesis tools.
 
 1. **Define the capability** in `internal/search/structured_domains.go` (or a sibling file): a `…Searcher` interface (the method), a `…Provider` interface (`…Searcher` + `Name()` + `Metadata()`), the `…SearchParams` / `…Result` structs, a `…ProviderConfig`, a `Supported…Providers` slice, a `New…ProviderByName()` factory, and an `Available…Providers()` constructor (it gives each provider its own `circuit.New(...)` breaker — copy the EDGAR/FRED shape exactly).
-2. **Implement the provider** in `internal/search/<name>.go` with the usual `Deps{HTTPClient, Breaker}`, a `SetBaseURL` test hook, typed 429/404/4xx handling, `io.LimitReader`-bounded reads, and a `var _ …Provider = (*XProvider)(nil)` assertion. Mirror `edgar.go` / `courtlistener.go` / `fred.go`.
+2. **Implement the provider** in `internal/search/<name>.go` with the usual `Deps{HTTPClient, Breaker}`, a `SetBaseURL` (or `SetBaseURLs` for providers with multiple base URLs, as in `edgar.go`) test hook, typed 429/404/4xx handling, `io.LimitReader`-bounded reads, and a `var _ …Provider = (*XProvider)(nil)` assertion. Mirror `edgar.go` / `courtlistener.go` / `fred.go`.
 3. **Add the tool** in `internal/tools/<name>.go`: a typed input struct (use `omitempty` + in-handler validation for "provide X or Y" inputs — a `,required` jsonschema tag is enforced by the SDK *before* your handler runs), a `resolve…Searcher` helper, `structuredResult`, `readOnlyAnnotations(true, true)`, the `untrusted-external-content` trust marker, audit + metrics, and an output schema in `internal/tools/schemas.go`. Register it conditionally in `RegisterAll()` (`internal/tools/registry.go`) and add a provider map to the `Dependencies` struct.
 4. **Wire it** in `cmd/web-researcher-mcp/main.go` (construct the config + `Available…Providers` map) and add the credential/contact env var to `internal/config/config.go` + `.env.example`.
 5. **Test + document** — `httptest` unit tests + a `//go:build live` test that skips without credentials; add the tool to `expectedTools`, `setupTestDeps`, and the trust-marker/output-schema maps in `metadata_test.go`; write a `## Tool N:` section in `docs/TOOLS.md` and a setup section in `docs/API_SETUP.md`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -312,6 +312,10 @@ Please include:
 
 This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. To report unacceptable behavior, see the confidential reporting instructions in [CODE_OF_CONDUCT.md](CODE_OF_CONDUCT.md#reporting-concerns).
 
+## When to use which extension point
+
+Not sure whether your idea should be a Tool, Provider, Lens, Enrichment Resolver, Prompt, or Resource? See [docs/EXTENSION_GUIDE.md](docs/EXTENSION_GUIDE.md) for a decision path and canonical examples.
+
 ## Adding a New Tool
 
 Adding a tool requires:

--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ Works with Claude, Claude Desktop, Cursor, and any AI assistant that supports to
 | `legal_search` | Search US court opinions and dockets via CourtListener — real cases with real citations |
 | `econ_search` | Look up economic data — World Bank global development indicators, OECD economic indicators, Eurostat European statistics (all keyless), and FRED US macro series (GDP, CPI, unemployment, rates; requires FRED_API_KEY) |
 | `clinical_search` | Search ClinicalTrials.gov — clinical-trial registrations with status, phase, sponsor, and whether results are posted (discovery, not medical advice) |
+| `local_search` | Search for physical places (restaurants, shops, services, points of interest) by local intent query — structured POI details and descriptions. Requires `BRAVE_API_KEY` |
 | `brand_research` | Research a company's complete brand identity — colors (hex), logos, typography, tone of voice, and social handles — from any domain or company name. Returns structured JSON for AI content generation. No API key required; BrandFetch key optional for richer data |
 | `verify_citation` | Check a citation before you rely on it — does it exist, match a real record, and is it retracted or a dead link? Evidence, not a verdict |
 | `audit_bibliography` | Audit a whole reference list in one pass — paste a CSL-JSON/RIS/BibTeX file (or a session) and get per-entry + corpus-level flags for retracted, dead-link, and unverifiable citations |
@@ -178,7 +179,7 @@ Works with Claude, Claude Desktop, Cursor, and any AI assistant that supports to
 | `research_export` | Export a research session as a shareable report (markdown or JSON), with full per-step provenance |
 | `format_bibliography` | Turn collected sources into a formatted bibliography — APA, MLA, BibTeX, RIS, or CSL-JSON (Zotero/EndNote/Mendeley-ready) |
 
-Most tools above are always available. A few activate only when the right provider or config is present: `citation_graph` requires a citation-capable academic provider (OpenAlex or Semantic Scholar); `filing_search` requires `EDGAR_CONTACT_EMAIL`; `answer` and `structured_search` require a provider that supports those capabilities (e.g. Exa). Operators can also enable opt-in, consent-gated tools (per-user analytics, long-term memory, shared workspaces) that appear only when their feature is turned on — see [`docs/TOOLS.md`](docs/TOOLS.md) for the authoritative, CI-verified tool list and full schemas.
+Most tools above are always available. A few activate only when the right provider or config is present: `citation_graph` requires a citation-capable academic provider (OpenAlex or Semantic Scholar); `filing_search` requires `EDGAR_CONTACT_EMAIL`; `local_search` requires `BRAVE_API_KEY`; `answer` and `structured_search` require a provider that supports those capabilities (e.g. Exa). Operators can also enable opt-in, consent-gated tools (per-user analytics, long-term memory, shared workspaces) that appear only when their feature is turned on — see [`docs/TOOLS.md`](docs/TOOLS.md) for the authoritative, CI-verified tool list and full schemas.
 
 ### Ready-made research templates
 
@@ -464,6 +465,7 @@ Search lenses let you control which websites your AI is allowed to search. Inste
 | `security` | CVEs, advisories, vulnerability research |
 | `journalism` | Public records, corporate filings, FOIA |
 | `programming` | Code docs, tutorials, Q&A |
+| `programming-goggle` | Developer-first results re-ranked by Brave's Programming Goggle — surfaces docs, repos, and authoritative technical content (requires Brave) |
 | `devops` | Infrastructure and operations — Kubernetes, Docker, Terraform, cloud, CI/CD |
 | `news` | Current events, journalism |
 | `tech` | Technology industry |
@@ -484,7 +486,7 @@ Your AI uses lenses automatically when you ask it to. For example: *"Search for 
 <details>
 <summary><strong>Creating Your Own Lens</strong></summary>
 
-Add a JSON file to the `lenses/` directory with the sites you trust:
+Create a directory for your custom lenses and add a JSON file for each one:
 
 ```json
 {
@@ -500,7 +502,13 @@ Add a JSON file to the `lenses/` directory with the sites you trust:
 }
 ```
 
-That's it. Now your AI will only search those sites when you use this lens. You can add up to ~10 domains per lens.
+Then point the server to your lens directory:
+
+```bash
+export CUSTOM_LENSES_PATH=/path/to/my-lenses
+```
+
+Your AI will now have `my-industry` as an available lens. Custom lenses load after the built-in set — a custom lens with the same `name` as a built-in one overrides it. You can add up to ~10 domains per lens.
 
 **Advanced options** (optional — most users can ignore these):
 - **cx** — If you have a Google Programmable Search Engine with up to 5,000 domains, put the engine ID here

--- a/docs/API_SETUP.md
+++ b/docs/API_SETUP.md
@@ -568,3 +568,18 @@ export IA_SECRET_KEY=your-ia-secret-key
 ```
 
 **Notes**: Both keys are required together — set neither or both. Values are never logged or included in error messages. Keyless SPN is sufficient for occasional archiving; keys are recommended for production deployments that archive frequently.
+
+### BrandFetch (Brand Research — Optional)
+
+Backs `brand_research`. Works **keyless** — the tool always runs and extracts brand identity from CSS, meta tags, and homepage content. A BrandFetch API key adds structured brand-color, font, logo, and slogan data from the BrandFetch Brand API.
+
+**Step 1**: (Optional) Sign up at [brandfetch.com](https://brandfetch.com) and copy your API key from the dashboard.
+
+**Step 2**: Configure (both are optional)
+
+```bash
+export BRANDFETCH_API_KEY=pk_your-key          # Brand + Context API; free tier: 100 req/month
+export BRANDFETCH_CLIENT_ID=your-client-id     # Logo CDN requests; free tier: 500K req/month
+```
+
+**Notes**: `BRANDFETCH_API_KEY` format is `pk_*`. The key is never logged. Without it, `brand_research` degrades gracefully to CSS extraction, homepage meta scraping, and web search — useful for most tasks.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -277,6 +277,7 @@ Note: Google keys are validated as required only when you explicitly select `SEA
 | `SEARCH_PROVIDER` | Primary provider: google, brave, serper, searxng, searchapi, duckduckgo, tavily, exa, hackernews | `google` (variable default); at runtime, when `google` is selected but no Google key is set, the server falls back to the zero-config `duckduckgo` provider |
 | `SEARCH_ROUTING` | Multi-provider routing (see below) | — |
 | `BRAVE_API_KEY` | Brave Search API key | — |
+| `BRAVE_EXTRA_SNIPPETS` | Return up to 5 extra snippets per Brave result | `false` |
 | `SERPER_API_KEY` | Serper.dev API key | — |
 | `SEARCHAPI_API_KEY` | SearchAPI.io API key | — |
 | `TAVILY_API_KEY` | Tavily API key (AI-agent search; sent as a Bearer token) | — |
@@ -329,9 +330,18 @@ These enable dedicated structured-research tools. Each provider is independent. 
 
 Each structured-domain provider gets an independent circuit breaker and uses the SSRF-safe HTTP client. `filing_search` returns XBRL company facts (with `facts=true`); `econ_search` returns observations passed through exactly as the source provides them — no rounding; `clinical_search` returns trial metadata for discovery (not medical advice).
 
+### BrandFetch (Optional)
+
+These enable the Tier 1 BrandFetch API for `brand_research`. The tool always works without them — it falls back to CSS extraction, homepage meta, and web search.
+
+| Variable | Description |
+|----------|-------------|
+| `BRANDFETCH_API_KEY` | BrandFetch Brand + Context API key (`pk_*`). Free tier: 100 req/month. Never logged | 
+| `BRANDFETCH_CLIENT_ID` | BrandFetch logo CDN client ID. Free tier: 500K req/month |
+
 ### Multi-Provider Routing
 
-When `SEARCH_ROUTING` is set, the server uses all configured providers with intelligent fallback:
+When `SEARCH_ROUTING` is set, the server uses all configured providers with priority-ordered fallback:
 
 ```bash
 # Simple: comma-separated priority list (applies to all operations)
@@ -412,7 +422,7 @@ The per-tenant, global, and per-IP limits below apply **only in HTTP mode** (whe
 
 | Variable | Description | Default |
 |----------|-------------|---------|
-| `MAX_CALLS_PER_DAY` | Total tool calls per day (STDIO + HTTP). Transport-agnostic hard cap. | — (disabled) |
+| `MAX_CALLS_PER_DAY` | Tool calls per day per `(tenant, user)` pair (STDIO + HTTP). In-process denial-of-wallet backstop; resets at UTC midnight. | — (disabled) |
 | `RATE_LIMIT_PER_TENANT` | Requests per minute per tenant | `120` |
 | `RATE_LIMIT_GLOBAL` | Total requests per second | `1000` |
 | `DAILY_QUOTA_PER_TENANT` | Max API calls per tenant per day | `5000` |
@@ -854,7 +864,7 @@ The admin key is stateless — rotating it is a single env-var change:
 2. Update `ADMIN_API_KEY` in your deployment and restart (or rolling-restart) the pods.
 3. Update any operational scripts/dashboards that send `X-Admin-Key`.
 
-There is no stored state encrypted under the admin key, so no migration is needed. In a rolling deployment, in-flight admin calls against an old pod simply use that pod's old key until it cycles; admin endpoints are operational, not user-facing, so a brief overlap is harmless.
+There is no stored state encrypted under the admin key, so no migration is needed. In a rolling deployment, in-flight admin calls against an old pod use that pod's old key until it cycles; admin endpoints are operational, not user-facing, so a brief overlap is harmless.
 
 ### Encryption key (`CACHE_ENCRYPTION_KEY`) — zero-downtime re-encryption
 
@@ -862,7 +872,7 @@ Disk-persisted data (cache, sessions, and any encrypted `persist.Store` namespac
 
 1. Move the current key to `CACHE_ENCRYPTION_KEY_PREV` and set a new 64-hex `CACHE_ENCRYPTION_KEY` (generate with `openssl rand -hex 32`).
 2. Restart. On every read, data sealed with the previous key is **decrypt-fall-back** decrypted and **lazily re-encrypted** with the new key — so hot data migrates automatically with no flush and no downtime.
-3. After at least one full data lifetime (e.g. `SESSION_TTL` for sessions, the cache TTL for cache) has elapsed, remove `CACHE_ENCRYPTION_KEY_PREV`. Any still-unread blobs from before the rotation simply expire.
+3. After at least one full data lifetime (e.g. `SESSION_TTL` for sessions, the cache TTL for cache) has elapsed, remove `CACHE_ENCRYPTION_KEY_PREV`. Any still-unread blobs from before the rotation expire naturally.
 
 To force immediate re-encryption rather than waiting for natural reads, flush the affected store (`DELETE /admin/cache`, `DELETE /admin/sessions`) after step 2 — data repopulates under the new key on demand.
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -188,13 +188,14 @@ Rate limited (google). Wait 60 seconds and retry, or try a different provider.
 
 | Function | File | Purpose |
 |----------|------|---------|
-| `structuredError(msg, ToolError)` | errors.go | Builds dual-format error response |
-| `scrapeErrorResponse(err, url)` | scrape.go | Maps ScrapeError → structured response |
-| `upstreamErrorResponse(toolName, err)` | search.go | Maps provider errors → structured response |
-| `resolveProvider()` | search.go | Returns structured error for unknown providers |
-| `resolvePatentSearcher()` | search.go | Same for patent providers |
-| `resolveAcademicSearcher()` | academic.go | Same for academic providers |
-| `toolError(msg)` | search.go | Plain-text validation errors (no JSON block) |
+| `structuredError(msg, ToolError)` | `internal/tools/errors.go` | Builds dual-format error response |
+| `scrapeErrorResponse(err, url)` | `internal/tools/scrape.go` | Maps ScrapeError → structured response |
+| `upstreamErrorResponse(toolName, err)` | `internal/tools/search.go` | Maps provider errors → structured response |
+| `toolError(msg)` | `internal/tools/search.go` | Plain-text validation errors (no JSON block) |
+| `structuredResult(jsonBytes)` | `internal/tools/search.go` | Wraps success payloads as MCP result |
+| `resolveProvider()` | `internal/tools/search.go` | Returns structured error for unknown providers |
+| `resolvePatentSearcher()` | `internal/tools/search.go` | Same for patent providers |
+| `resolveAcademicSearcher()` | `internal/tools/academic.go` | Same for academic providers |
 
 ### Validation Errors
 
@@ -314,7 +315,8 @@ The GitHub issue link appears in exactly two places (`scrapeErrorResponse` cases
 
 - `TestAllToolsHaveAnnotations` — CI verifies every tool has proper MCP annotations
 - `internal/tools/scrape_errors_test.go` — integration tests for each error kind → LLM message mapping
-- `internal/scraper/scraper_test.go` — unit tests for error classification, composite errors, tier propagation
+- `internal/scraper/errors_test.go` — unit tests for HTTP status classification and raw error classification
+- `internal/scraper/scraper_test.go` — unit tests for composite error assembly and tier propagation
 
 ---
 
@@ -370,6 +372,7 @@ if input.Query == "" {
 | `internal/tools/scrape.go` | `scrapeErrorResponse()`, negative cache helpers |
 | `internal/session/outcomes.go` | Session-level outcome log + `AggregateOutcomes()`, kind→remediation map, `ErrorPatternMinCount` |
 | `internal/tools/sourcetracker.go` | `trackOutcome()` / `trackScrapeOutcome()` — record per-call outcomes onto a session |
-| `internal/tools/search.go` | `upstreamErrorResponse()`, `toolError()`, `rateLimitError()`, resolver functions, `allSupportedProviders()` |
+| `internal/tools/search.go` | `upstreamErrorResponse()`, `toolError()`, `rateLimitError()`, `structuredResult()`, resolver functions, `allSupportedProviders()` |
 | `internal/tools/scrape_errors_test.go` | Integration tests for error → response mapping |
-| `internal/scraper/scraper_test.go` | Unit tests for error classification |
+| `internal/scraper/errors_test.go` | Unit tests for HTTP status classification and raw error classification |
+| `internal/scraper/scraper_test.go` | Unit tests for composite error assembly and tier propagation |

--- a/docs/EXAMPLES.md
+++ b/docs/EXAMPLES.md
@@ -399,7 +399,7 @@ Before filing a brief or submitting a paper, audit the whole reference list in o
 }
 ```
 
-You can also pass an explicit `entries` list or a `sequential_search` `sessionId` instead of a document. The response carries a `summary` (`{total, retracted, deadLink, notFound, unchecked, mischaracterized, ok}`) plus per-entry `entries[]` with `exists`, `retractionStatus`, `linkLive`/`httpStatus`, an `archivedUrl` (Wayback) for dead links, `flags`, and a `reason` explaining any flagged entry. The flags distinguish a **possible fabrication** (`not_found` — a DOI Crossref doesn't have) from a source that simply **couldn't be checked** (`unchecked` — e.g. a book or paywalled report; absence of evidence, not proof it's fake). It is **evidence, not a verdict** — you decide what to fix. The audit is capped at 200 entries per call (overflow is reported in `skipped`). Use `verify_citation` for a single citation and `format_bibliography` to produce the list.
+You can also pass an explicit `entries` list or a `sequential_search` `sessionId` instead of a document. The response carries a `summary` (`{total, retracted, deadLink, notFound, unchecked, mischaracterized, ok}`) plus per-entry `entries[]` with `exists`, `retractionStatus`, `linkLive`/`httpStatus`, an `archivedUrl` (Wayback) for dead links, `flags`, and a `reason` explaining any flagged entry. The flags distinguish a **possible fabrication** (`not_found` — a DOI Crossref doesn't have) from a source that **couldn't be checked** (`unchecked` — e.g. a book or paywalled report; absence of evidence, not proof it's fake). It is **evidence, not a verdict** — you decide what to fix. The audit is capped at 200 entries per call (overflow is reported in `skipped`). Use `verify_citation` for a single citation and `format_bibliography` to produce the list.
 
 To also check that a source **actually says what it's cited for** (mischaracterization), add a `claim` to an explicit entry:
 
@@ -420,13 +420,237 @@ To also check that a source **actually says what it's cited for** (mischaracteri
 
 The source page is fetched (live, or its Wayback snapshot if the link is dead) and checked for whether it addresses the claim. `claimSupport` reports **coverage, not a stance**: `addressed` (claim-relevant sentences found — returned in `claimEvidence` so you judge whether they support or contradict), `partially_addressed` (some overlap — evidence shown but not flagged; ambiguous, you judge), `not_addressed` (the source doesn't mention the claim → flagged `mischaracterized`), or `source_unavailable`. It never asserts "supports"/"refutes" — you read the evidence and decide.
 
-## Combining Tools for Deep Research
+## Verifying a Citation (verify_citation)
 
-A typical research workflow combines multiple tools:
+Before you cite a source, verify it exists, hasn't been retracted, and actually says what it's cited for.
 
-1. **web_search** with a lens to find relevant sources
-2. **scrape_page** on the most promising URLs to get full content
-3. **academic_search** or **news_search** for domain-specific depth
-4. **sequential_search** to track progress across multiple steps
+```json
+{
+  "tool": "verify_citation",
+  "arguments": {
+    "citation": "10.1056/NEJMoa2007764",
+    "claim": "remdesivir shortened recovery time in hospitalized patients"
+  }
+}
+```
 
-The AI assistant orchestrates these tools automatically based on the research question — you don't need to call them manually.
+`citation` accepts a DOI, a URL, or a free-text reference string — the tool detects which. **Response** carries: `exists` (boolean), `matchedRecord` (the real bibliographic record from Crossref/academic sources, with a `matchConfidence`), `titleMatch` (does the title you supplied match the real record — catches swapped DOIs), `retractionStatus` (from Crossref Retraction Watch), and link-liveness (`linkLive`, `httpStatus`, `archivedUrl`). When you add a `claim`, you also get `claimCoverage` (`addressed` / `partially_addressed` / `not_addressed` → flagged `mischaracterized`), `claimEvidence` (claim-relevant sentences from the source), and a `contrastSignal` if the source contradicts the claim. This is evidence, not a verdict — you decide whether to cite. Use `audit_bibliography` to check an entire reference list at once.
+
+---
+
+## Checking a Recommendation List (verify_recommendation)
+
+Got a listicle or AI-generated product/service recommendation? Check it for self-promotion, conflicts of interest, and independent corroboration.
+
+```json
+{
+  "tool": "verify_recommendation",
+  "arguments": {
+    "recommendations": [
+      { "title": "Stripe", "url": "https://stripe.com", "author": "John Smith", "authorBio": "VP of Sales at Stripe" },
+      { "title": "Square", "url": "https://squareup.com" }
+    ],
+    "claim": "best payment processors for small businesses"
+  }
+}
+```
+
+**Response** carries per-item signals: `selfPromotionSignal` (is the author promoting their own product?), `conflictOfInterest` (does the author bio signal a financial relationship?), `domainReputation` (is this a known trustworthy source?), `linkLive` (is the URL still up?), and — when `claim` is set — `corroborationSearches` (what independent journalism and tech sources say about this recommendation). The `flags` field summarizes any concerns, including `no_independent_corroboration` when no outside source agrees. This is evidence, not a verdict — you decide whether the list is genuinely helpful or gaming you.
+
+---
+
+## Archiving a Source (archive_source)
+
+Lock in a timestamped snapshot before you cite a page that might change or disappear.
+
+```json
+{
+  "tool": "archive_source",
+  "arguments": {
+    "url": "https://www.bbc.com/news/technology-example"
+  }
+}
+```
+
+This is the only **write tool** in the suite — it asks the Internet Archive's Save Page Now to capture a fresh snapshot. **Response** carries: `status` (`archived` = fresh capture confirmed, `existing` = no new capture made but a recent snapshot exists, `pending` = capture in-flight), `snapshotUrl` (the permanent Wayback URL), `capturedAt` (timestamp), and `provenance`. Run `verify_citation` first to see whether a link is already dead or already archived before capturing.
+
+---
+
+## Tracing Citation Networks (citation_graph)
+
+Map the academic neighborhood of a paper — the works it references and the works that cite it.
+
+```json
+{
+  "tool": "citation_graph",
+  "arguments": {
+    "paper": "10.1038/nature12373",
+    "direction": "both",
+    "num_results": 10,
+    "influential_only": false
+  }
+}
+```
+
+`paper` accepts a DOI or an exact title. `direction` is `cited_by` (forward — works that cite the seed), `references` (backward — works the seed cites), or `both` (default). **Response** carries: `seed` (the resolved seed record), `citedBy` and `references` arrays (each with `title`, `doi`, `authors`, `year`, `citationCount`, `isInfluential`, `citationIntents`), and `provider`. Requires at least one academic provider (Semantic Scholar or OpenAlex). Use alongside `academic_search` to discover papers and `verify_citation` to check individual ones.
+
+---
+
+## Brand Identity Research (brand_research)
+
+Pull a company's colors, logo, typography, and tone of voice from its official brand portals and guidelines.
+
+```json
+{
+  "tool": "brand_research",
+  "arguments": {
+    "url": "stripe.com"
+  }
+}
+```
+
+You can pass a `url` (domain or full URL) or a `company_name` — `url` takes precedence when both are set. **Response** carries a structured `identity` object with `name`, `domain`, `colors` (hex values with their roles), `fonts`, `logo` URLs, `socialHandles`, `toneOfVoice`, and `guidelinesUrl`. Empty fields mean the data wasn't found — not that it doesn't exist. When a brand portal is found, `brand_portal_resource` carries a `research://artifact/{id}` URI — pass it to `read_resource` to get the full rendered portal text for deeper analysis. When no portal is found, the `suggestion` field tells you what to do next. Results are cached for 24 hours; `cache_age` tells you how fresh they are.
+
+---
+
+## Local Place Search (local_search)
+
+Find places near a location — restaurants, services, venues — with distance ranking and coordinate support. Requires `BRAVE_API_KEY`.
+
+```json
+{
+  "tool": "local_search",
+  "arguments": {
+    "query": "best coffee shops near downtown Seattle",
+    "near": "downtown Seattle",
+    "num_results": 5
+  }
+}
+```
+
+For precise radius filtering, pass `latitude`, `longitude`, and `radius` (in meters) instead of `near`. **Response** carries `places` (array with `name`, `address`, `phone`, `rating`, `categories`, `url`, `distance`) and `resultCount`. Filter by `country` (ISO 3166-1 alpha-2) and set `units` to `metric` or `imperial`.
+
+---
+
+## Synthesized Answer (answer)
+
+Get a single synthesized answer with citations — the provider searches the live web and distills it for you. Requires a provider that supports synthesis (e.g., Exa).
+
+```json
+{
+  "tool": "answer",
+  "arguments": {
+    "query": "What is the current federal funds rate?"
+  }
+}
+```
+
+**Response** carries: `answer` (the synthesized text), `citations` (sources backing the answer), and `provider`. Use this for quick factual lookups; use `sequential_search` + `scrape_page` for deep investigation.
+
+---
+
+## Structured Entity Search (structured_search)
+
+Extract structured data about entities — companies, people, papers — from search results. Requires a provider that supports structured extraction (e.g., Exa).
+
+```json
+{
+  "tool": "structured_search",
+  "arguments": {
+    "query": "Stripe",
+    "category": "company",
+    "num_results": 3,
+    "schema": {
+      "type": "object",
+      "properties": {
+        "founded": { "type": "string" },
+        "headquarters": { "type": "string" },
+        "ceo": { "type": "string" }
+      }
+    }
+  }
+}
+```
+
+**Response** carries `results` (each with `title`, `url`, `highlights` — verbatim source snippets, and `summary` — JSON conforming to your schema if supplied). The `schema` field is optional; omit it for plain text summaries. Extraction is best-effort — treat `highlights` as the authoritative payload and `summary` as a convenience. Provider-specific limits on schema complexity apply.
+
+---
+
+## Exporting a Research Session (research_export)
+
+Turn a `sequential_search` session into a shareable report.
+
+```json
+{
+  "tool": "research_export",
+  "arguments": {
+    "sessionId": "abc123-from-earlier",
+    "format": "markdown",
+    "verify_links": true
+  }
+}
+```
+
+`format` is `markdown` (readable write-up with goal, steps, gaps, and sources) or `json` (full structured session for machine use). When `verify_links` is `true`, each source URL is checked for liveness and dead links get a Wayback snapshot attached — adds latency but ensures your report's sources stay verifiable. Pair with `format_bibliography` to produce a formatted citations list.
+
+---
+
+## Formatting a Bibliography (format_bibliography)
+
+Format your sources as APA, MLA, BibTeX, RIS, or CSL-JSON — straight from a session or an explicit list.
+
+```json
+{
+  "tool": "format_bibliography",
+  "arguments": {
+    "sessionId": "abc123-from-earlier",
+    "style": "bibtex"
+  }
+}
+```
+
+Or pass an explicit `sources` list:
+
+```json
+{
+  "tool": "format_bibliography",
+  "arguments": {
+    "style": "apa",
+    "sources": [
+      {
+        "url": "https://www.nejm.org/doi/full/10.1056/NEJMoa2007764",
+        "title": "Remdesivir for the Treatment of Covid-19",
+        "author": "Beigel, J.H. et al.",
+        "site": "New England Journal of Medicine",
+        "date": "2020",
+        "doi": "10.1056/NEJMoa2007764"
+      }
+    ]
+  }
+}
+```
+
+`style` is `apa` (default), `mla`, `bibtex`, `ris`, or `csl-json`. `apa`/`mla` are human-readable; `bibtex`/`ris`/`csl-json` are reference-manager interchange formats. Each source needs at least a `url`; add `doi` so reference managers keep the persistent ID.
+
+---
+
+## Cross-Tool Trust Workflow
+
+A full trust-verification pass for academic or legal research:
+
+1. **academic_search** — discover relevant papers
+2. **citation_graph** — trace influential references and citing works
+3. **verify_citation** with `claim` — confirm each key citation exists, hasn't been retracted, and actually addresses the claim
+4. **archive_source** — lock in a Wayback snapshot for any sources you intend to cite
+5. **audit_bibliography** — batch-check your full reference list for retracted, dead, or possibly fabricated entries
+6. **research_export** with `verify_links: true` — produce a final report with source liveness confirmed
+
+A general discovery-to-report workflow:
+
+1. **web_search** with a `lens` — find sources in a curated domain
+2. **search_and_scrape** with `claim` — get full text with claim evidence surfaced
+3. **news_search** or **academic_search** — add domain-specific depth
+4. **sequential_search** — track progress across steps with recoverable session state
+5. **format_bibliography** or **research_export** — produce the final output
+
+The AI assistant orchestrates these tools based on the research question. You don't need to call them manually.

--- a/docs/EXTENSION_GUIDE.md
+++ b/docs/EXTENSION_GUIDE.md
@@ -1,0 +1,200 @@
+# Extension Guide — choosing the right extension point
+
+This guide answers one question: **when you want to add something new, which extension point do you use?**
+
+The codebase has six extension points. They are not interchangeable — each maps to a different architectural contract. Pick the wrong one and you either fight the interface or silently miss a capability.
+
+## Quick-pick table
+
+| Extension point | Use when |
+|---|---|
+| **Tool** | New capability with its own input schema and output shape |
+| **Provider** | Alternative backend for an existing search capability |
+| **Lens** | Restrict `web_search` to a curated domain list — no custom output |
+| **Enrichment Resolver** | Decorate DOI-bearing results post-search with side-channel data |
+| **Prompt / Template** | Reusable multi-step research workflow for the model to orchestrate |
+| **Resource** | Expose read-only server-side state via a URI scheme |
+
+---
+
+## Decision path
+
+Start here. Work down until you hit a match.
+
+1. **Does it produce output that fits an existing search interface** (web, image, news, academic, patent, answer, structured, filing, case, econ, trial, local)?
+   - Yes → **Provider** (new backend, existing tool surface, no schema change)
+   - No → continue
+
+2. **Does it only restrict *which sites* a search queries, with no new fields in the response?**
+   - Yes → **Lens** (domain allowlist; piggybacks on `web_search` output)
+   - No → continue
+
+3. **Does it annotate already-found results using a DOI, without changing the tool surface?**
+   - Yes → **Enrichment Resolver** (`DOIRegistry`, `OAResolver`, `RetractionResolver`, or `DOIResolver`)
+   - No → continue
+
+4. **Does it expose a new capability with its own parameters and response shape?**
+   - Yes → **Tool**
+
+5. **Is it a pre-built research workflow the model should execute rather than raw data retrieval?**
+   - Yes → **Prompt / Template**
+
+6. **Is it server-side state (counters, health, artifacts) accessed by URI with no input?**
+   - Yes → **Resource**
+
+---
+
+## Tool
+
+A Tool is the right choice when nothing else fits: your feature has its own input parameters and produces output with a shape that doesn't map to any existing interface.
+
+**When to use:**
+- New retrieval capability with distinct structured output (`brand_research`, `local_search`, `clinical_search`)
+- An action that mutates state or creates an external artifact (`archive_source`, `memory_save`)
+- A synthesis or verification step that consumes inputs from other tools (`verify_citation`, `audit_bibliography`)
+
+**When NOT to use:**
+- The output shape matches an existing provider interface → use **Provider**
+- You only need to restrict search to certain sites → use **Lens**
+- You need to annotate existing DOI-bearing results → use **Enrichment Resolver**
+
+**Hard case — brand_research:** brand logos, colors, and social handles can't be expressed as `web_search` results. The output schema is entirely different. Brand research must be a Tool, with optional BrandFetch and web-search enrichment layers inside the handler.
+
+**Integration checklist:**
+1. `internal/tools/<name>.go` — typed input struct + `register<Name>()` + `readOnlyAnnotations()` or `writeAnnotations()`
+2. `internal/tools/registry.go` — add `register<Name>(srv, deps)` to `RegisterAll()`
+3. `internal/tools/tools_test.go` + `metadata_test.go` (`expectedTools`) — tests and drift guard
+4. `docs/TOOLS.md` — `## Tool N: \`name\`` section (drift-tested by CI)
+5. `make gen-python-client` → stage and commit regenerated `python/web_researcher_mcp/`
+
+See `CLAUDE.md → How to Add a Tool` for the full step-by-step.
+
+---
+
+## Provider
+
+A Provider is a new backend for a capability the codebase already knows how to surface. The tool layer doesn't change — it just gets a new option in the provider map.
+
+**When to use:**
+- A new search engine or data source whose results fit `web_search`, `academic_search`, `patent_search`, `answer`, `structured_search`, `filing_search`, `legal_search`, `econ_search`, `clinical_search`, or `local_search`
+- Adding a second source for an existing capability (e.g. a second clinical-trial registry alongside ClinicalTrials.gov)
+
+**When NOT to use:**
+- The output has fields that don't exist in the existing tool's response → use **Tool**
+- You need to filter which sites existing providers query → use **Lens**
+
+**Hard case — World Bank under `econ_search`:** World Bank's indicators fit `EconProvider` output exactly (series ID, country, period, value). No new tool needed — it wires in under `deps.EconProviders` alongside FRED and OECD.
+
+**Integration checklist:**
+1. `internal/search/<name>.go` — implement the matching interface; `var _ Provider = (*XProvider)(nil)` assertion
+2. `internal/search/provider.go` (for `search.Provider`) or `domain.go` / `synthesis.go` / `structured_domains.go` — add to `Supported…Providers` + `New…ProviderByName` + `Available…Providers`
+3. `internal/config/config.go` + `.env.example` — env var + required-when-selected check
+4. Wire `circuit.New(...)` inside `Available…Providers` (every provider gets its own breaker)
+
+See `CLAUDE.md → How to Add a Search Provider` for the full step-by-step.
+
+---
+
+## Lens
+
+A Lens is a JSON domain allowlist. When a caller sets the `lens` parameter on `web_search`, the router injects `site:` operators for every domain in the list. The output is ordinary `web_search` results — no new fields, no new schema.
+
+**When to use:**
+- You want to restrict `web_search` to a known-good set of sites for a domain (legal databases, medical publishers, open-access repositories)
+- Optional: add a `cx` field to route to a Google Programmable Search Engine, or a `goggle` URL for Brave re-ranking
+
+**When NOT to use:**
+- You need structured output specific to the domain (e.g. case docket metadata, clinical trial phases) → use **Tool** + **Provider**
+- The new capability requires a different API entirely, not just filtered web search → use **Tool**
+
+**Hard case — legal research:** A lens can restrict searches to `courtlistener.com`, `law.cornell.edu`, etc. But a `legal_search` tool with typed docket fields, citation numbers, and jurisdiction metadata cannot be expressed as filtered web search results. Both exist: `legal_search` (Tool + CourtListener Provider) for structured case law, and `legal` / `legal-proceedings` lenses for unstructured site-restricted research.
+
+**Integration checklist:**
+1. `lenses/<name>.json` — `{"name":"…","description":"…","domains":[…]}` (optionally `"cx":"…"` or `"goggle":"…"`)
+2. `make sync-lenses` — copies to `internal/search/lenses_embed/`; `TestEmbeddedLensesMatchRoot` fails CI if out of sync
+3. `lenses/README.md` — add a row to the table
+
+Schema reference: `lenses/README.md`.
+
+---
+
+## Enrichment Resolver
+
+An Enrichment Resolver is an interface that decorates already-found results with side-channel data. Resolvers operate post-search — they take a DOI and add fields (retraction status, open-access PDF link, existence confirmation) to results the tool already has.
+
+**When to use:**
+- You have a side-channel API keyed on DOI that adds provenance or integrity signals to existing results
+- The new data belongs on the same result object, not as a separate tool call
+
+**When NOT to use:**
+- You need a new query axis or input parameters → use **Tool** or **Provider**
+- The data source isn't keyed on DOI → consider a **Tool** instead
+
+**The four resolver interfaces** (all in `internal/search/`):
+
+| Interface | What it adds | Implementation |
+|---|---|---|
+| `DOIRegistry` | Cross-registrar DOI existence (doi.org handle API) | `doi_registry.go` |
+| `DOIResolver` | Exact-entity DOI lookup (title-match guard against fabrication) | `domain.go` |
+| `OAResolver` | Open-access PDF link via Unpaywall | `unpaywall.go` |
+| `RetractionResolver` | Retraction/expression-of-concern status via Crossref Retraction Watch | `retraction.go` |
+
+**Integration checklist:**
+1. `internal/search/<name>.go` — implement the resolver interface
+2. `main.go` — construct and wire into the matching `deps` field
+3. Tool handlers that consume it: best-effort (never fail the tool call on resolver error); nil-check before calling
+
+---
+
+## Prompt / Template
+
+An MCP Prompt is a pre-built research workflow the model invokes by name. It returns a filled-in message sequence the model uses to orchestrate a multi-step investigation — not raw data.
+
+**When to use:**
+- You want to guide the model through a standard research pattern (systematic review, competitive analysis, due-diligence checklist) without hardcoding the steps into a tool
+- The workflow reuses existing tools in a defined sequence
+
+**When NOT to use:**
+- The workflow needs to return structured data to a caller → use **Tool**
+- It's just a search with different parameters → use a **Lens**
+
+**Integration checklist:**
+1. `internal/resources/prompts.go` — add a `mcp.Prompt` entry to the registered prompt list
+2. No schema drift test covers prompts; keep descriptions current manually
+
+---
+
+## Resource
+
+An MCP Resource exposes read-only server-side state via a URI scheme. Resources accept no input parameters — they are polled or read on demand.
+
+**When to use:**
+- Operator-facing state: health signals, error rings, provider stats (`diagnostics://`, `stats://`)
+- The lenses catalog (`lenses://catalog`) — metadata about registered lenses
+- Large payloads returned by reference (`research://artifact/{id}`) — the tool stores the payload; the caller fetches it via the resource URI
+
+**When NOT to use:**
+- The caller needs to pass parameters → use **Tool**
+- The data changes in response to input → use **Tool**
+
+**Integration checklist:**
+1. `internal/resources/resources.go` — register the URI template + handler
+2. If adding a new URI scheme, document it in `docs/DEPLOYMENT.md` (operator-facing) or `docs/TOOLS.md` (if surfaced in tool output)
+
+---
+
+## Canonical ambiguous cases
+
+These come up repeatedly. The answer is always the same.
+
+**"Could this be a lens?"**  
+Only if the output is plain web search results. If you need any custom fields — company data, typed metadata, domain-specific schema — it's a Tool. Lenses filter; they don't transform.
+
+**"Could this be a provider instead of a tool?"**  
+Only if the output matches an existing capability interface exactly. Check the interface in `internal/search/` first. If you'd need to add fields to make it fit, it needs a new Tool.
+
+**"Should this be an enrichment resolver or a tool?"**  
+Enrichment resolvers are keyed on a DOI that already exists in a search result. If your side-channel data requires the caller to supply a query or URL, it's a Tool. If it silently annotates results as a side effect, it's a resolver.
+
+**"Prompt or tool?"**  
+A Prompt guides the model to use existing tools in sequence. A Tool produces data directly. If a caller outside the model loop needs to consume the output programmatically, it must be a Tool.

--- a/docs/LESSONS_LEARNED.md
+++ b/docs/LESSONS_LEARNED.md
@@ -18,7 +18,7 @@ Myself and collaborators spent three versions (v6.2.0 through v6.4.0) building i
 
 ### Google Discontinuing "Entire Web" Search (Issue #107)
 
-Google announced it would be discontinuing support for Programmable Search Engines configured to search the "entire web." The project was named `google-researcher-mcp` — the dependency on a single search provider was an foundational risk.
+Google announced it would be discontinuing support for Programmable Search Engines configured to search the "entire web." The project was named `google-researcher-mcp` — the dependency on a single search provider was a foundational risk.
 
 **Go fix**: A clean provider interface that lets you swap search backends freely, plus a routing layer that automatically switches to the next provider when one fails.
 
@@ -58,7 +58,7 @@ The project had 100+ source files but a tightly coupled `shared/` directory with
 
 ### 1. Don't Fight Your Runtime
 
-Node.js process management is fundamentally fragile for long-lived servers launched via npx. The runtime doesn't support robust parent-death detection, and the nested process tree (npx → node → worker) makes signal propagation unreliable. We spent three versions building increasingly complex orphan detection. Go's single binary eliminated the entire category of problems.
+Node.js process management is fundamentally fragile for long-lived servers launched via npx. The runtime has no reliable parent-death detection, and the nested process tree (npx → node → worker) makes signal propagation unreliable. We spent three versions building increasingly complex orphan detection. Go's single binary eliminated the entire category of problems.
 
 **Takeaway**: If you're spending significant engineering effort working around your runtime's limitations, that's a signal to evaluate whether the runtime fits the problem.
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -50,20 +50,22 @@ Understanding what backs each provider helps you reason about result overlap and
 
 Which tools each web search provider enables. `—` means the provider returns empty (no error) for that capability — image-capable providers in `SEARCH_ROUTING` will handle the fallback automatically.
 
-| Provider | `web_search` | `image_search` | `news_search` | `answer` | `structured_search` | Scrape fallback tier |
-|---|:---:|:---:|:---:|:---:|:---:|:---:|
-| **[DuckDuckGo](https://duckduckgo.com/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[Google PSE](https://programmablesearchengine.google.com/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[Serper](https://serper.dev/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[SearchAPI.io](https://www.searchapi.io/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[Brave](https://brave.com/search/api/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[Exa](https://exa.ai/)** | ✓ | — | ✓ | ✓ | ✓ | ✓ (paid, last-resort) |
-| **[Tavily](https://app.tavily.com/)** | ✓ | — | ✓ | — | — | — |
-| **[SearXNG](https://docs.searxng.org/)** | ✓ | ✓ | ✓ | — | — | — |
-| **[HackerNews](https://hn.algolia.com/)** | ✓ | — | ✓ | — | — | — |
+| Provider | `web_search` | `image_search` | `news_search` | `answer` | `structured_search` | `local_search` | Scrape fallback tier |
+|---|:---:|:---:|:---:|:---:|:---:|:---:|:---:|
+| **[DuckDuckGo](https://duckduckgo.com/)** | ✓ | ✓ | ✓ | — | — | — | — |
+| **[Google PSE](https://programmablesearchengine.google.com/)** | ✓ | ✓ | ✓ | — | — | — | — |
+| **[Serper](https://serper.dev/)** | ✓ | ✓ | ✓ | — | — | — | — |
+| **[SearchAPI.io](https://www.searchapi.io/)** | ✓ | ✓ | ✓ | — | — | — | — |
+| **[Brave](https://brave.com/search/api/)** | ✓ | ✓ | ✓ | — | — | ✓ | — |
+| **[Exa](https://exa.ai/)** | ✓ | — | ✓ | ✓ | ✓ | — | ✓ (paid, last-resort) |
+| **[Tavily](https://app.tavily.com/)** | ✓ | — | ✓ | — | — | — | — |
+| **[SearXNG](https://docs.searxng.org/)** | ✓ | ✓ | ✓ | — | — | — | — |
+| **[HackerNews](https://hn.algolia.com/)** | ✓ | — | ✓ | — | — | — | — |
 
 **Notes:**
 - `answer` and `structured_search` are provider-independent tools, but Exa is the only web provider that backs them with its native API. They remain unavailable if no Exa key is set.
+- `local_search` is Brave-only — it requires `BRAVE_API_KEY`. No other web provider supports the three-call local pipeline (locations → POIs → descriptions).
+- Brave also exposes a LLM context endpoint (`/res/v1/llm/context`) consumed by `search_and_scrape` as a fast-path for RAG/grounding workflows. When Brave is the active provider, `search_and_scrape` tries the server-assembled context first; if that fails, it falls back to the standard search-then-scrape pipeline. Requires `BRAVE_DATA_FOR_AI` plan access.
 - Exa's scrape fallback tier (`/contents`) fires only when all four free tiers (markdown → stealth → HTML → browser) have failed. It charges an Exa credit per call.
 - Tavily's time-range filter is aggressive on web search — for recent content, `news_search` works better; `web_search` may return nothing for narrow windows.
 
@@ -110,7 +112,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 
 **[Serper](https://serper.dev/) and [SearchAPI.io](https://www.searchapi.io/)** — Google results without the PSE setup overhead. Serper is the simpler option; SearchAPI.io supports multiple engine backends beyond Google. Both draw from Google — no coverage difference between them or vs. Google PSE.
 
-**[Brave](https://brave.com/search/api/)** — Own crawler, own index, privacy-first. Best all-purpose choice when you want index independence from Google/Bing and a generous free tier. Supports web, image, news, and Goggles-based custom result weighting. Also exposes local/map results via `local_search`.
+**[Brave](https://brave.com/search/api/)** — Own crawler, own index, privacy-first. Best all-purpose choice when you want index independence from Google/Bing and a generous free tier. Supports web, image, news, and Goggles-based custom result weighting. Also exposes local/map results via `local_search` (the only provider that does) and a LLM context endpoint used by `search_and_scrape` for faster grounding when you're on Brave's Data for AI plan.
 
 **[Exa](https://exa.ai/)** — Neural/semantic index. Results are ranked by embedding similarity, not just keyword match — better for conceptual or research queries. The only provider that backs `answer` (grounded synthesis with citations) and `structured_search` (schema-defined entity extraction). Also provides a paid `/contents` scrape tier as a last-resort fallback for `scrape_page`. Most expensive per-call but uniquely capable.
 
@@ -130,13 +132,15 @@ Which tools each web search provider enables. `—` means the provider returns e
 |---|:---:|:---:|:---:|:---:|:---:|---|
 | **[OpenAlex](https://openalex.org/)** | ✓ | ✓ | ✓ | via Unpaywall | — | No (email for polite pool) |
 | **[CrossRef](https://www.crossref.org/)** | ✓ | ✓ (authoritative) | — | — | — | No (email for polite pool) |
-| **[Semantic Scholar](https://www.semanticscholar.org/)** | ✓ | ✓ | ✓ (rich edges) | — | ✓ (tldr) | No (key raises limits) |
+| **[Semantic Scholar](https://www.semanticscholar.org/)** | ✓ | — | ✓ (rich edges) | — | ✓ (tldr) | No (key raises limits) |
 | **[PubMed](https://pubmed.ncbi.nlm.nih.gov/)** | ✓ | — | — | — | — | No (key raises limits) |
+| **[Exa](https://exa.ai/)** | ✓ | — | — | — | — | Yes (`EXA_API_KEY`) |
 
 **Notes:**
 - CrossRef is the official DOI registration agency — the authoritative source for DOI metadata. Every DOI-registered work appears here.
-- Semantic Scholar enriches results with AI-generated `tldr` summaries and citation intent/influence edges, which power `citation_graph`.
-- OpenAlex and CrossRef both support the `DOIResolver` interface (exact-entity lookup). Semantic Scholar also implements it. PubMed does not.
+- Semantic Scholar enriches results with AI-generated `tldr` summaries and citation intent/influence edges, which power `citation_graph`. OpenAlex also implements `citation_graph` support with citation-count edges as a fallback.
+- Only OpenAlex implements the `DOIResolver` interface (exact-entity lookup via `/works/doi:{doi}`). CrossRef, Semantic Scholar, and PubMed do not.
+- Exa routes academic queries using its `research-paper` category — useful when its neural index surfaces papers the bibliographic databases miss.
 - [Unpaywall](https://unpaywall.org/) OA enrichment runs as a post-processing step on any DOI-bearing result — not a separate provider to select.
 
 ### Coverage
@@ -147,6 +151,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 | **[CrossRef](https://www.crossref.org/)** | 140M+ DOI-registered works | Peer-reviewed literature; authoritative DOI metadata |
 | **[Semantic Scholar](https://www.semanticscholar.org/)** | 200M+ papers | Broad; strong on CS, medicine, biology |
 | **[PubMed](https://pubmed.ncbi.nlm.nih.gov/)** | 35M+ citations | Biomedical and life science only |
+| **[Exa](https://exa.ai/)** | Neural web index | Research-paper category; surfaces papers outside bibliographic DBs |
 
 ### Academic Routing
 
@@ -169,9 +174,11 @@ If no academic providers are configured, `academic_search` automatically falls b
 | **[EPO OPS](https://developers.epo.org/)** | ✓ | ✓ | ✓ | ✓ (100M+ docs, all major offices) | Yes (free registration) |
 | **[The Lens](https://www.lens.org/)** | ✓ | ✓ | ✓ | ✓ (100+ jurisdictions) | Yes (free, request access) |
 | **[USPTO](https://data.uspto.gov/)** | ✓ | — | — | — | Yes (free) |
+| **[SearchAPI.io](https://www.searchapi.io/)** | ✓ | ✓ | ✓ | ✓ (Google Patents via SerpAPI) | Yes (`SEARCHAPI_API_KEY`) |
 
 **Notes:**
-- EPO OPS and The Lens both cover worldwide jurisdictions; USPTO covers US patents only.
+- EPO OPS and The Lens cover worldwide jurisdictions; USPTO covers US patents only.
+- SearchAPI.io wraps Google Patents via SerpAPI — good for quick coverage when you already have a SearchAPI key.
 - The Lens uniquely links patents to citing academic papers.
 - Without any patent provider configured, `patent_search` falls back to site-restricted web discovery.
 - The `patent_office` parameter enables intelligent routing — a search restricted to `EP` automatically skips USPTO.

--- a/docs/PYTHON_CLIENT.md
+++ b/docs/PYTHON_CLIENT.md
@@ -92,6 +92,8 @@ result: ScrapePageResponse = await client.scrape_page(
 )
 ```
 
+See [`docs/TOOLS.md`](TOOLS.md) for the full parameter schema.
+
 ### `search_and_scrape`
 
 ```python
@@ -195,7 +197,7 @@ result: VerifyRecommendationResponse = await client.verify_recommendation([
 
 ### `sequential_search`
 
-The three positional arguments are required; the following shows common optional keyword arguments (note the camelCase names — they match the JSON field names exactly). See [`docs/TOOLS.md`](TOOLS.md) for the complete list.
+The three required arguments are positional; the following shows common optional keyword arguments (the camelCase names match the JSON field names exactly). See [`docs/TOOLS.md`](TOOLS.md) for the complete list.
 
 ```python
 result: SequentialSearchResponse = await client.sequential_search(
@@ -210,12 +212,27 @@ result: SequentialSearchResponse = await client.sequential_search(
     branchId=None,
     knowledgeGap=None,
     researchGoal=None,
+    confidence=None,       # "low" | "medium" | "high"
+    depth=None,            # "shallow" | "standard" | "deep"
+    reasoning=None,
+    responseMode=None,
+    sessionSummary=None,
+    rejectedApproaches=None,
 )
 ```
 
+### Synthesis tools
+
+```python
+ans:  AnswerResponse          = await client.answer(query, provider=None)
+srch: StructuredSearchResponse = await client.structured_search(query, provider=None, ...)
+```
+
+See [`docs/TOOLS.md`](TOOLS.md) for the full parameter schema.
+
 ### Structured-domain searches
 
-`patent_search`, `econ_search`, `legal_search`, `clinical_search`, and `filing_search` follow the same shape — all keyword arguments, all optional, returning their typed `<Name>Response`. The exact parameters are documented per-tool in [`docs/TOOLS.md`](TOOLS.md):
+`patent_search`, `econ_search`, `legal_search`, `clinical_search`, `filing_search`, and `local_search` follow the same shape — all keyword arguments, all optional, returning their typed `<Name>Response`. The exact parameters are documented per-tool in [`docs/TOOLS.md`](TOOLS.md):
 
 ```python
 patents:  PatentSearchResponse   = await client.patent_search(query="mRNA vaccine", patent_office="USPTO")
@@ -223,19 +240,49 @@ econ:     EconSearchResponse     = await client.econ_search(series_id="GDP", dat
 cases:    LegalSearchResponse    = await client.legal_search(query="fair use", jurisdiction="ca9")
 trials:   ClinicalSearchResponse = await client.clinical_search(condition="melanoma", status="recruiting")
 filings:  FilingSearchResponse   = await client.filing_search(ticker="AAPL", form_type="10-K")
+local:    LocalSearchResponse    = await client.local_search(query="coffee shops", near="Seattle, WA")
+```
+
+### Brand research
+
+```python
+result: BrandResearchResponse = await client.brand_research(
+    company_name=None,        # company name to look up
+    url=None,                 # brand homepage URL (alternative to company_name)
+    depth=None,               # "shallow" | "standard" | "deep"
+    include_design_tokens=False,
+    sessionId=None,
+)
+```
+
+### Regulated / opt-in tools
+
+These tools register only when the matching feature is enabled on the server (see `MEMORY_ENABLED`, `USER_ANALYTICS_ENABLED`, `WORKSPACES_ENABLED` in [`.env.example`](../.env.example)).
+
+```python
+# Long-term memory (requires MEMORY_ENABLED=true + consent)
+await client.memory_save(note, tags=None, topic=None, url=None)
+await client.memory_recall(limit=None, topic=None)
+
+# Per-user analytics (requires USER_ANALYTICS_ENABLED=true + consent)
+await client.get_my_analytics()
+
+# Shared workspaces (requires WORKSPACES_ENABLED=true + consent, HTTP mode only)
+await client.workspace_contribute(workspace_id, note, tags=None, url=None)
+await client.workspace_read(workspace_id)
 ```
 
 ### Session / bibliography helpers
 
 ```python
 session: GetResearchSessionResponse = await client.get_research_session(sessionId, stepId=None)
-export:  ResearchExportResponse     = await client.research_export(sessionId, format="markdown")
+export:  ResearchExportResponse     = await client.research_export(sessionId, format=None, verify_links=False)
 biblio:  FormatBibliographyResponse = await client.format_bibliography(sessionId=None, sources=None, style=None)
 graph:   CitationGraphResponse      = await client.citation_graph(paper, direction=None, influential_only=False,
                                                                    num_results=None, provider=None, sessionId=None)
 ```
 
-`citation_graph`'s `paper` is a DOI or title; `format_bibliography` takes either a `sessionId` or an explicit `sources` list (pass `style="apa"` to control the output format).
+`citation_graph`'s `paper` is a DOI or title; `format_bibliography` takes either a `sessionId` or an explicit `sources` list (pass `style="apa"` to control the output format); `research_export`'s `format` defaults to `"markdown"` server-side when omitted.
 
 ### Generic passthrough
 
@@ -285,6 +332,7 @@ class ScrapePageResponse:
     citation: Optional[Citation]
     metadata: Optional[ScrapePageMetadata]
     structuredData: Optional[StructuredData]
+    forumSignals: Optional[ForumSignals]  # present on forum/discussion pages
     sourceType: Optional[str]
     authorityTier: Optional[str]
     domainCategory: Optional[str]
@@ -402,9 +450,9 @@ async with WebResearcherClient(server_env={"GOOGLE_CUSTOM_SEARCH_API_KEY": "..."
 ## Testing
 
 ```bash
-make test-python                              # pytest tests/python/ --ignore=tests/python/test_live_e2e.py -v
-python3 -m pytest tests/python/ -v           # direct
-python3 -m unittest tests.python.test_client # stdlib runner
+make test-python                                                                        # pytest (falls back to unittest discover)
+python3 -m pytest tests/python/ --ignore=tests/python/test_live_e2e.py -v             # direct pytest
+python3 -m unittest discover -s tests/python -v                                        # stdlib runner (no pytest needed)
 ```
 
 Tests use a stdlib `HTTPServer` mock — no API keys, no binary, no network required.

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -122,7 +122,7 @@ Scope enforcement is opt-in via `ENFORCE_SCOPES=true` and remains permissive by 
 - `ENFORCE_SCOPES=true`, token carries **no** scope claim — allowed (backward-compatible: tokens issued before scopes existed keep working).
 - `ENFORCE_SCOPES=true`, token **carries** a scope claim — the caller must hold one of `tool:*` (wildcard), `tool:<toolName>` (exact), or the coarse-grained `research` scope; AND every entry in `REQUIRED_SCOPES` (if configured) must be present. Otherwise the call is rejected.
 
-This fails closed only for present-but-insufficient scopes — it never silently downgrades a token that simply predates scope issuance. The gate is wired as an SDK receiving-middleware (registered in `main.go`) inside the HTTP-mode block only; STDIO is unaffected.
+This fails closed only for present-but-insufficient scopes — it never silently downgrades a token that predates scope issuance. The gate is wired as an SDK receiving-middleware (registered in `main.go`) inside the HTTP-mode block only; STDIO is unaffected.
 
 ---
 
@@ -393,8 +393,8 @@ It never reflects the literal `*` together with credentials. The default is secu
 
 Two HTTP-mode subsystems durably persist state across restarts through a single `persist.Store` interface (`internal/persist/store.go`):
 
-- **Token revocation (H2)** — revoked JTIs are written through to the store with a TTL matching natural token expiry, so a revoked token stays revoked across restarts. The in-memory set remains authoritative; the store is consulted as an additional source of truth (a JTI is revoked if present in **either** layer — fail-closed).
-- **Daily quota counters (H7)** — enabled by `RATE_LIMIT_PERSIST=true`, so per-tenant daily quotas survive restarts.
+- **Token revocation (Layer 2 — Auth)** — revoked JTIs are written through to the store with a TTL matching natural token expiry, so a revoked token stays revoked across restarts. The in-memory set remains authoritative; the store is consulted as an additional source of truth (a JTI is revoked if present in **either** layer — fail-closed).
+- **Daily quota counters (Layer 5 — Rate Limiting)** — enabled by `RATE_LIMIT_PERSIST=true`, so per-tenant daily quotas survive restarts.
 
 The default implementation is the encrypted-disk pattern generalized from the session store: AES-256-GCM, atomic temp-file-and-rename writes, `0600` permissions, an 8-byte big-endian expiry prefix, SHA-256-hashed filenames, and key-bound GCM AAD. Local (memory) and disk backends behave identically — no drift between STDIO and HTTP. In HTTP mode, setting `REDIS_URL` swaps in a `RedisStore` that satisfies the same interface for cross-pod shared state; Redis-stored values are AES-256-GCM encrypted before write (so `REDIS_URL` requires `CACHE_ENCRYPTION_KEY`). All Redis code is confined to `internal/redisbackend` (the sole importer of the Redis client), constructed in one gated place in `main.go`; STDIO never reaches it.
 

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -281,16 +281,19 @@ user-controlled deletion.
 
 ### Right to Erasure
 
-For HTTP multi-tenant deployments: admin endpoints allow per-tenant data
-purging (sessions, cache entries, rate state, analytics). For STDIO: data is
-local to your machine — delete the cache directory. Any feature that stores
-data beyond the request lifecycle provides a deletion mechanism.
+For HTTP multi-tenant deployments: the `DELETE /admin/data` endpoint erases
+all personal data for a `(tenant_id, user_id)` subject across every registered
+store (sessions, analytics, memory, workspace) and simultaneously withdraws
+consent so processing cannot silently resume. `GET /admin/data` exports the
+same scope for portability. For STDIO: data is local to your machine — delete
+the cache directory. Any feature that stores data beyond the request lifecycle
+provides a deletion mechanism.
 
 ### User Insights Without Surveillance
 
-The project may offer features that help users understand their own research
-patterns (search trends, topic analysis, session history). These are designed
-as **user-owned insights, not profiling**:
+The project offers features that help you understand your own research
+patterns — which tools you used, how often, and when (opt-in, consent-gated).
+These are designed as **user-owned insights, not profiling**:
 
 - Data belongs to the user/tenant and is never shared across boundaries
 - The user can view, export, and delete their own data at any time

--- a/docs/SESSION_PERSISTENCE.md
+++ b/docs/SESSION_PERSISTENCE.md
@@ -71,7 +71,7 @@ The index is rebuilt from disk on server startup — so even a full restart (ser
 
 ### 3. Sources are tracked server-side (not by the LLM)
 
-When search tools (`web_search`, `scrape_page`, `search_and_scrape`, `news_search`, `academic_search`, `patent_search`, `citation_graph`, `filing_search`, `legal_search`, `clinical_search`) are called with a `sessionId` parameter, the server automatically records discovered URLs and titles as session sources. This happens server-side — no LLM relay needed.
+When search tools (`web_search`, `scrape_page`, `search_and_scrape`, `news_search`, `academic_search`, `patent_search`, `citation_graph`, `filing_search`, `legal_search`, `local_search`, `clinical_search`) are called with a `sessionId` parameter, the server automatically records discovered URLs and titles as session sources. This happens server-side — no LLM relay needed.
 
 Why this matters: if the LLM were responsible for reporting sources back to the session, it could hallucinate URLs, forget to record some, or lose them during compaction. By recording at the server level — where the actual API responses are — the source list is always accurate and complete.
 
@@ -163,7 +163,7 @@ Summary mode returns:
 
 This is typically 5-10 KB — enough to continue coherently without overwhelming the window.
 
-The AI can override this with `responseMode: "full"` to skip the synthesized summary and receive the step index directly. To retrieve full details of a specific earlier step, the AI uses `get_research_session` with a `stepId`.
+The AI can override this on any `sequential_search` call by passing `responseMode: "full"` to receive the step index directly. To retrieve full details of a specific earlier step, the AI calls `get_research_session` with a `stepId`.
 
 ### Why per-tenant isolation?
 

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1174,6 +1174,7 @@ Export a completed `sequential_search` session as a shareable deliverable — a 
 |-------|------|----------|---------|-------------|
 | `sessionId` | string | yes | — | The `sequential_search` session to export |
 | `format` | string | no | `markdown` | `markdown` (readable report) or `json` (full structured session) |
+| `verify_links` | bool | no | `false` | When true, check each source URL is still live and attach a Wayback snapshot for any dead link. Adds latency. Best-effort — failures leave a source unverified, never error. |
 
 ### Output Fields
 
@@ -1194,6 +1195,7 @@ Export a completed `sequential_search` session as a shareable deliverable — a 
 - **Markdown report** contains: research-goal heading, a metadata block (session id, started, step/source counts), every step with its reasoning/confidence/rejected-approaches/timestamp (revisions and branches are labeled in the step heading), an Open Questions section (knowledge gaps), a numbered Sources list, and a provenance footer (export time, tenant).
 - Deterministic: same session → byte-identical output aside from the `exportedAt` stamp (idempotency).
 - Sessions are private to their owning `(tenant, user)`; a leaked sessionId is honored only for its owner.
+- **`verify_links=true`**: runs a batched SSRF-safe liveness check on every recorded source URL and attaches a Wayback Machine snapshot URL for any dead link. Best-effort — a URL that can't be checked is left unverified, never an error. Off by default (adds latency proportional to source count).
 
 ### Annotations
 - ReadOnly: true · Idempotent: true · OpenWorld: false (reads internal session state)

--- a/lenses/README.md
+++ b/lenses/README.md
@@ -10,6 +10,7 @@ A **lens** restricts a `web_search` to a curated set of trusted, authority-weigh
   "description": "One line: what this lens scopes search to.",
   "domains": ["law.cornell.edu", "courtlistener.com", "supremecourt.gov"],
   "cx": "",
+  "goggle": "",
   "routing": ""
 }
 ```
@@ -18,11 +19,12 @@ A **lens** restricts a `web_search` to a curated set of trusted, authority-weigh
 |-------|----------|---------|
 | `name` | yes | The lens id users pass as `lens: <name>`. Must be unique (a later load overrides an earlier one). |
 | `description` | recommended | Shown in tool docs/UX; keep to one line. |
-| `domains` | one of `domains`/`cx` | Hosts injected as `site:` operators (up to 10 used). A host, optionally path-scoped (`github.com/advisories`). No scheme, no spaces. |
-| `cx` | one of `domains`/`cx` | A dedicated Google Programmable Search Engine id. When set, the lens skips `site:` operator injection — the PSE engine is expected to already scope results to the intended domains. The cx value itself must be configured as the global `GOOGLE_CUSTOM_SEARCH_ID`; this field is a documentation signal, not a per-request routing override. |
+| `domains` | one of `domains`/`cx`/`goggle` | Hosts injected as `site:` operators (up to 10 used). A host, optionally path-scoped (`github.com/advisories`). No scheme, no spaces. |
+| `cx` | one of `domains`/`cx`/`goggle` | A dedicated Google Programmable Search Engine id. When set, the lens skips `site:` operator injection — the PSE engine is expected to already scope results to the intended domains. The cx value itself must be configured as the global `GOOGLE_CUSTOM_SEARCH_ID`; this field is a documentation signal, not a per-request routing override. |
+| `goggle` | one of `domains`/`cx`/`goggle` | A Brave Goggle URL (`https://` required). When set, the Goggle is passed to the Brave provider for server-side re-ranking. Use with `SEARCH_PROVIDER=brave` or a routing config that includes Brave. See [`programming-goggle.json`](programming-goggle.json) for an example. |
 | `routing` | no | Optional provider routing hint. |
 
-A lens **must** define at least one of `domains` or `cx` — otherwise it never restricts a search. This is enforced by `search.ValidateLens` (`internal/search/lenses.go`); an invalid lens fails `make validate-lenses`. For custom lenses loaded via `CUSTOM_LENSES_PATH`, an invalid lens also fails startup in HTTP mode (`PORT` set); in STDIO mode it is a warning.
+A lens **must** define at least one of `domains`, `cx`, or `goggle` — otherwise it never restricts a search. This is enforced by `search.ValidateLens` (`internal/search/lenses.go`); an invalid lens fails `make validate-lenses`. For custom lenses loaded via `CUSTOM_LENSES_PATH`, an invalid lens also fails startup in HTTP mode (`PORT` set); in STDIO mode it is a warning.
 
 ## Add a bundled lens
 

--- a/llms-install.md
+++ b/llms-install.md
@@ -13,7 +13,58 @@ One of:
 - OR Docker installed
 - OR Go (version per `go.mod`) installed
 
-## Option A: Binary Install (recommended)
+## Option A: uvx (no compile, any OS)
+
+Install [`uv`](https://docs.astral.sh/uv/) first if you don't have it:
+
+```bash
+# macOS/Linux
+curl -LsSf https://astral.sh/uv/install.sh | sh
+# Windows
+winget install astral-sh.uv
+```
+
+Then add to your MCP client configuration:
+
+**Claude Code** (run in terminal):
+```bash
+claude mcp add --scope user web-researcher -- uvx web-researcher-mcp
+```
+
+**Cursor / VS Code / Cline / other clients** (Settings > MCP Servers):
+```json
+{
+  "mcpServers": {
+    "web-researcher": {
+      "command": "uvx",
+      "args": ["web-researcher-mcp"],
+      "env": {
+        "GOOGLE_CUSTOM_SEARCH_API_KEY": "YOUR_API_KEY",
+        "GOOGLE_CUSTOM_SEARCH_ID": "YOUR_SEARCH_ENGINE_ID"
+      }
+    }
+  }
+}
+```
+
+`uvx` fetches the right prebuilt binary for your platform — no Go, no compile, no manual PATH setup. The `env` block is optional; omit it to run zero-config with DuckDuckGo.
+
+## Option B: One-command install (macOS/Linux)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/install.sh | sh
+```
+
+Windows:
+```powershell
+powershell -ExecutionPolicy Bypass -c "irm https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/install.ps1 | iex"
+```
+
+Downloads the binary, verifies its SHA-256 checksum, puts it on your PATH, and registers it with Claude Code automatically when the `claude` CLI is present.
+
+Then add to other MCP clients as in Option A (replacing `"command": "uvx", "args": ["web-researcher-mcp"]` with `"command": "web-researcher-mcp"`).
+
+## Option C: Download binary manually
 
 1. Download the latest release for your platform:
    ```text
@@ -23,52 +74,9 @@ One of:
 
 2. Extract and place the binary in your PATH (e.g., `~/.local/bin/` or `/usr/local/bin/`)
 
-3. Add to your MCP client configuration. The `env` block is optional — omit it entirely to run zero-config with the DuckDuckGo fallback, or add a provider key for better results:
+3. Configure as in Option A (use `"command": "web-researcher-mcp"` instead of uvx).
 
-**Claude Code** (`~/.claude.json`):
-```json
-{
-  "mcpServers": {
-    "web-researcher": {
-      "command": "web-researcher-mcp",
-      "env": {
-        "GOOGLE_CUSTOM_SEARCH_API_KEY": "YOUR_API_KEY",
-        "GOOGLE_CUSTOM_SEARCH_ID": "YOUR_SEARCH_ENGINE_ID"
-      }
-    }
-  }
-}
-```
-
-**Cursor** (Settings > MCP Servers):
-```json
-{
-  "web-researcher": {
-    "command": "web-researcher-mcp",
-    "env": {
-      "GOOGLE_CUSTOM_SEARCH_API_KEY": "YOUR_API_KEY",
-      "GOOGLE_CUSTOM_SEARCH_ID": "YOUR_SEARCH_ENGINE_ID"
-    }
-  }
-}
-```
-
-**Cline** (MCP Settings):
-```json
-{
-  "mcpServers": {
-    "web-researcher": {
-      "command": "web-researcher-mcp",
-      "env": {
-        "GOOGLE_CUSTOM_SEARCH_API_KEY": "YOUR_API_KEY",
-        "GOOGLE_CUSTOM_SEARCH_ID": "YOUR_SEARCH_ENGINE_ID"
-      }
-    }
-  }
-}
-```
-
-## Option B: Docker
+## Option D: Docker
 
 ```json
 {
@@ -85,15 +93,15 @@ One of:
 }
 ```
 
-The Docker image bundles Chromium (with `CHROME_PATH` preset), so JavaScript-heavy pages render out of the box with no extra download.
+The Docker image bundles Chromium (with `CHROME_PATH` preset), so JavaScript-heavy pages render without an extra download.
 
-## Option C: Go Install
+## Option E: Go Install
 
 ```bash
 go install github.com/zoharbabin/web-researcher-mcp/cmd/web-researcher-mcp@latest
 ```
 
-Then configure as in Option A.
+Then configure as in Option C.
 
 ## Environment Variables
 
@@ -101,11 +109,11 @@ Then configure as in Option A.
 
 ## Available Tools
 
-The differentiator is the **trust suite**: `verify_citation` checks whether one citation actually exists, matches a real record, has been retracted (live Crossref / Retraction Watch), and still resolves — evidence, never a verdict. `audit_bibliography` runs those same checks over a whole reference list (CSL-JSON / RIS / BibTeX / a session) and flags retracted, dead, fabricated (`not_found`), or mischaracterized entries. `archive_source` captures a source to the Internet Archive (Wayback / Save Page Now) so a link you cite can't quietly rot.
+The differentiator is the **trust suite**: `verify_citation` checks whether one citation actually exists, matches a real record, has been retracted (live Crossref / Retraction Watch), and still resolves — evidence, never a verdict. `audit_bibliography` runs those same checks over a whole reference list (CSL-JSON / RIS / BibTeX / a session) and flags retracted, dead, fabricated (`not_found`), or mischaracterized entries. `archive_source` captures a source to the Internet Archive (Wayback / Save Page Now) so a link you cite can't quietly rot. `verify_recommendation` checks a recommended source for self-promotion, conflicts of interest, domain reputation, and dead links before you trust it.
 
-Alongside those, the always-on core tools include web search, full-page/document scraping (`mode: raw` for verbatim source), combined search-and-scrape with quality ranking, image and news search, academic search (real DOIs) and citation-graph traversal, patent search (US/EP/WO/JP/CN/KR), SEC filing search (`filing_search`, EDGAR — including XBRL company facts), US case-law search (`legal_search`, CourtListener), economic data (`econ_search`, FRED + World Bank + OECD + Eurostat), clinical-trial search (`clinical_search`, ClinicalTrials.gov), grounded `answer` and `structured_search`, research-session export and bibliography formatting (APA/MLA/BibTeX/RIS/CSL-JSON), and multi-step `sequential_search` with recoverable sessions.
+Alongside those, the always-on core tools include web search, full-page/document scraping (`mode: raw` for verbatim source), combined search-and-scrape with quality ranking, image and news search, academic search (real DOIs) and citation-graph traversal, patent search (US/EP/WO/JP/CN/KR), SEC filing search (`filing_search`, EDGAR — including XBRL company facts), US case-law search (`legal_search`, CourtListener), economic data (`econ_search`, FRED + World Bank + OECD + Eurostat), clinical-trial search (`clinical_search`, ClinicalTrials.gov), grounded `answer` and `structured_search`, research-session export and bibliography formatting (APA/MLA/BibTeX/RIS/CSL-JSON), multi-step `sequential_search` with recoverable sessions, and `brand_research` for structured brand identity data (colors, logos, typography, social handles) from any domain or company name.
 
-Optional keys `EDGAR_CONTACT_EMAIL`, `COURTLISTENER_API_TOKEN`, and `FRED_API_KEY` enrich the filing/legal/economic tools — `legal_search` works with no key, `filing_search` needs a contact email (falls back to `OPENALEX_EMAIL`), and `econ_search` is always registered (World Bank, OECD, and Eurostat are keyless); `FRED_API_KEY` adds FRED US macro series to it.
+Optional keys `EDGAR_CONTACT_EMAIL`, `COURTLISTENER_API_TOKEN`, and `FRED_API_KEY` enrich the filing/legal/economic tools — `legal_search` works with no key, `filing_search` needs a contact email (falls back to `OPENALEX_EMAIL`), and `econ_search` is always registered (World Bank, OECD, and Eurostat are keyless); `FRED_API_KEY` adds FRED US macro series to it. `local_search` (place/business search) registers only when `BRAVE_API_KEY` is set.
 
 Operators can additionally enable opt-in, consent-gated tools (per-user analytics, long-term memory, shared workspaces) that register only when their feature is turned on.
 
@@ -126,3 +134,4 @@ The assistant should invoke `news_search` and return results with real, clickabl
 - **"invalid API key"** — Verify your Google API key is enabled for Custom Search API
 - **No results** — Check that your Search Engine ID (cx) is configured to search the entire web
 - **Timeout errors** — Each scrape tier has its own bounded timeout (a few seconds up to ~30s for browser rendering); slow or JavaScript-heavy sites may hit these and fall through to the next tier
+- **Scraping private/internal URLs** — By default the server blocks private IP ranges (SSRF protection). Set `ALLOW_PRIVATE_IPS=true` to permit internal network URLs


### PR DESCRIPTION
## Summary

- Full zero-drift audit across all 17 markdown files — corrects stale claims, missing env vars, wrong tier counts, absent tools, and banned words (see commit `0242518` for the full 76-finding sweep)
- Optimizes `CLAUDE.md` against Anthropic best practices: removes global-CLAUDE.md duplications, adds Contribution Rules section (never-push-to-main, commit format, sync-lenses, gen-python-client triggers), fixes E2E command missing `-tags=e2e`, fixes consent pattern (was invalid bitwise-OR of string constants)
- Adds `docs/EXTENSION_GUIDE.md` — decision guide for choosing between Tool, Provider, Lens, Enrichment Resolver, Prompt, and Resource; includes quick-pick table, six-step decision path, integration checklists, and canonical ambiguous cases
- Cross-links the guide from `CLAUDE.md` Reference Docs table and from `CONTRIBUTING.md` above "Adding a New Tool"

## Test plan

- [x] `make verify` passes (docs-drift CI job covers `TestToolsDocMatchesRegistry` + `TestAllToolsHaveAnnotations`)
- [x] No tool schema changes — no `make gen-python-client` needed
- [x] No lens changes — no `make sync-lenses` needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)