### PR TITLE
chore: sync server.json + plugin.json to v1.36.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "name": "web-researcher-mcp",
   "displayName": "Web Researcher",
   "description": "Your AI research assistant that cites real sources and stays honest. Search the entire web or narrow it down to just the sites you trust; medical journals, court databases, news outlets, academic papers. Analyze the full source, not just snippets. Links that work, citations you can trust, no made up closed garden pre-synthesized results.",
-  "version": "1.36.3",
+  "version": "1.36.4",
   "author": {
     "name": "Zohar Babin",
     "url": "https://github.com/zoharbabin"

--- a/server.json
+++ b/server.json
@@ -7,11 +7,11 @@
     "url": "https://github.com/zoharbabin/web-researcher-mcp",
     "source": "github"
   },
-  "version": "1.36.3",
+  "version": "1.36.4",
   "packages": [
     {
       "registryType": "oci",
-      "identifier": "ghcr.io/zoharbabin/web-researcher-mcp:1.36.3",
+      "identifier": "ghcr.io/zoharbabin/web-researcher-mcp:1.36.4",
       "transport": {
         "type": "stdio"
       },
@@ -95,7 +95,7 @@
     },
     {
       "registryType": "oci",
-      "identifier": "docker.io/zoharbabin/web-researcher-mcp:1.36.3",
+      "identifier": "docker.io/zoharbabin/web-researcher-mcp:1.36.4",
       "transport": {
         "type": "stdio"
       }


### PR DESCRIPTION
## Summary

- Bumps `server.json` version from 1.36.3 → 1.36.4 (GHCR + Docker Hub identifiers)
- Bumps `.claude-plugin/plugin.json` version to 1.36.4
- Ran `scripts/sync-version.sh` — same script the MCP Registry publish job calls at release time

## Why

v1.36.4 was released on 2026-06-25, before the `update-packaging` CI job (added in PR #307 on 2026-06-26) existed. The manifests were left at 1.36.3.

## Test plan
- [ ] CI passes (no code change, just JSON version strings)
- [ ] `server.json` version matches `VERSION` file after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)