### PR TITLE
perf(docs): remove Google Fonts (fix LCP 6s→<2s) + add image dimensions (fix CLS 0.17→0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 <!-- mcp-name: io.github.zoharbabin/web-researcher-mcp -->
 <p align="center">
-  <img src="assets/logo-final.svg" width="120" alt="web-researcher-mcp logo">
+  <img src="assets/logo-final.svg" width="120" height="120" alt="web-researcher-mcp logo">
 </p>
 <h1 align="center">web-researcher-mcp</h1>
 <p align="center">
@@ -14,15 +14,15 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml"><img src="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
-  <a href="https://goreportcard.com/report/github.com/zoharbabin/web-researcher-mcp"><img src="https://goreportcard.com/badge/github.com/zoharbabin/web-researcher-mcp" alt="Go Report Card"></a>
-  <a href="https://pkg.go.dev/github.com/zoharbabin/web-researcher-mcp"><img src="https://pkg.go.dev/badge/github.com/zoharbabin/web-researcher-mcp.svg" alt="Go Reference"></a>
-  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" alt="License: MIT"></a>
-  <a href="https://github.com/zoharbabin/web-researcher-mcp/releases"><img src="https://img.shields.io/github/v/release/zoharbabin/web-researcher-mcp" alt="Release"></a>
-  <a href="https://hub.docker.com/r/zoharbabin/web-researcher-mcp"><img src="https://img.shields.io/docker/pulls/zoharbabin/web-researcher-mcp?cacheSeconds=3600" alt="Docker"></a>
-  <a href="https://pypi.org/project/web-researcher-mcp/"><img src="https://img.shields.io/pypi/v/web-researcher-mcp?label=PyPI" alt="PyPI"></a>
-  <a href="https://glama.ai/mcp/servers/zoharbabin/web-researcher-mcp"><img src="https://glama.ai/mcp/servers/zoharbabin/web-researcher-mcp/badges/score.svg" alt="web-researcher-mcp MCP server"></a>
-  <a href="https://github.com/zoharbabin/web-researcher-mcp/stargazers"><img src="https://img.shields.io/github/stars/zoharbabin/web-researcher-mcp?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml"><img src="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml/badge.svg" height="20" alt="CI"></a>
+  <a href="https://goreportcard.com/report/github.com/zoharbabin/web-researcher-mcp"><img src="https://goreportcard.com/badge/github.com/zoharbabin/web-researcher-mcp" height="20" alt="Go Report Card"></a>
+  <a href="https://pkg.go.dev/github.com/zoharbabin/web-researcher-mcp"><img src="https://pkg.go.dev/badge/github.com/zoharbabin/web-researcher-mcp.svg" height="20" alt="Go Reference"></a>
+  <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" height="20" alt="License: MIT"></a>
+  <a href="https://github.com/zoharbabin/web-researcher-mcp/releases"><img src="https://img.shields.io/github/v/release/zoharbabin/web-researcher-mcp" height="20" alt="Release"></a>
+  <a href="https://hub.docker.com/r/zoharbabin/web-researcher-mcp"><img src="https://img.shields.io/docker/pulls/zoharbabin/web-researcher-mcp?cacheSeconds=3600" height="20" alt="Docker"></a>
+  <a href="https://pypi.org/project/web-researcher-mcp/"><img src="https://img.shields.io/pypi/v/web-researcher-mcp?label=PyPI" height="20" alt="PyPI"></a>
+  <a href="https://glama.ai/mcp/servers/zoharbabin/web-researcher-mcp"><img src="https://glama.ai/mcp/servers/zoharbabin/web-researcher-mcp/badges/score.svg" height="20" alt="web-researcher-mcp MCP server"></a>
+  <a href="https://github.com/zoharbabin/web-researcher-mcp/stargazers"><img src="https://img.shields.io/github/stars/zoharbabin/web-researcher-mcp?style=social" height="20" alt="GitHub Stars"></a>
 </p>
 
 ### Get started in 30 seconds
@@ -761,7 +761,7 @@ Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for cod
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/chart?repos=zoharbabin/web-researcher-mcp&type=date&legend=top-left)](https://www.star-history.com/?repos=zoharbabin%2Fweb-researcher-mcp&type=date&legend=top-left)
+<a href="https://www.star-history.com/?repos=zoharbabin%2Fweb-researcher-mcp&type=date&legend=top-left"><img src="https://api.star-history.com/chart?repos=zoharbabin/web-researcher-mcp&type=date&legend=top-left" width="800" height="450" alt="Star History Chart"></a>
 
 ---
 

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,21 +8,9 @@
 {% endblock %}
 
 {% block extrahead %}
-  <!-- Preconnect for cross-origin resources -->
-  <link rel="preconnect" href="https://fonts.googleapis.com">
-  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <!-- Preconnect for cross-origin badge/asset origins -->
   <link rel="preconnect" href="https://www.googletagmanager.com">
   <link rel="preconnect" href="https://raw.githubusercontent.com">
-  <!-- Load Google Fonts asynchronously (non-blocking) — theme.font:false
-       disables Material's blocking <link>; we reload with media trick instead -->
-  <link rel="preload" as="style"
-        href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&display=swap">
-  <link rel="stylesheet" media="print" onload="this.media='all'"
-        href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&display=swap">
-  <noscript>
-    <link rel="stylesheet"
-          href="https://fonts.googleapis.com/css?family=Roboto:300,300i,400,400i,700,700i%7CRoboto+Mono:400,400i,700,700i&display=swap">
-  </noscript>
   <!-- Google Analytics -->
   <script async src="https://www.googletagmanager.com/gtag/js?id=G-P8TN6HBMMD"></script>
   <script>
@@ -45,8 +33,6 @@
 {% block scripts %}
   {{ super() }}
   <script>
-    /* Add loading="lazy" to any GIF/PNG not already lazy-loaded — prevents
-       the demo GIF (2.5 MB) from blocking LCP on the homepage. */
     document.addEventListener("DOMContentLoaded", function() {
       document.querySelectorAll('img[src$=".gif"], img[src$=".png"]').forEach(function(img) {
         if (!img.loading) img.loading = "lazy";


### PR DESCRIPTION
## Summary

- **Remove Google Fonts injection** from `overrides/main.html`: `theme.font: false` already makes Material use system fonts; the Roboto `preload` + `stylesheet` chain was driving LCP to 6s on every cold load (HTML → fonts.googleapis.com → fonts.gstatic.com before first paint). Dropping it means LCP renders from local cache with no cross-origin round-trips.
- **Add `height` to all unsized images in README.md**: logo (120px), all 9 badges (20px), star-history chart (800×450). This eliminates the CLS of 0.168 caused by the browser reflow when each badge dimension resolves.

## Expected score change

| Metric | Before | Expected |
|---|---|---|
| LCP | ~6.0 s (0.13) | <2.0 s |
| CLS | 0.158 (0.74) | ~0 |
| Performance | 71 | 90+ |

## Test plan

- [ ] CI docs workflow deploys cleanly
- [ ] Live HTML has no `fonts.googleapis.com` stylesheet links
- [ ] All badge `<img>` tags have `height="20"` in rendered HTML
- [ ] Lighthouse mobile score ≥90 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)