### PR TITLE
perf(docs): defer GA + remove navigation.instant to fix 5.7s LCP

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,7 +35,6 @@ theme:
         icon: material/brightness-4
         name: Switch to light mode
   features:
-    - navigation.instant
     - navigation.sections
     - navigation.top
     - search.highlight

--- a/overrides/main.html
+++ b/overrides/main.html
@@ -9,16 +9,7 @@
 
 {% block extrahead %}
   <!-- Preconnect for cross-origin badge/asset origins -->
-  <link rel="preconnect" href="https://www.googletagmanager.com">
   <link rel="preconnect" href="https://raw.githubusercontent.com">
-  <!-- Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=G-P8TN6HBMMD"></script>
-  <script>
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', 'G-P8TN6HBMMD');
-  </script>
   <meta property="og:type" content="website" />
   <meta property="og:title" content="{{ page.title }} - Web Researcher MCP" />
   <meta property="og:description" content="Your AI research assistant that cites real sources and stays honest. Search the entire web or narrow it down to just the sites you trust. Free, private, open source." />
@@ -37,6 +28,16 @@
       document.querySelectorAll('img[src$=".gif"], img[src$=".png"]').forEach(function(img) {
         if (!img.loading) img.loading = "lazy";
       });
+    });
+    window.addEventListener("load", function() {
+      var s = document.createElement("script");
+      s.src = "https://www.googletagmanager.com/gtag/js?id=G-P8TN6HBMMD";
+      s.async = true;
+      document.head.appendChild(s);
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag("js", new Date());
+      gtag("config", "G-P8TN6HBMMD");
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
## Problem

LCP is stuck at 5.7 s despite video preload=none fix. Two JS sources are causing long tasks that delay the LCP text element from painting:

1. **`navigation.instant`** — Material's client-side instant navigation patches all links and does DOM mutations during parse, contributing to the 2.1 s `elementRenderDelay` on the above-fold `<p>` text.
2. **Google Analytics in `<head>`** — GA's 163 KB script added long tasks at 5.1–5.2 s (120 ms combined), pushing LCP past the window.

## Fix

- Remove `navigation.instant` from `mkdocs.yml` features list. All other nav features retained.
- Move GA loading from `<head>` to `window.load` event. GA fires after the page is fully interactive — accurate session tracking is preserved; only the timing shifts.

## Expected

| Metric | Before | Expected |
|---|---|---|
| LCP | 5.7 s (0.16) | ~2.0 s (0.7+) |
| Performance | 74–77 | 90+ |

## Test plan

- [ ] Deployed page renders and navigates normally without instant nav
- [ ] GA events still fire (check Network tab → `gtag` requests after load)
- [ ] Lighthouse mobile score ≥90 after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)