### PR TITLE
perf(docs): preconnect api.github.com to cut throttled LCP

### DIFF
--- a/overrides/main.html
+++ b/overrides/main.html
@@ -8,8 +8,9 @@
 {% endblock %}
 
 {% block extrahead %}
-  <!-- Preconnect for cross-origin badge/asset origins -->
+  <!-- Preconnect for cross-origin origins used on every page load -->
   <link rel="preconnect" href="https://raw.githubusercontent.com">
+  <link rel="preconnect" href="https://api.github.com">
   <meta property="og:type" content="website" />
   <meta property="og:title" content="{{ page.title }} - Web Researcher MCP" />
   <meta property="og:description" content="Your AI research assistant that cites real sources and stays honest. Search the entire web or narrow it down to just the sites you trust. Free, private, open source." />


### PR DESCRIPTION
## Summary

- Add `<link rel="preconnect" href="https://api.github.com">` — Material's bundle.js calls the GitHub API for the repo star count and latest release badge. Without preconnect, the TLS handshake happens after bundle.js executes (~503ms from nav start), costing an extra ~360ms. With preconnect the handshake starts during HTML parsing.

## Expected

~360ms reduction in simulated LCP under Lighthouse mobile throttle.

## Test plan

- [ ] Lighthouse `network-dependency-tree-insight` no longer lists `api.github.com` as a preconnect candidate
- [ ] Mobile performance score improves

🤖 Generated with [Claude Code](https://claude.com/claude-code)