### PR TITLE
seo(docs): generate robots.txt with Sitemap directive on every deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -114,4 +114,7 @@ jobs:
           cp decks/compliance/compliance-deck.html site_src/decks/compliance/index.html
           cp decks/compliance/compliance-deck.pdf  site_src/decks/compliance/compliance-deck.pdf
 
+      - name: Generate robots.txt
+        run: printf 'User-agent: *\nAllow: /\n\nSitemap: https://zoharbabin.github.io/web-researcher-mcp/sitemap.xml\n' > site_src/robots.txt
+
       - run: mkdocs gh-deploy --force


### PR DESCRIPTION
## Summary

- Adds a `robots.txt` generation step to the docs workflow, producing `User-agent: * / Allow: / / Sitemap: <url>` on every deploy
- Deployed to `gh-pages` branch alongside `sitemap.xml`, so Googlebot can discover the sitemap without relying on Search Console submission alone
- Fixes the current 404 on `/web-researcher-mcp/robots.txt`

## Context

Audit confirmed the homepage is indexed but has zero organic traffic. The missing `robots.txt` with a `Sitemap:` directive means crawlers have no self-contained pointer to the sitemap — they depend entirely on GSC submission (which showed "Couldn't fetch" earlier today). This closes that gap.

## Test plan

- [ ] Merge and confirm docs workflow runs successfully
- [ ] `curl -sI https://zoharbabin.github.io/web-researcher-mcp/robots.txt` returns HTTP 200
- [ ] `curl -s https://zoharbabin.github.io/web-researcher-mcp/robots.txt` shows correct content with Sitemap directive

🤖 Generated with [Claude Code](https://claude.com/claude-code)