### PR TITLE
chore: update site_url and sitemap to zoharbabin.com

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -116,6 +116,6 @@ jobs:
 
       - name: Generate robots.txt
         run: |
-          printf 'User-agent: *\nAllow: /\n\nSitemap: https://zoharbabin.github.io/web-researcher-mcp/sitemap.xml\n' > site_src/robots.txt
+          printf 'User-agent: *\nAllow: /\n\nSitemap: https://zoharbabin.com/web-researcher-mcp/sitemap.xml\n' > site_src/robots.txt
 
       - run: mkdocs gh-deploy --force

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -396,8 +396,8 @@ See `docs/DEPLOYMENT.md` for the table of every variable, its default, and its e
 
 > **Prefer slides?** The same story — how architecture, not paperwork, keeps
 > this project aligned with 23 standards — is captured in a short visual deck:
-> **[Compliance as Architecture](https://zoharbabin.github.io/web-researcher-mcp/decks/compliance/)**
-> ([PDF](https://zoharbabin.github.io/web-researcher-mcp/decks/compliance/compliance-deck.pdf) ·
+> **[Compliance as Architecture](https://zoharbabin.com/web-researcher-mcp/decks/compliance/)**
+> ([PDF](https://zoharbabin.com/web-researcher-mcp/decks/compliance/compliance-deck.pdf) ·
 > [source](https://github.com/zoharbabin/web-researcher-mcp/blob/main/decks/compliance/compliance-deck.md)).
 > Each technical claim names the file that backs it — open any one and check.
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,5 +1,5 @@
 site_name: Web Researcher MCP
-site_url: https://zoharbabin.github.io/web-researcher-mcp/
+site_url: https://zoharbabin.com/web-researcher-mcp/
 site_description: Your AI research assistant that cites real sources and stays honest. Search the entire web or narrow it down to just the sites you trust.
 repo_url: https://github.com/zoharbabin/web-researcher-mcp
 repo_name: zoharbabin/web-researcher-mcp


### PR DESCRIPTION
## Summary
- Updates `mkdocs.yml` `site_url` from `zoharbabin.github.io/web-researcher-mcp/` to `zoharbabin.com/web-researcher-mcp/`
- Updates robots.txt generation in `docs.yml` to point sitemap at `zoharbabin.com`
- Updates deck links in `docs/SECURITY_AND_COMPLIANCE.md` to the new domain

## Why
`zoharbabin.com` is now live as a custom domain on GitHub Pages. MkDocs uses `site_url` to generate canonical URLs, the sitemap, and OG meta — all of which need to reflect the authoritative domain for correct SEO canonicalization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)