### PR TITLE
chore(packaging): bump AUR + Nix manifests to v1.37.0

### DIFF
--- a/packaging/aur/.SRCINFO
+++ b/packaging/aur/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = web-researcher-mcp
 	pkgdesc = Your AI research assistant that cites real sources and stays honest
-	pkgver = 1.36.4
+	pkgver = 1.37.0
 	pkgrel = 1
 	url = https://github.com/zoharbabin/web-researcher-mcp
 	arch = x86_64
@@ -8,9 +8,9 @@ pkgbase = web-researcher-mcp
 	license = MIT
 	provides = web-researcher-mcp
 	conflicts = web-researcher-mcp-git
-	source_x86_64 = web-researcher-mcp-1.36.4-x86_64.tar.gz::https://github.com/zoharbabin/web-researcher-mcp/releases/download/v1.36.4/web-researcher-mcp_1.36.4_linux_amd64.tar.gz
-	sha256sums_x86_64 = d62f476818658b818cb732451d2ffb37fb8facb1b95f907c4f9116db6bede637
-	source_aarch64 = web-researcher-mcp-1.36.4-aarch64.tar.gz::https://github.com/zoharbabin/web-researcher-mcp/releases/download/v1.36.4/web-researcher-mcp_1.36.4_linux_arm64.tar.gz
-	sha256sums_aarch64 = a9d7319805b749516002936fc7fe9195fe7015f8e093f7c26a307a2e4c3cb9ee
+	source_x86_64 = web-researcher-mcp-1.37.0-x86_64.tar.gz::https://github.com/zoharbabin/web-researcher-mcp/releases/download/v1.37.0/web-researcher-mcp_1.37.0_linux_amd64.tar.gz
+	sha256sums_x86_64 = e3b7c5ae5b3c9de3b73c7dfda6de027cae3d61abb040f5657e377c36c551ca16
+	source_aarch64 = web-researcher-mcp-1.37.0-aarch64.tar.gz::https://github.com/zoharbabin/web-researcher-mcp/releases/download/v1.37.0/web-researcher-mcp_1.37.0_linux_arm64.tar.gz
+	sha256sums_aarch64 = d2b33b027f5fc5e9003fae8b9fd5cd3e41dcd3c8113d88462ef5095bb151a9be
 
 pkgname = web-researcher-mcp

--- a/packaging/aur/PKGBUILD
+++ b/packaging/aur/PKGBUILD
@@ -1,6 +1,6 @@
 # Maintainer: Zohar Babin <zohar.babin@kaltura.com>
 pkgname=web-researcher-mcp
-pkgver=1.36.4
+pkgver=1.37.0
 pkgrel=1
 pkgdesc="Your AI research assistant that cites real sources and stays honest"
 arch=('x86_64' 'aarch64')

--- a/packaging/nix/flake.nix
+++ b/packaging/nix/flake.nix
@@ -16,26 +16,26 @@
       let
         pkgs = import nixpkgs { inherit system; };
 
-        version = "1.36.4";
+        version = "1.37.0";
 
         # Pre-built binaries per platform — matches GoReleaser archive names.
         # Update hashes by running: nix-prefetch-url --unpack <url>
         platformMap = {
           "x86_64-linux" = {
             url = "https://github.com/zoharbabin/web-researcher-mcp/releases/download/v${version}/web-researcher-mcp_${version}_linux_amd64.tar.gz";
-            hash = "sha256-1i9HaBhli4GMtzJFHS/7N/uPrLG5X5B8T5EW22vt5jc=";
+            hash = "sha256-47fFrls8neO3PH39pt4CfK49YauwQPVlfjd8NsVRyhY=";
           };
           "aarch64-linux" = {
             url = "https://github.com/zoharbabin/web-researcher-mcp/releases/download/v${version}/web-researcher-mcp_${version}_linux_arm64.tar.gz";
-            hash = "sha256-qdcxmAW3SVFgApNvx/6Rlf5wFfjgk/fCajB6Lkw8ue4=";
+            hash = "sha256-0rM7An9fxekAP66Ln9XNPkHc08gRPYhGLvUJW7FRqb4=";
           };
           "x86_64-darwin" = {
             url = "https://github.com/zoharbabin/web-researcher-mcp/releases/download/v${version}/web-researcher-mcp_${version}_darwin_amd64.tar.gz";
-            hash = "sha256-J+GzQVIS0255nQe8/pzJlL00Uhn3vYxxvU6te3Nb/7c=";
+            hash = "sha256-oy/3UzoppcTg9YapQRT2gsS3vY77FnOpos5jWbHBesA=";
           };
           "aarch64-darwin" = {
             url = "https://github.com/zoharbabin/web-researcher-mcp/releases/download/v${version}/web-researcher-mcp_${version}_darwin_arm64.tar.gz";
-            hash = "sha256-uKv7noDb44hbJ/Qhp4ZGIEvakSGBi4dybAQzIr8OueA=";
+            hash = "sha256-8kt8OmpSv1+iK77IPbksJ6w8r7jzlq6UssbMQB4bj2k=";
           };
         };
 


### PR DESCRIPTION
## Summary
- Bumps `packaging/aur/PKGBUILD` `pkgver` from `1.36.4` → `1.37.0`
- Bumps `packaging/nix/flake.nix` `version` from `1.36.4` → `1.37.0` with updated SHA256 hashes for all 4 platforms

The release CI job (`Update AUR + Nix packaging`) attempted to push this directly to main but was blocked by branch protection. Manual PR as workaround.

## Test plan
- [ ] CI passes (chore-only commit — no Go code changes)
- [ ] Hash values match `checksums.txt` from the v1.37.0 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)