### PR TITLE
fix(ci): make update-packaging step idempotent on re-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -515,18 +515,26 @@ jobs:
             exit 0
           fi
 
-          git checkout -b "$BRANCH"
+          # Create or reset the branch (idempotent on re-run).
+          git checkout -B "$BRANCH"
           git commit -m "chore(packaging): bump AUR + Nix manifests to v${VERSION} [skip ci]"
-          git push origin "$BRANCH"
+          git push --force-with-lease origin "$BRANCH"
 
           PR_BODY=$(printf 'Automated packaging bump for v%s.\n\nUpdates:\n- packaging/aur/PKGBUILD — version + SHA256 checksums\n- packaging/aur/.SRCINFO — version + SHA256 checksums\n- packaging/nix/flake.nix — version + SRI hashes (all 4 platforms)\n\nTriggered by the release workflow after checksums.txt was published to the GitHub release page.' "${VERSION}")
 
-          PR_URL=$(gh pr create \
-            --title "chore(packaging): bump AUR + Nix manifests to v${VERSION}" \
-            --body "$PR_BODY" \
-            --base main \
-            --head "$BRANCH")
-          echo "Opened packaging PR: $PR_URL"
+          # Reuse an existing open PR if the branch was already pushed on a prior run.
+          EXISTING_PR=$(gh pr list --head "$BRANCH" --state open --json url --jq '.[0].url' 2>/dev/null || true)
+          if [ -n "$EXISTING_PR" ]; then
+            PR_URL="$EXISTING_PR"
+            echo "Reusing existing packaging PR: $PR_URL"
+          else
+            PR_URL=$(gh pr create \
+              --title "chore(packaging): bump AUR + Nix manifests to v${VERSION}" \
+              --body "$PR_BODY" \
+              --base main \
+              --head "$BRANCH")
+            echo "Opened packaging PR: $PR_URL"
+          fi
 
           # Auto-merge once the validate-packaging CI job passes. --admin bypasses
           # the review requirement (the packaging files are metadata, not code).


### PR DESCRIPTION
## Summary

- `git push origin` on a re-run fails because the branch tip is already on remote — fixes by using `git checkout -B` + `git push --force-with-lease`
- `gh pr create` would fail if the PR already exists from a prior partial run — fixes by detecting an open PR for the branch first and reusing it
- These two scenarios both hit during the v1.37.1 release test run

## Root causes

1. Repo setting "Allow GitHub Actions to create and approve pull requests" was disabled → fixed in repo settings before this PR
2. After that fix, a re-run of the failed job couldn't push because the branch already existed with the same commit

## Test plan

- [x] YAML passes local validation
- [ ] CI passes on this PR
- [ ] After merge: tag `v1.37.2` will exercise the fixed path end-to-end (or manually verify via re-run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)