### PR TITLE
fix(ci): drop --admin from gh pr merge in update-packaging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -536,9 +536,11 @@ jobs:
             echo "Opened packaging PR: $PR_URL"
           fi
 
-          # Auto-merge once the validate-packaging CI job passes. --admin bypasses
-          # the review requirement (the packaging files are metadata, not code).
-          gh pr merge "$PR_URL" --squash --admin --auto \
+          # Auto-merge once the validate-packaging CI job passes.
+          # --auto and --admin are mutually exclusive in gh CLI; --auto alone is
+          # correct here because the only required check is validate-packaging,
+          # which passes on these metadata files.
+          gh pr merge "$PR_URL" --squash --auto \
             --subject "chore(packaging): bump AUR + Nix manifests to v${VERSION} [skip ci]" \
             --body "Automated squash-merge of packaging bump for v${VERSION}."
           echo "Auto-merge enabled on $PR_URL"


### PR DESCRIPTION
## Summary

`gh pr merge --squash --admin --auto` fails with `specify only one of --auto, --disable-auto, or --admin` — these flags are mutually exclusive in the gh CLI.

Drop `--admin`. `--auto` alone is correct: the only required check on packaging PRs is `validate-packaging`, which passes on these metadata files and then triggers the auto-merge itself.

## Verified

Observed in the live v1.37.2 release run (PR #333 was created successfully but the merge step failed on this exact error).

## Test plan

- [x] YAML passes local validation  
- [ ] CI passes on this PR
- [ ] After merge: v1.37.3 tag → all 6 release jobs succeed including 📦 Update Packaging Manifests with auto-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)