### PR TITLE
fix(ci): packaging PR auto-merge + skip redundant CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      packaging: ${{ steps.filter.outputs.packaging }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -49,24 +50,32 @@ jobs:
           if [ -z "$base" ] || ! git cat-file -e "$base^{commit}" 2>/dev/null; then
             echo "No usable diff base; running full CI."
             echo "code=true" >> "$GITHUB_OUTPUT"
+            echo "packaging=false" >> "$GITHUB_OUTPUT"
             exit 0
           fi
           files=$(git diff --name-only "$base" HEAD)
           echo "Changed files:"; echo "$files"
           # A file is "harmless" if it matches the allowlist; if ANY changed
           # file is not harmless, run full CI (code=true).
+          # A PR is "packaging-only" if every changed file is under packaging/.
           code=false
+          packaging=true
           while IFS= read -r f; do
             [ -z "$f" ] && continue
             case "$f" in
-              *.md|docs/*|decks/*|assets/*|LICENSE|.gitignore|mkdocs.yml|overrides/*|packaging/**|.github/*_TEMPLATE*|.github/ISSUE_TEMPLATE/*)
-                : ;;                       # harmless — keep checking
+              packaging/*) : ;;            # packaging — keep checking both flags
+              *.md|docs/*|decks/*|assets/*|LICENSE|.gitignore|mkdocs.yml|overrides/*|.github/*_TEMPLATE*|.github/ISSUE_TEMPLATE/*)
+                packaging=false ;;         # harmless but not packaging-only
               *)
-                code=true; break ;;        # anything else → full CI
+                code=true; packaging=false; break ;;  # anything else → full CI
             esac
           done <<< "$files"
+          # Edge case: empty diff (e.g. workflow_dispatch with no changes)
+          # is not a packaging-only PR.
+          [ -z "$files" ] && packaging=false
           echo "code=$code" >> "$GITHUB_OUTPUT"
-          echo "Decision: code=$code"
+          echo "packaging=$packaging" >> "$GITHUB_OUTPUT"
+          echo "Decision: code=$code packaging=$packaging"
 
   # ── Always-run gates (every PR, even docs-only) ───────────────────────────────
   # These never skip. They catch cross-cutting drift that a change detector can't
@@ -101,11 +110,13 @@ jobs:
           version: v2.12
           args: --timeout=5m
 
-  # 📄 Docs drift — docs/TOOLS.md ↔ registry drift. Runs on EVERY PR including
-  # docs-only ones: a docs-only change could introduce registry drift and the
-  # gated `test` job would never catch it.
+  # 📄 Docs drift — docs/TOOLS.md ↔ registry drift. Runs on every PR except
+  # packaging-only ones: a machine-generated packaging bump cannot cause
+  # docs/registry drift, so skipping saves ~2 min on every release cycle.
   docs-drift:
     name: 📄 Docs ↔ Registry Drift
+    needs: changes
+    if: needs.changes.outputs.packaging != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -120,10 +131,12 @@ jobs:
             ./internal/tools/...
 
   # 🐍 Python client drift — regenerated client must match live Go schemas.
-  # Runs on every PR so a schema change without `make gen-python-client` is caught
-  # even on code-only PRs that skip the docs gate.
+  # Runs on every PR except packaging-only ones: a packaging bump cannot change
+  # Go tool schemas.
   python-drift:
     name: 🐍 Python Client Drift
+    needs: changes
+    if: needs.changes.outputs.packaging != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -138,8 +151,11 @@ jobs:
         run: make check-python-drift
 
   # 🧪 Python SDK tests — unit + integration tests (mock HTTP, no binary needed).
+  # Skipped on packaging-only PRs — a packaging bump cannot break the Python SDK.
   test-python:
     name: 🧪 Test · Python SDK
+    needs: changes
+    if: needs.changes.outputs.packaging != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -517,7 +517,7 @@ jobs:
 
           # Create or reset the branch (idempotent on re-run).
           git checkout -B "$BRANCH"
-          git commit -m "chore(packaging): bump AUR + Nix manifests to v${VERSION} [skip ci]"
+          git commit -m "chore(packaging): bump AUR + Nix manifests to v${VERSION}"
           git push --force-with-lease origin "$BRANCH"
 
           PR_BODY=$(printf 'Automated packaging bump for v%s.\n\nUpdates:\n- packaging/aur/PKGBUILD — version + SHA256 checksums\n- packaging/aur/.SRCINFO — version + SHA256 checksums\n- packaging/nix/flake.nix — version + SRI hashes (all 4 platforms)\n\nTriggered by the release workflow after checksums.txt was published to the GitHub release page.' "${VERSION}")
@@ -541,6 +541,6 @@ jobs:
           # correct here because the only required check is validate-packaging,
           # which passes on these metadata files.
           gh pr merge "$PR_URL" --squash --auto \
-            --subject "chore(packaging): bump AUR + Nix manifests to v${VERSION} [skip ci]" \
+            --subject "chore(packaging): bump AUR + Nix manifests to v${VERSION}" \
             --body "Automated squash-merge of packaging bump for v${VERSION}."
           echo "Auto-merge enabled on $PR_URL"

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -15,16 +15,18 @@ Every push / PR                         v* tag push
  │  (merge gate)     │             │  (publish pipeline)  │
  └─────────┬─────────┘             └──────────┬───────────┘
            │                                  │
-    change detector                 🏗️ GoReleaser · Build & Publish
-    ┌───────┴────────────────────────────────────────────────────┐
-    │ always-run (every PR)     code-only (skipped on docs PRs)  │
-    │ ─────────────────         ─────────────────────────────    │
-    │ 🧹 lint                   🧪 test (race detector)          │
-    │ 📄 docs-drift             🔬 e2e (STDIO + HTTP + OAuth)    │
-    │ 🐍 python-drift           🐳 docker-smoke                  │
-    │ 🧪 test-python            🏗️ build (5 platforms)           │
-    │ 📦 validate-packaging     🛡️ security (vuln + gosec)       │
-    └────────────────────────────────────────────────────────────┘
+    change detector (code / packaging flags)
+    ┌──────────────────┬──────────────────────┬────────────────────────┐
+    │ packaging-only   │ docs/human (no code) │ code change            │
+    │ ──────────────   │ ────────────────      │ ──────────────────     │
+    │ 📦 validate-pkg  │ 📄 docs-drift        │ 🧹 lint                │
+    │                  │ 🐍 python-drift      │ 🧪 test (race+coverage)│
+    │                  │ 🧪 test-python       │ 🔬 e2e (STDIO+HTTP+OAuth│
+    │                  │ 📦 validate-pkg      │ 🐳 docker-smoke        │
+    │                  │                      │ 🏗️ build (5 platforms) │
+    │                  │                      │ 🛡️ security (vuln+gosec│
+    └──────────────────┴──────────────────────┴────────────────────────┘
+                                              🏗️ GoReleaser · Build & Publish
                                           │
                            ┌──────────────┼────────────────────┐
                            ▼              ▼                     ▼
@@ -57,29 +59,31 @@ There is also a fourth file, `codeql.yml`, that runs GitHub's CodeQL deep static
 
 ### 🔍 Change detector (`changes` job)
 
-The first job classifies every PR. It reads the list of changed files and outputs `code=true` or `code=false`.
+The first job classifies every PR. It reads the list of changed files and outputs two flags:
 
-**Harmless files** (skip heavy CI):
+- `code=true` — at least one file outside the harmless/packaging allowlist changed → full CI runs
+- `packaging=true` — every changed file is under `packaging/**` → packaging-only mode (only `validate-packaging` runs)
+
+**Harmless files** (skip heavy CI, not packaging-only):
 - `*.md`, `docs/**`, `decks/**`, `assets/**`
 - `LICENSE`, `.gitignore`, `mkdocs.yml`, `overrides/**`
-- `packaging/**` (version-bump PRs don't need a full Go test run)
 - `.github/**_TEMPLATE*`, `.github/ISSUE_TEMPLATE/**`
 
-Anything else → `code=true` → full CI runs.
+Anything else outside `packaging/**` → `code=true` → full CI runs.
 
-> **Why?** Branch protection marks skipped *required* checks as passing. A docs-only PR goes green in seconds without getting stuck on checks that legitimately have nothing to test.
+> **Why?** Branch protection marks skipped *required* checks as passing. A docs-only PR goes green in seconds without getting stuck on checks that legitimately have nothing to test. A machine-generated packaging PR only runs `validate-packaging` — the one check that actually matters.
 
-### 🔒 Always-run jobs (every PR, regardless of what changed)
+### 🔒 Always-run jobs (every PR except packaging-only)
 
-These never skip. They catch cross-cutting drift that a change detector can't safely filter:
+These run on every PR — except packaging-only ones, which can't cause the drift they detect:
 
-| Job | What it catches |
-|-----|----------------|
-| **🧹 lint** | `gofmt -s` + `golangci-lint` — formatting and static analysis |
-| **📄 docs-drift** | `docs/TOOLS.md` ↔ registry drift; tool annotation coverage |
-| **🐍 python-drift** | Python client (`models.py`/`client.py`) not regenerated after Go schema change |
-| **🧪 test-python** | Python SDK unit + integration tests (mock HTTP, no binary needed) |
-| **📦 validate-packaging** | `PKGBUILD` / `.SRCINFO` / `flake.nix` version + hash consistency |
+| Job | What it catches | Skipped on packaging-only? |
+|-----|----------------|---------------------------|
+| **🧹 lint** | `gofmt -s` + `golangci-lint` — formatting and static analysis | No (gated on `code=true`) |
+| **📄 docs-drift** | `docs/TOOLS.md` ↔ registry drift; tool annotation coverage | Yes |
+| **🐍 python-drift** | Python client (`models.py`/`client.py`) not regenerated after Go schema change | Yes |
+| **🧪 test-python** | Python SDK unit + integration tests (mock HTTP, no binary needed) | Yes |
+| **📦 validate-packaging** | `PKGBUILD` / `.SRCINFO` / `flake.nix` version + hash consistency | No — this is the only job that runs on packaging-only PRs |
 
 > **Rule:** If you change a Go tool schema, run `make gen-python-client` before pushing. If you change `docs/TOOLS.md`, the matching tool definition must change in the same commit (or vice versa). These jobs enforce both.
 
@@ -273,9 +277,9 @@ Runs GitHub's CodeQL engine with `security-extended,security-and-quality` query 
 
 ### Adding a job to ci.yml
 
-1. If the job must run on every PR (e.g., a new drift gate): add it **without** a `needs: changes` dependency.
-2. If the job is only relevant when Go code changes: gate it on `needs.changes.outputs.code == 'true'` and add `needs: [changes, lint]` (so formatting failures fast-fail first).
-3. Add `packaging/**` to the `changes` allowlist if the new job should not run on packaging PRs.
+1. **Runs on every non-packaging PR** (e.g., a new drift gate): add `needs: changes` and `if: needs.changes.outputs.packaging != 'true'`.
+2. **Only relevant when Go code changes**: gate it on `needs.changes.outputs.code == 'true'` and add `needs: [changes, lint]` (so formatting failures fast-fail first).
+3. **Must run even on packaging PRs**: omit the `packaging` guard and add `needs: changes` only if you need the outputs. Only `validate-packaging` falls into this category.
 
 ### Adding a post-release distribution channel
 


### PR DESCRIPTION
## Summary

Two related fixes for the automated packaging PR flow triggered after each release.

### Fix 1 — Remove `[skip ci]` from packaging commits (commit 1)

`[skip ci]` in the commit message prevented any CI run on `chore/packaging-v*` branches. With no CI run, required status checks never reported, so `gh pr merge --auto` waited forever → packaging PR stayed open indefinitely. This is why PR #336 (`chore/packaging-v1.37.3`) was stuck and needed a manual `--admin` merge.

### Fix 2 — Skip irrelevant CI jobs on packaging-only PRs (commit 2)

Even without `[skip ci]`, the always-run jobs (`docs-drift`, `python-drift`, `test-python`) fired on packaging PRs unnecessarily — a machine-generated file touching only `packaging/**` cannot cause docs/registry drift or Python SDK breakage. This wasted ~2 min on every release cycle.

**Changes to `ci.yml`:**
- Change detector now emits a second flag: `packaging=true` when every changed file is under `packaging/**`
- `docs-drift`, `python-drift`, `test-python` gain `if: needs.changes.outputs.packaging != 'true'`
- `validate-packaging` continues to run on all PR types (it's the one check that matters)

**Result:** A packaging PR now runs exactly one job: `validate-packaging`. Passes in ~30s → auto-merge fires.

## What happens on the next release

1. GoReleaser builds + publishes binaries
2. `update-packaging` job runs `scripts/update-packaging.sh`, pushes `chore/packaging-vX.Y.Z`
3. CI on that branch: change detector → `packaging=true` → only `validate-packaging` runs (~30s)
4. `gh pr merge --auto` fires as soon as `validate-packaging` passes
5. PR merges itself, no human action needed

## Test plan

- [ ] PR #337 CI passes (this PR itself touches workflow + docs, so `packaging=false`, full gate runs)
- [ ] Merge this PR
- [ ] Cut v1.37.4 patch release to verify end-to-end: packaging PR opens, only `validate-packaging` runs, auto-merge fires within ~1 min

🤖 Generated with [Claude Code](https://claude.com/claude-code)