### PR TITLE
fix(ci): add workflow_dispatch fallback + fix stale CICD.md comment

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,12 @@ name: 🚀 Release
 on:
   push:
     tags: ["v*"]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to release (e.g. v1.37.5) — use only when the push trigger misfired"
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -22,9 +28,14 @@ jobs:
     name: 🏗️ GoReleaser · Build & Publish
     runs-on: ubuntu-latest
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -325,6 +336,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - name: Install cosign
         uses: sigstore/cosign-installer@v3
 
@@ -351,6 +366,10 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - name: Sync version for publish
@@ -381,6 +400,10 @@ jobs:
     needs: release
     if: ${{ vars.SMITHERY_ENABLED == 'true' }}
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-node@v6
@@ -425,6 +448,10 @@ jobs:
     permissions:
       id-token: write   # mandatory for PyPI Trusted Publishing; job-scoped
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
 
       - uses: actions/setup-python@v6
@@ -485,7 +512,13 @@ jobs:
     permissions:
       contents: write
     steps:
+      - name: Resolve tag ref (override for manual dispatch)
+        if: github.event_name == 'workflow_dispatch'
+        run: echo "GITHUB_REF_NAME=${{ inputs.tag }}" >> "$GITHUB_ENV"
+
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref }}
 
       - name: Install helpers (xxd, python3)
         run: sudo apt-get install -y xxd python3

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -305,7 +305,7 @@ git push origin HEAD  # via PR
 git tag v1.38.0
 git push origin v1.38.0
 # → release.yml starts automatically
-# → update-packaging job opens and auto-merges chore/packaging-v1.38.0
+# → update-packaging job generates PKGBUILD/.SRCINFO/flake.nix and attaches them to the release
 ```
 
 ---
@@ -329,6 +329,7 @@ git push origin v1.38.0
 | Docker sign failure | Check GHCR image exists; check cosign OIDC token permissions |
 | MCP Registry warning | Non-fatal; check `mcp-publisher` OIDC credentials, may already be published |
 | Smithery warning | Non-fatal; check `SMITHERY_API_KEY` secret, may already be published |
+| Release workflow didn't fire on tag push | GitHub infrastructure glitch — use `Actions → 🚀 Release → Run workflow` and supply the tag (e.g. `v1.37.5`) to retrigger manually |
 
 ---
 


### PR DESCRIPTION
## Summary

- Adds `workflow_dispatch` to `release.yml` with a `tag` input (e.g. `v1.37.5`) — lets us manually re-trigger a release when GitHub Actions misses the tag-push event (observed for v1.37.5)
- Each job that uses `GITHUB_REF_NAME` now sets it from `inputs.tag` when dispatched manually so all downstream steps (docker sign, MCP registry, Smithery, PyPI, packaging) work correctly
- Fixes a stale line in `docs/CICD.md` that still said the `update-packaging` job "opens and auto-merges chore/packaging-vX.Y.Z" (removed in #340)
- Adds a debugging entry for the missed-trigger case

## Test plan

- [ ] PR CI passes (workflow file + docs changes only — no code drift to test)
- [ ] After merge: manually dispatch `🚀 Release` → `Run workflow` → branch `v1.37.5` → tag `v1.37.5` to verify v1.37.5 releases correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)