### PR TITLE
fix(ci): use env.AUR_SSH_KEY in step condition instead of secrets context

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -545,7 +545,7 @@ jobs:
           echo "Attached PKGBUILD, .SRCINFO, flake.nix to v${VERSION} release"
 
       - name: Push to AUR
-        if: ${{ secrets.AUR_SSH_KEY != '' }}
+        if: env.AUR_SSH_KEY != ''
         env:
           AUR_SSH_KEY: ${{ secrets.AUR_SSH_KEY }}
         run: |


### PR DESCRIPTION
## Summary

GitHub Actions validates workflow files when `workflow_dispatch` is added as a trigger, and it rejects `secrets` context references in step-level `if:` conditions. The `Push to AUR` step used `if: ${{ secrets.AUR_SSH_KEY != '' }}` which fails that check.

Fix: set `AUR_SSH_KEY` as a step `env:` var (already done for the `run:` block) and check `env.AUR_SSH_KEY != ''` in the `if:` condition instead. Behavior is identical — the step skips when the secret is absent.

## Test plan

- [ ] PR CI passes
- [ ] After merge: manually dispatch `🚀 Release` → `Run workflow` → tag `v1.37.5` to complete v1.37.5 release verification

🤖 Generated with [Claude Code](https://claude.com/claude-code)