### PR TITLE
fix(ci): use shell env var for tag in post-GoReleaser upload steps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,14 @@ jobs:
       - name: Build .mcpb bundles
         run: |
           sudo apt-get install -y jq zip
-          bash scripts/build-mcpb.sh "${{ github.ref_name }}"
+          bash scripts/build-mcpb.sh "${GITHUB_REF_NAME}"
 
       - name: Upload .mcpb bundles to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for f in dist/mcpb/*.mcpb; do
-            gh release upload "${{ github.ref_name }}" "$f" --clobber
+            gh release upload "${GITHUB_REF_NAME}" "$f" --clobber
           done
 
       - name: Generate SBOM
@@ -291,7 +291,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" sbom-web-researcher-mcp.spdx.json --clobber
+          gh release upload "${GITHUB_REF_NAME}" sbom-web-researcher-mcp.spdx.json --clobber
 
       - name: Sign checksums.txt with cosign (keyless OIDC)
         env:
@@ -306,7 +306,7 @@ jobs:
           cosign sign-blob --yes "$CHECKSUM_FILE" \
             --output-signature "${CHECKSUM_FILE}.sig" \
             --output-certificate "${CHECKSUM_FILE}.pem"
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "${GITHUB_REF_NAME}" \
             "${CHECKSUM_FILE}.sig" "${CHECKSUM_FILE}.pem" --clobber
 
       # Persist the cross-compiled (and signed/notarized) binaries so the


### PR DESCRIPTION
## Summary

- Replaces `${{ github.ref_name }}` with `${GITHUB_REF_NAME}` in four `run:` blocks inside the `release` job
- `${{ github.ref_name }}` is a GitHub template expression evaluated **before** the job starts — when `workflow_dispatch` fires from the `main` branch ref, it permanently resolves to `main`, even after the \"Resolve tag ref\" step writes `GITHUB_REF_NAME=v1.37.5` to `$GITHUB_ENV`
- `${GITHUB_REF_NAME}` is the shell environment variable, which **is** correctly overridden by that step
- This caused the v1.37.5 manual dispatch to fail on `.mcpb` upload, SBOM attach, and cosign sig attach with "release not found" (it was trying to upload to the `main` release, not `v1.37.5`)

Affected steps:
1. `Build .mcpb bundles` — `bash scripts/build-mcpb.sh "${GITHUB_REF_NAME}"`
2. `Upload .mcpb bundles to release` — `gh release upload "${GITHUB_REF_NAME}" ...`
3. `Attach SBOM to release` — `gh release upload "${GITHUB_REF_NAME}" ...`
4. `Sign checksums.txt with cosign (keyless OIDC)` — `gh release upload "${GITHUB_REF_NAME}" ...`

## Test plan

- [ ] Merge and re-dispatch `🚀 Release` with tag `v1.37.5` — all four steps should now upload to the correct release
- [ ] Verify `.mcpb` bundles, SBOM (`sbom-web-researcher-mcp.spdx.json`), `checksums.txt.sig` and `checksums.txt.pem` appear as assets on the v1.37.5 GitHub Release
- [ ] Verify downstream jobs (docker-sign, publish-mcp-registry, publish-smithery, publish-pypi, update-packaging) all complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)