### PR TITLE
fix(ci): add replace_existing_artifacts to goreleaser release config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,14 @@ jobs:
       - name: Build .mcpb bundles
         run: |
           sudo apt-get install -y jq zip
-          bash scripts/build-mcpb.sh "${{ github.ref_name }}"
+          bash scripts/build-mcpb.sh "${GITHUB_REF_NAME}"
 
       - name: Upload .mcpb bundles to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for f in dist/mcpb/*.mcpb; do
-            gh release upload "${{ github.ref_name }}" "$f" --clobber
+            gh release upload "${GITHUB_REF_NAME}" "$f" --clobber
           done
 
       - name: Generate SBOM
@@ -291,7 +291,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" sbom-web-researcher-mcp.spdx.json --clobber
+          gh release upload "${GITHUB_REF_NAME}" sbom-web-researcher-mcp.spdx.json --clobber
 
       - name: Sign checksums.txt with cosign (keyless OIDC)
         env:
@@ -306,7 +306,7 @@ jobs:
           cosign sign-blob --yes "$CHECKSUM_FILE" \
             --output-signature "${CHECKSUM_FILE}.sig" \
             --output-certificate "${CHECKSUM_FILE}.pem"
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "${GITHUB_REF_NAME}" \
             "${CHECKSUM_FILE}.sig" "${CHECKSUM_FILE}.pem" --clobber
 
       # Persist the cross-compiled (and signed/notarized) binaries so the

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -346,6 +346,7 @@ release:
     name: web-researcher-mcp
   draft: false
   prerelease: auto
+  replace_existing_artifacts: true
   name_template: "{{.ProjectName}} v{{.Version}}"
   header: |
     ## What's Changed


### PR DESCRIPTION
## Summary

- Adds `replace_existing_artifacts: true` to the GoReleaser `release:` config in `.goreleaser.yml`
- When `workflow_dispatch` re-runs the release for an existing tag (needed when a run fails mid-way), GoReleaser fails with `422 already_exists` because binaries from the first run are already attached to the release
- With this flag, GoReleaser deletes and re-uploads existing assets instead of failing, making manual re-runs idempotent

## Background

v1.37.5 was released successfully (GoReleaser created the release + uploaded all binaries), but the subsequent `.mcpb` upload failed because of the `${{ github.ref_name }}` bug fixed in #344. We then needed to re-dispatch the release workflow to complete the `.mcpb`/SBOM/cosign steps — but GoReleaser failed again because the assets it tries to upload already exist.

## Test plan

- [ ] Merge and re-dispatch `🚀 Release` with tag `v1.37.5` — GoReleaser should succeed (overwriting existing assets), then `.mcpb`/SBOM/cosign steps should succeed with the corrected `${GITHUB_REF_NAME}`
- [ ] Verify all downstream jobs complete (docker-sign, publish-mcp-registry, publish-smithery, publish-pypi, update-packaging)

🤖 Generated with [Claude Code](https://claude.com/claude-code)