### PR TITLE
fix(ci): pre-clear release assets before GoReleaser on manual re-dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -221,6 +221,28 @@ jobs:
 
       # ── GoReleaser — the core release step ────────────────────────────────────
 
+      # When re-running via workflow_dispatch for an existing tag (e.g. to
+      # complete a partial run that failed mid-way), GoReleaser errors with
+      # "already_exists" on each asset. This step pre-deletes all existing
+      # assets on the release so GoReleaser can re-upload cleanly.
+      - name: Clear existing release assets (idempotent re-run)
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          RELEASE_ID=$(gh api "repos/zoharbabin/web-researcher-mcp/releases/tags/${GITHUB_REF_NAME}" --jq '.id' 2>/dev/null || true)
+          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
+            echo "No existing release found for ${GITHUB_REF_NAME} — nothing to clear."
+            exit 0
+          fi
+          echo "Clearing assets for release ID ${RELEASE_ID} (${GITHUB_REF_NAME})..."
+          gh api "repos/zoharbabin/web-researcher-mcp/releases/${RELEASE_ID}/assets" --jq '.[].id' | while read -r asset_id; do
+            gh api -X DELETE "repos/zoharbabin/web-researcher-mcp/releases/assets/${asset_id}" \
+              && echo "  deleted asset ${asset_id}"
+          done
+          echo "Done clearing assets."
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,14 +271,14 @@ jobs:
       - name: Build .mcpb bundles
         run: |
           sudo apt-get install -y jq zip
-          bash scripts/build-mcpb.sh "${{ github.ref_name }}"
+          bash scripts/build-mcpb.sh "${GITHUB_REF_NAME}"
 
       - name: Upload .mcpb bundles to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           for f in dist/mcpb/*.mcpb; do
-            gh release upload "${{ github.ref_name }}" "$f" --clobber
+            gh release upload "${GITHUB_REF_NAME}" "$f" --clobber
           done
 
       - name: Generate SBOM
@@ -291,7 +291,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload "${{ github.ref_name }}" sbom-web-researcher-mcp.spdx.json --clobber
+          gh release upload "${GITHUB_REF_NAME}" sbom-web-researcher-mcp.spdx.json --clobber
 
       - name: Sign checksums.txt with cosign (keyless OIDC)
         env:
@@ -306,7 +306,7 @@ jobs:
           cosign sign-blob --yes "$CHECKSUM_FILE" \
             --output-signature "${CHECKSUM_FILE}.sig" \
             --output-certificate "${CHECKSUM_FILE}.pem"
-          gh release upload "${{ github.ref_name }}" \
+          gh release upload "${GITHUB_REF_NAME}" \
             "${CHECKSUM_FILE}.sig" "${CHECKSUM_FILE}.pem" --clobber
 
       # Persist the cross-compiled (and signed/notarized) binaries so the

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -346,6 +346,7 @@ release:
     name: web-researcher-mcp
   draft: false
   prerelease: auto
+  replace_existing_artifacts: true
   name_template: "{{.ProjectName}} v{{.Version}}"
   header: |
     ## What's Changed


### PR DESCRIPTION
## Summary

- Adds a \"Clear existing release assets\" step that fires **only on `workflow_dispatch`** (not on normal tag pushes)
- When `workflow_dispatch` re-runs the release for an existing tag (needed to complete a partial run that failed mid-way), GoReleaser fails with `422 already_exists` on every binary it tries to upload
- The new step queries the release by tag, lists all existing assets, and deletes them so GoReleaser can re-upload cleanly — making manual re-dispatches idempotent
- `replace_existing_artifacts: true` in `.goreleaser.yml` is kept as a belt+suspenders fallback

## Background

v1.37.5 had a cascading failure:
1. Initial tag push → release.yml never triggered (GitHub infra glitch) → PR #342 added `workflow_dispatch`
2. Manual dispatch → `.mcpb` upload used `${{ github.ref_name }}` → resolved to `main` → PR #344 fixed to `${GITHUB_REF_NAME}`
3. Re-dispatch → GoReleaser failed with `already_exists` on all assets from step 1
4. Another re-dispatch (after #345 adding `replace_existing_artifacts`) → still failed (GoReleaser v2.16.0 apparently doesn't honour the flag)
5. This PR: pre-clear assets before GoReleaser so re-dispatches work

## Test plan

- [ ] Merge and re-dispatch `🚀 Release` with tag `v1.37.5` — `Clear existing release assets` step should delete all assets, then GoReleaser re-uploads them, then `.mcpb`/SBOM/cosign steps complete
- [ ] Verify complete run: all 6 jobs green
- [ ] Verify v1.37.5 release has all expected assets: binaries, .mcpb bundles, SBOM, checksums.txt.sig/.pem

🤖 Generated with [Claude Code](https://claude.com/claude-code)