### PR TITLE
fix(ci): use inputs.tag in clear-assets step (not GITHUB_REF_NAME)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,19 +225,24 @@ jobs:
       # complete a partial run that failed mid-way), GoReleaser errors with
       # "already_exists" on each asset. This step pre-deletes all existing
       # assets on the release so GoReleaser can re-upload cleanly.
+      # Uses ${{ inputs.tag }} directly because GitHub Actions runner vars
+      # (GITHUB_REF_NAME) cannot be overridden via $GITHUB_ENV.
       - name: Clear existing release assets (idempotent re-run)
         if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          DISPATCH_TAG: ${{ inputs.tag }}
         run: |
           set -euo pipefail
-          RELEASE_ID=$(gh api "repos/zoharbabin/web-researcher-mcp/releases/tags/${GITHUB_REF_NAME}" --jq '.id' 2>/dev/null || true)
-          if [ -z "$RELEASE_ID" ] || [ "$RELEASE_ID" = "null" ]; then
-            echo "No existing release found for ${GITHUB_REF_NAME} — nothing to clear."
+          RELEASE_ID=$(gh api "repos/zoharbabin/web-researcher-mcp/releases/tags/${DISPATCH_TAG}" \
+            --jq '.id // empty' 2>/dev/null || true)
+          if [ -z "$RELEASE_ID" ]; then
+            echo "No existing release found for ${DISPATCH_TAG} — nothing to clear."
             exit 0
           fi
-          echo "Clearing assets for release ID ${RELEASE_ID} (${GITHUB_REF_NAME})..."
-          gh api "repos/zoharbabin/web-researcher-mcp/releases/${RELEASE_ID}/assets" --jq '.[].id' | while read -r asset_id; do
+          echo "Clearing assets for release ID ${RELEASE_ID} (${DISPATCH_TAG})..."
+          gh api "repos/zoharbabin/web-researcher-mcp/releases/${RELEASE_ID}/assets" \
+            --jq '.[].id' | while read -r asset_id; do
             gh api -X DELETE "repos/zoharbabin/web-researcher-mcp/releases/assets/${asset_id}" \
               && echo "  deleted asset ${asset_id}"
           done


### PR DESCRIPTION
## Summary

- Fixes the \"Clear existing release assets\" step to use `DISPATCH_TAG=${{ inputs.tag }}` instead of `${GITHUB_REF_NAME}`
- GitHub Actions **runner vars** (`GITHUB_REF_NAME`, `GITHUB_SHA`, etc.) cannot be overridden via `\$GITHUB_ENV` — only custom env vars can; the built-in runner context is set before any steps run
- When dispatched with `--ref main`, `GITHUB_REF_NAME` is always `main` in the shell, even after the \"Resolve tag ref\" override step writes `GITHUB_REF_NAME=v1.37.5` to `\$GITHUB_ENV`
- This caused `gh api ...releases/tags/main` to return 404, whose full JSON body was captured as `RELEASE_ID`, and then the next URL construction failed with `unsupported protocol scheme`
- Also switches from `--jq '.id'` to `--jq '.id // empty'` so a 404 response produces empty output (not `null`), making the `-z` check work correctly

## Test plan

- [ ] Merge and re-dispatch `🚀 Release` with tag `v1.37.5`
- [ ] \"Clear existing release assets\" step logs `Clearing assets for release ID <id> (v1.37.5)...` or `No existing release found for v1.37.5 — nothing to clear.`
- [ ] GoReleaser runs successfully and uploads all assets
- [ ] `.mcpb`/SBOM/cosign steps complete
- [ ] All downstream jobs complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)