### PR TITLE
fix(ci): use RELEASE_TAG step-env for post-GoReleaser uploads on manual dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -296,16 +296,19 @@ jobs:
       # ── Post-release artifact attachment ─────────────────────────────────────
 
       - name: Build .mcpb bundles
+        env:
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           sudo apt-get install -y jq zip
-          bash scripts/build-mcpb.sh "${GITHUB_REF_NAME}"
+          bash scripts/build-mcpb.sh "${RELEASE_TAG}"
 
       - name: Upload .mcpb bundles to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           for f in dist/mcpb/*.mcpb; do
-            gh release upload "${GITHUB_REF_NAME}" "$f" --clobber
+            gh release upload "${RELEASE_TAG}" "$f" --clobber
           done
 
       - name: Generate SBOM
@@ -317,12 +320,14 @@ jobs:
       - name: Attach SBOM to release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
-          gh release upload "${GITHUB_REF_NAME}" sbom-web-researcher-mcp.spdx.json --clobber
+          gh release upload "${RELEASE_TAG}" sbom-web-researcher-mcp.spdx.json --clobber
 
       - name: Sign checksums.txt with cosign (keyless OIDC)
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ inputs.tag || github.ref_name }}
         run: |
           set -euo pipefail
           CHECKSUM_FILE="dist/checksums.txt"
@@ -333,7 +338,7 @@ jobs:
           cosign sign-blob --yes "$CHECKSUM_FILE" \
             --output-signature "${CHECKSUM_FILE}.sig" \
             --output-certificate "${CHECKSUM_FILE}.pem"
-          gh release upload "${GITHUB_REF_NAME}" \
+          gh release upload "${RELEASE_TAG}" \
             "${CHECKSUM_FILE}.sig" "${CHECKSUM_FILE}.pem" --clobber
 
       # Persist the cross-compiled (and signed/notarized) binaries so the


### PR DESCRIPTION
## Summary

- All four post-GoReleaser steps (`build .mcpb`, `upload .mcpb`, `attach SBOM`, `sign checksums`) were using `${GITHUB_REF_NAME}` in bash, which the GitHub Actions runner resolves to the **triggering ref** (`main` on `workflow_dispatch`) — not the release tag
- Writing `GITHUB_REF_NAME=v1.37.5` to `$GITHUB_ENV` in a prior step does **not** override the runner's own built-in; the shell still sees `main`
- Fix: add `RELEASE_TAG: ${{ inputs.tag || github.ref_name }}` as a step-level `env:` var on each affected step; template expressions are evaluated at workflow-parse time before any steps run, so `inputs.tag` wins on manual dispatch and `github.ref_name` is the correct fallback on normal tag push

## Root cause

GitHub Actions runner built-in variables (`GITHUB_REF_NAME`, `GITHUB_SHA`, etc.) are set by the runner process and **cannot be overridden** via `$GITHUB_ENV`. The log display is misleading — it shows the env-file value in the env block but the shell's expansion still resolves to the runner original. Template expressions (`${{ }}`) in step-level `env:` blocks evaluate before the runner starts any step, so they correctly pick up `inputs.tag`.

## Test plan

- [ ] Merge to main
- [ ] Re-dispatch `🚀 Release` workflow with `tag=v1.37.5`
- [ ] Confirm all four post-GoReleaser steps reference `v1.37.5` in their logs
- [ ] Confirm `.mcpb` bundles, `sbom-web-researcher-mcp.spdx.json`, `checksums.txt.sig`, `checksums.txt.pem` are attached to the v1.37.5 release

🤖 Generated with [Claude Code](https://claude.com/claude-code)