### PR TITLE
fix(ci): escape pkgs.lib.fakeHash in nixpkgs heredocs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -684,7 +684,7 @@ jobs:
             owner = "zoharbabin";
             repo = "web-researcher-mcp";
             tag = "v${VERSION}";
-            hash = "${pkgs.lib.fakeHash}";
+            hash = "\${pkgs.lib.fakeHash}";
           }
           NIX
           # Capture the error — it contains the real hash.
@@ -720,7 +720,7 @@ jobs:
               hash = "${SRC_HASH}";
             };
             env.CGO_ENABLED = 0;
-            vendorHash = "${pkgs.lib.fakeHash}";
+            vendorHash = "\${pkgs.lib.fakeHash}";
           }
           NIX
           HASH_OUT="$(nix-build /tmp/vendor-hash.nix --no-out-link 2>&1 || true)"


### PR DESCRIPTION
## Summary
- The v1.37.6 release run's "🐧 Submit → nixpkgs proper" job failed at "Compute src hash" with `bad substitution`.
- Root cause: the unquoted `<<NIX` heredocs let bash expand every `${...}` in the embedded Nix expression, including `${pkgs.lib.fakeHash}` — valid Nix, not valid bash. Only `VERSION`/`SRC_HASH` were meant to be bash-substituted.
- Fix: escape the `$` on `${pkgs.lib.fakeHash}` in both the src-hash and vendorHash heredocs so it stays literal for Nix while `VERSION`/`SRC_HASH` still interpolate correctly.

## Test plan
- [x] Reproduced the exact heredoc locally with bash — confirmed `${pkgs.lib.fakeHash}` broke with "bad substitution" pre-fix, and resolves correctly post-fix (verified output content matches intended Nix syntax)
- [x] CI green on this PR
- [ ] Next release tag will confirm the nixpkgs job runs end-to-end (this job only runs on `v*` tag pushes)