### PR TITLE
fix(ci): stop double-indenting zookatron in nixpkgs maintainer-list insert

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -795,7 +795,7 @@ jobs:
           # Entries are alphabetical; zoharbabin sorts between zohl and zookatron.
           MLIST="/tmp/nixpkgs/maintainers/maintainer-list.nix"
           if ! grep -q 'zoharbabin' "${MLIST}"; then
-            perl -i -0pe 's|(  zookatron = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n  $1|' "${MLIST}"
+            perl -i -0pe 's|(  zookatron = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n$1|' "${MLIST}"
             git -C /tmp/nixpkgs add maintainers/maintainer-list.nix
           fi
 


### PR DESCRIPTION
## Summary
- `NixOS/nixpkgs#537807` (our v1.37.6 nixpkgs submission) failed the `treefmt` lint check because the maintainer-list insertion script re-indented the neighboring `zookatron` entry from 2 to 4 spaces.
- Root cause: the perl regex capture group `(  zookatron = \{)` already includes the 2-space indent, but the replacement prepended an extra `  ` before `$1`, doubling it.
- Fix: drop the extra leading spaces before `$1` so `zookatron`'s original indentation is preserved.

## Test plan
- [x] Reproduced the bug and verified the fix locally with a standalone perl invocation against a representative snippet of `maintainer-list.nix` — confirmed `zookatron` keeps its 2-space indent after the fix (previously became 4-space).
- [x] Confirmed `.github/workflows/release.yml` still parses as valid YAML after the edit.
- [ ] Will be exercised for real on the next release's nixpkgs submission job (or a manual `workflow_dispatch` re-run) — no way to unit test the live nixpkgs PR flow without dispatching a release.