### PR TITLE
fix(ci): use --force not --force-with-lease for nixpkgs bot branch push

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -802,7 +802,12 @@ jobs:
           git -C /tmp/nixpkgs add "${PKG_DIR}/package.nix"
           git -C /tmp/nixpkgs commit -m "web-researcher-mcp: init at ${VERSION}"
 
-          git -C /tmp/nixpkgs push "${FORK_REMOTE}" "${BRANCH}" --force-with-lease
+          # Plain --force, not --force-with-lease: this is a shallow, fresh clone
+          # that never fetched ${BRANCH}, so there's no local tracking ref to lease
+          # against — git treats the branch as "expected absent" and rejects the
+          # push as stale on any re-run once the branch already exists on the fork.
+          # The bot fully owns this branch and always intends to overwrite it.
+          git -C /tmp/nixpkgs push "${FORK_REMOTE}" "${BRANCH}" --force
           echo "fork_user=${GH_USER}" >> "$GITHUB_ENV"
           echo "pr_branch=${BRANCH}" >> "$GITHUB_ENV"
           echo "pkg_version=${VERSION}" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- The v1.37.6 re-dispatch (run 28598806228, triggered to verify PR #363's maintainer-list fix) failed at `Clone fork, create branch, push` with `! [rejected] ... (stale info)`.
- Root cause: the fork clone is `--depth=1 --branch master` — it never fetches the `nixpkgs-web-researcher-mcp-<version>` bot branch, so there's no local tracking ref for `--force-with-lease` to compare against. Once that branch already exists on the fork (from any prior run), git treats it as unexpectedly present and rejects the push.
- This branch is fully bot-owned and always meant to be overwritten on re-run — same idempotency intent as the release-asset-clearing step elsewhere in this workflow. Plain `--force` is correct here.

## Test plan
- [x] Confirmed via job logs that the failure is exactly `--force-with-lease`'s stale-info rejection on a shallow clone, not a real conflict.
- [x] Confirmed `.github/workflows/release.yml` still parses as valid YAML after the edit.
- [ ] Will be exercised for real on the next nixpkgs submission (re-dispatching v1.37.6 again, or the next tagged release) — this flow can only be verified live.