### PR TITLE
fix(ci): insert zoharbabin before zohl, not zookatron, in maintainer-list

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -792,10 +792,11 @@ jobs:
           git -C /tmp/nixpkgs config user.email "github-actions@users.noreply.github.com"
 
           # Add zoharbabin to maintainers/maintainer-list.nix if not already present.
-          # Entries are alphabetical; zoharbabin sorts between zohl and zookatron.
+          # Entries are alphabetical; "zoharbabin" < "zohl" (4th char 'a' < 'l'),
+          # so it sorts immediately before zohl, not before zookatron.
           MLIST="/tmp/nixpkgs/maintainers/maintainer-list.nix"
           if ! grep -q 'zoharbabin' "${MLIST}"; then
-            perl -i -0pe 's|(  zookatron = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n$1|' "${MLIST}"
+            perl -i -0pe 's|(  zohl = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n$1|' "${MLIST}"
             git -C /tmp/nixpkgs add maintainers/maintainer-list.nix
           fi
 


### PR DESCRIPTION
## Summary
- The v1.37.6 nixpkgs PR (NixOS/nixpkgs#537807) still failed `Lint / treefmt` after PR #363's indent fix — this time because `nixfmt` reordered the maintainer list and flagged our insertion as out of order.
- Root cause: `"zoharbabin" < "zohl"` alphabetically (4th character `a` < `l`), so `zoharbabin` must sort immediately before `zohl`. The insertion script anchored on `zookatron` instead, placing `zoharbabin` *after* `zohl` — wrong order.
- Fix: anchor the perl insertion on `zohl` instead of `zookatron`.

## Test plan
- [x] Verified locally with a representative snippet of `maintainer-list.nix`: after the fix, the three entries (`zoharbabin`, `zohl`, `zookatron`) come out in correct alphabetical order with 2-space indentation preserved (`python3 sorted()` check passes).
- [x] Confirmed `.github/workflows/release.yml` still parses as valid YAML.
- [ ] Will be exercised for real by force-pushing to the existing nixpkgs PR #537807 (via a release re-dispatch) once merged — this can only be verified against nixpkgs' live `treefmt` CI.