### PR TITLE
fix(ci): enable __structuredAttrs for nixpkgs package + sync gen-nixpkgs-pr.sh fixes

### DIFF
--- a/packaging/nixpkgs/package.nix
+++ b/packaging/nixpkgs/package.nix
@@ -7,6 +7,8 @@
 }:
 
 buildGoModule (finalAttrs: {
+  __structuredAttrs = true;
+
   pname = "web-researcher-mcp";
   version = "1.37.3";
 

--- a/scripts/gen-nixpkgs-pr.sh
+++ b/scripts/gen-nixpkgs-pr.sh
@@ -137,10 +137,11 @@ git -C "${NIXPKGS}" config user.name  "web-researcher-mcp-bot"
 git -C "${NIXPKGS}" config user.email "github-actions@users.noreply.github.com"
 
 # Add zoharbabin to maintainers/maintainer-list.nix if not already present.
-# Entries are alphabetical; zoharbabin sorts between zohl and zookatron.
+# Entries are alphabetical; "zoharbabin" < "zohl" (4th char 'a' < 'l'),
+# so it sorts immediately before zohl, not before zookatron.
 MLIST="${NIXPKGS}/maintainers/maintainer-list.nix"
 if ! grep -q 'zoharbabin' "${MLIST}"; then
-  perl -i -0pe 's|(  zookatron = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n  $1|' "${MLIST}"
+  perl -i -0pe 's|(  zohl = \{)|  zoharbabin = \{\n    email = "zohar\@zoharbabin.com";\n    github = "zoharbabin";\n    githubId = 150514;\n    name = "Zohar Babin";\n  };\n$1|' "${MLIST}"
   git -C "${NIXPKGS}" add maintainers/maintainer-list.nix
   log "Added zoharbabin to maintainers/maintainer-list.nix"
 fi
@@ -154,7 +155,10 @@ if [ "${DRY_RUN}" = "--dry-run" ]; then
   exit 0
 fi
 
-git -C "${NIXPKGS}" push "${FORK_REMOTE}" "${BRANCH}" --force-with-lease
+# Plain --force, not --force-with-lease: this is a shallow, fresh clone that
+# never fetched ${BRANCH}, so there's no local tracking ref to lease against.
+# The bot fully owns this branch and always intends to overwrite it.
+git -C "${NIXPKGS}" push "${FORK_REMOTE}" "${BRANCH}" --force
 info "Branch pushed: ${GH_USER}/nixpkgs:${BRANCH}"
 
 # ── 9. Open the PR ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- NixOS/nixpkgs#537807's `Lint / nixpkgs-vet` check failed once `treefmt` was fixed (PRs #363, #365): new by-name packages must opt into `__structuredAttrs = true;` (NPV-166). Fixed in `packaging/nixpkgs/package.nix`, matching the established `buildGoModule` convention (top-level `__structuredAttrs = true;` alongside `env.CGO_ENABLED = 0;` — confirmed against nixpkgs' own `netfoil` package).
- `scripts/gen-nixpkgs-pr.sh` duplicates `release.yml`'s nixpkgs submission logic for local/manual use and had the same two already-fixed bugs (wrong maintainer-list sort anchor, `--force-with-lease` failing on a shallow clone) — ported both fixes over so the two code paths don't drift.

## Test plan
- [x] Verified against real nixpkgs `buildGoModule` packages (`sonar`, `netfoil`) that `__structuredAttrs = true;` as a top-level attribute alongside `env.CGO_ENABLED = 0;` is the standard, working pattern.
- [x] `bash -n scripts/gen-nixpkgs-pr.sh` — syntax OK.
- [ ] Will be exercised for real on the next nixpkgs submission (re-dispatching v1.37.6 again) — `nixpkgs-vet` can only be verified against nixpkgs' live CI.