### PR TITLE
fix(lens): remove dead Lens.Routing field

### DIFF
--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -415,7 +415,6 @@ SEARCH_ROUTING='{"web":"brave,google","news":"brave,serper","images":"google,bra
 - Requests route to the first healthy provider in the priority list
 - If a provider fails (timeout, rate limit, 5xx), the next provider is tried automatically
 - Each provider gets an independent circuit breaker. The routing-layer breakers that govern fallback (web, patent, and academic alike) open after 3 consecutive failures and reset after 30s (`internal/search/router.go`). Domain providers additionally wrap their own upstream HTTP calls in an inner breaker (5 failures / 60s, `internal/search/domain.go`) — a separate, deeper layer, not the effective routing breaker. See those files for the authoritative values.
-- Lenses can override routing via the `"routing"` field in their JSON definition
 
 **Operation types:** `web`, `images`, `news`, `academic`, `patents`, `default`. The `academic` and `patents` lists are filtered to providers that implement the academic/patent interface — `academic` accepts `openalex`, `crossref`, `pubmed`, `semanticscholar`, `exa`; `patents` accepts `searchapi`, `epo`, `lens`, `uspto`. Names that don't implement the interface are silently dropped, so use the example values above.
 

--- a/internal/search/lenses.go
+++ b/internal/search/lenses.go
@@ -14,7 +14,6 @@ type Lens struct {
 	Description string   `json:"description"`
 	Domains     []string `json:"domains"`
 	CX          string   `json:"cx"`
-	Routing     string   `json:"routing,omitempty"`
 	Goggle      string   `json:"goggle,omitempty"`
 }
 

--- a/internal/search/lenses_embed/academic.json
+++ b/internal/search/lenses_embed/academic.json
@@ -13,6 +13,5 @@
     "europepmc.org",
     "jstor.org"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/awesome-lists.json
+++ b/internal/search/lenses_embed/awesome-lists.json
@@ -13,6 +13,5 @@
     "awesome.ecosyste.ms",
     "github.com/bayandin/awesome-awesomeness"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/clinical.json
+++ b/internal/search/lenses_embed/clinical.json
@@ -13,6 +13,5 @@
     "medlineplus.gov",
     "uptodate.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/docs.json
+++ b/internal/search/lenses_embed/docs.json
@@ -27,6 +27,5 @@
     "docs.anthropic.com",
     "platform.openai.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/journalism.json
+++ b/internal/search/lenses_embed/journalism.json
@@ -13,6 +13,5 @@
     "congress.gov",
     "gao.gov"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/osint.json
+++ b/internal/search/lenses_embed/osint.json
@@ -14,6 +14,5 @@
     "github.com",
     "opencorporates.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/internal/search/lenses_embed/security.json
+++ b/internal/search/lenses_embed/security.json
@@ -13,6 +13,5 @@
     "security.googleblog.com",
     "msrc.microsoft.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/README.md
+++ b/lenses/README.md
@@ -10,8 +10,7 @@ A **lens** restricts a `web_search` to a curated set of trusted, authority-weigh
   "description": "One line: what this lens scopes search to.",
   "domains": ["law.cornell.edu", "courtlistener.com", "supremecourt.gov"],
   "cx": "",
-  "goggle": "",
-  "routing": ""
+  "goggle": ""
 }
 ```
 
@@ -22,7 +21,6 @@ A **lens** restricts a `web_search` to a curated set of trusted, authority-weigh
 | `domains` | one of `domains`/`cx`/`goggle` | Hosts injected as `site:` operators (up to 10 used). A host, optionally path-scoped (`github.com/advisories`). No scheme, no spaces. |
 | `cx` | one of `domains`/`cx`/`goggle` | A dedicated Google Programmable Search Engine id. When set, the lens skips `site:` operator injection — the PSE engine is expected to already scope results to the intended domains. The cx value itself must be configured as the global `GOOGLE_CUSTOM_SEARCH_ID`; this field is a documentation signal, not a per-request routing override. |
 | `goggle` | one of `domains`/`cx`/`goggle` | A Brave Goggle URL (`https://` required). When set, the Goggle is passed to the Brave provider for server-side re-ranking. Use with `SEARCH_PROVIDER=brave` or a routing config that includes Brave. See [`programming-goggle.json`](programming-goggle.json) for an example. |
-| `routing` | no | Optional provider routing hint. |
 
 A lens **must** define at least one of `domains`, `cx`, or `goggle` — otherwise it never restricts a search. This is enforced by `search.ValidateLens` (`internal/search/lenses.go`); an invalid lens fails `make validate-lenses`. For custom lenses loaded via `CUSTOM_LENSES_PATH`, an invalid lens also fails startup in HTTP mode (`PORT` set); in STDIO mode it is a warning.
 

--- a/lenses/academic.json
+++ b/lenses/academic.json
@@ -13,6 +13,5 @@
     "europepmc.org",
     "jstor.org"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/awesome-lists.json
+++ b/lenses/awesome-lists.json
@@ -13,6 +13,5 @@
     "awesome.ecosyste.ms",
     "github.com/bayandin/awesome-awesomeness"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/clinical.json
+++ b/lenses/clinical.json
@@ -13,6 +13,5 @@
     "medlineplus.gov",
     "uptodate.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/docs.json
+++ b/lenses/docs.json
@@ -27,6 +27,5 @@
     "docs.anthropic.com",
     "platform.openai.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/journalism.json
+++ b/lenses/journalism.json
@@ -13,6 +13,5 @@
     "congress.gov",
     "gao.gov"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/osint.json
+++ b/lenses/osint.json
@@ -14,6 +14,5 @@
     "github.com",
     "opencorporates.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }

--- a/lenses/security.json
+++ b/lenses/security.json
@@ -13,6 +13,5 @@
     "security.googleblog.com",
     "msrc.microsoft.com"
   ],
-  "cx": "",
-  "routing": ""
+  "cx": ""
 }


### PR DESCRIPTION
## Summary
- `Lens.Routing` was defined, serialized, and documented (`docs/DEPLOYMENT.md`, `lenses/README.md`) as a working provider-routing override, but no Go code path ever read it (confirmed via full-repo grep — `RoutingConfig`/`RoutingDecision`/`RoutingTrace` are a separate, unrelated multi-provider-fallback mechanism).
- Removes the field from the struct, from all 7 bundled lenses that declared it (`"routing": ""` was a no-op everywhere), and corrects both docs that described it as functional.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./internal/search/... ./internal/tools/...` — pass
- [x] `make verify` — full CI gate (vet, lint, gosec, govulncheck, validate-lenses, `-race` test suite, e2e, python-drift dry-run, python tests, build) — all green

Fixes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)