### PR TITLE
feat(search): add sites []string param to web_search for ad hoc multi-domain scoping

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -42,11 +42,12 @@ Perform a web search and return structured result URLs with metadata.
 | `time_range` | string | no | — | `day`, `week`, `month`, `year` |
 | `safe` | string | no | `medium` | `off`, `medium`, `high` |
 | `language` | string | no | — | ISO 639-1 code |
-| `site` | string | no | — | Domain restriction (cannot combine with `lens`) |
+| `site` | string | no | — | Single-domain restriction (cannot combine with `sites`) |
+| `sites` | []string | no | — | Multi-domain restriction, OR-joined into `site:` operators (up to 10; cannot combine with `site`) |
 | `exact_terms` | string | no | — | Exact phrase match |
 | `exclude_terms` | string | no | — | Terms to exclude |
 | `country` | string | no | — | ISO 3166-1 alpha-2 |
-| `lens` | string | no | — | Domain lens (overrides `site`). See `lenses/` directory for available lenses |
+| `lens` | string | no | — | Domain lens (overrides `site`/`sites`). See `lenses/` directory for available lenses |
 | `provider` | string | no | — | Force search provider. Returns error listing available providers if unknown |
 | `sessionId` | string | no | — | Link results to a `sequential_search` session |
 | `claim` | string | no | — | Optional claim to evaluate against each result's snippet; when set, each result gains a `claimSignal` (#66). Evidence only — never a verdict |
@@ -78,15 +79,16 @@ type SearchResult struct {
 
 `publishedAt` (#356) is **optional and provider-dependent**, populated only by providers whose web response carries a date signal (Google via pagemap metadata, Tavily, Exa, SearXNG, HackerNews) and omitted (never guessed from snippet/title text) for providers that don't (Brave, Serper, DuckDuckGo, SearchAPI). When present it is normalized to RFC3339 UTC regardless of the provider's raw format.
 
-On a zero-result response, `hints` carries a `ZeroResultHints` object (the same shape `academic_search` and `patent_search` emit) explaining why nothing matched and how to recover: `reason` (`no_match` | `filters_too_restrictive`), `filtersApplied` (the constraints that may have eliminated results — `site`, `lens`, `time_range`, `country`, `language`, `exact_terms`, `exclude_terms`), `suggestedActions` (remove-filter / try-different-provider), and `epistemicWarning` (#357: a fixed reminder that zero results do not confirm absence — the fact may exist and simply be unreachable by the current query/provider; never assert non-existence from an empty result set). Suggested alternative providers are limited to those **configured and currently healthy**. On any non-empty result set the field is omitted.
+On a zero-result response, `hints` carries a `ZeroResultHints` object (the same shape `academic_search` and `patent_search` emit) explaining why nothing matched and how to recover: `reason` (`no_match` | `filters_too_restrictive`), `filtersApplied` (the constraints that may have eliminated results — `site`, `sites`, `lens`, `time_range`, `country`, `language`, `exact_terms`, `exclude_terms`), `suggestedActions` (remove-filter / try-different-provider), and `epistemicWarning` (#357: a fixed reminder that zero results do not confirm absence — the fact may exist and simply be unreachable by the current query/provider; never assert non-existence from an empty result set). Suggested alternative providers are limited to those **configured and currently healthy**. On any non-empty result set the field is omitted.
 
 ### Behavior
 
 1. If `SEARCH_ROUTING` is set, route through the multi-provider Router (priority-ordered fallback with per-provider circuit breakers).
 2. If `lens` is specified and has a dedicated `cx`, route directly to that Google PSE engine.
 3. If `lens` is specified without `cx`, inject `site:` operators and route to the configured provider.
-4. Apply `time_range` as date restriction parameter.
-5. Return deduplicated URLs and full result objects.
+4. `site` and `sites` are mutually exclusive — combining them returns an error. `sites` entries are validated (bare host, optional path prefix — no scheme, no whitespace) and OR-joined into a single `site:` group, capped at 10 domains; exceeding the cap returns an error rather than silently truncating. A `lens` overrides both.
+5. Apply `time_range` as date restriction parameter.
+6. Return deduplicated URLs and full result objects.
 
 ### Cache
 - Key: SHA-256 of (provider + query + all params)

--- a/internal/search/google.go
+++ b/internal/search/google.go
@@ -285,10 +285,17 @@ type googleImage struct {
 	Height        int    `json:"height"`
 }
 
+// buildQuery is the single chokepoint that turns Site/Sites into query-text
+// site: operators for every provider that funnels its query through it
+// (google, brave, serper, searxng, searchapi, duckduckgo, tavily, exa).
+// Site and Sites are mutually exclusive by the time params reaches here (the
+// tool layer enforces it), so at most one branch ever fires.
 func buildQuery(params WebSearchParams) string {
 	query := params.Query
 	if params.Site != "" {
 		query += " site:" + params.Site
+	} else if len(params.Sites) > 0 {
+		query = BuildSitesQuery(query, params.Sites)
 	}
 	return query
 }

--- a/internal/search/lenses.go
+++ b/internal/search/lenses.go
@@ -55,15 +55,26 @@ func ValidateLens(lens *Lens, source string) error {
 		return fmt.Errorf("lens %q (%s): goggle must be an https:// URL", lens.Name, source)
 	}
 	for i, d := range lens.Domains {
-		if strings.TrimSpace(d) == "" {
-			return fmt.Errorf("lens %q (%s): domains[%d] is empty", lens.Name, source, i)
+		if err := ValidateSiteDomain(d); err != nil {
+			return fmt.Errorf("lens %q (%s): domains[%d]: %w", lens.Name, source, i, err)
 		}
-		// A site: operator value: a host, optionally with a path prefix
-		// (e.g. "github.com/advisories" is a valid path-scoped site: filter).
-		// Reject a scheme or whitespace — those break the injected `site:` operator.
-		if strings.Contains(d, "://") || strings.ContainsAny(d, " \t") {
-			return fmt.Errorf("lens %q (%s): domain %q must be a bare host or host/path (e.g. \"example.com\" or \"example.com/section\"), not a URL with a scheme", lens.Name, source, d)
-		}
+	}
+	return nil
+}
+
+// ValidateSiteDomain checks a single site: operator value — a bare host,
+// optionally with a path prefix (e.g. "github.com/advisories" is a valid
+// path-scoped site: filter). Rejects a scheme or whitespace, since either
+// would break the injected `site:` operator once concatenated into a query
+// string. Shared by lens domain validation (ValidateLens) and the ad hoc
+// `sites` param on web_search (#374), so both paths reject a malformed entry
+// with the same message instead of one being silently permissive.
+func ValidateSiteDomain(d string) error {
+	if strings.TrimSpace(d) == "" {
+		return fmt.Errorf("must not be empty")
+	}
+	if strings.Contains(d, "://") || strings.ContainsAny(d, " \t") {
+		return fmt.Errorf("%q must be a bare host or host/path (e.g. \"example.com\" or \"example.com/section\"), not a URL with a scheme", d)
 	}
 	return nil
 }
@@ -135,19 +146,33 @@ func (lr *LensRegistry) List() []string {
 }
 
 func (lr *LensRegistry) BuildSiteQuery(query string, lens *Lens) string {
-	if len(lens.Domains) == 0 {
+	return BuildSitesQuery(query, lens.Domains)
+}
+
+// MaxSiteDomains caps how many domains a single OR-joined site: group may
+// contain — shared by lens domain injection (BuildSiteQuery) and the ad hoc
+// `sites` param on web_search (#374), so both paths bound query length/
+// complexity identically instead of one being unbounded.
+const MaxSiteDomains = 10
+
+// BuildSitesQuery appends an OR-joined group of site: operators — one per
+// domain, capped at MaxSiteDomains — to query. Returns query unchanged when
+// domains is empty. This is the shared OR-join primitive behind both
+// LensRegistry.BuildSiteQuery (file-defined lenses) and the `sites []string`
+// param on web_search (ad hoc, caller-supplied domains, #374).
+func BuildSitesQuery(query string, domains []string) string {
+	if len(domains) == 0 {
 		return query
 	}
 
-	// Use up to 10 domains in site: operators
-	maxDomains := 10
-	if len(lens.Domains) < maxDomains {
-		maxDomains = len(lens.Domains)
+	maxDomains := MaxSiteDomains
+	if len(domains) < maxDomains {
+		maxDomains = len(domains)
 	}
 
 	siteOps := make([]string, maxDomains)
 	for i := 0; i < maxDomains; i++ {
-		siteOps[i] = "site:" + lens.Domains[i]
+		siteOps[i] = "site:" + domains[i]
 	}
 
 	return query + " (" + strings.Join(siteOps, " OR ") + ")"

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -16,6 +16,7 @@ type WebSearchParams struct {
 	Language     string
 	Country      string
 	Site         string
+	Sites        []string // ad hoc multi-domain scoping, OR-joined into site: operators by buildQuery (#374); mutually exclusive with Site at the tool boundary
 	ExactTerms   string
 	ExcludeTerms string
 	Offset       int      // pagination offset (provider-specific, ignored when 0)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -920,12 +920,49 @@ func TestBuildQuery(t *testing.T) {
 	}{
 		{WebSearchParams{Query: "hello"}, "hello"},
 		{WebSearchParams{Query: "hello", Site: "example.com"}, "hello site:example.com"},
+		{WebSearchParams{Query: "hello", Sites: []string{"example.com"}}, "hello (site:example.com)"},
+		{WebSearchParams{Query: "hello", Sites: []string{"example.com", "github.com"}}, "hello (site:example.com OR site:github.com)"},
+		// Site takes precedence when both are set (the tool layer rejects this
+		// combination before it reaches here; this only pins buildQuery's own
+		// fallback order in case that guard is ever bypassed).
+		{WebSearchParams{Query: "hello", Site: "example.com", Sites: []string{"github.com"}}, "hello site:example.com"},
 	}
 	for _, tt := range tests {
 		got := buildQuery(tt.params)
 		if got != tt.expected {
 			t.Errorf("buildQuery(%+v) = %q, want %q", tt.params, got, tt.expected)
 		}
+	}
+}
+
+func TestBuildSitesQuery(t *testing.T) {
+	tests := []struct {
+		query    string
+		domains  []string
+		expected string
+	}{
+		{"hello", nil, "hello"},
+		{"hello", []string{}, "hello"},
+		{"hello", []string{"example.com"}, "hello (site:example.com)"},
+		{"hello", []string{"example.com", "github.com"}, "hello (site:example.com OR site:github.com)"},
+	}
+	for _, tt := range tests {
+		got := BuildSitesQuery(tt.query, tt.domains)
+		if got != tt.expected {
+			t.Errorf("BuildSitesQuery(%q, %v) = %q, want %q", tt.query, tt.domains, got, tt.expected)
+		}
+	}
+
+	// Cap enforcement: more than MaxSiteDomains domains still produces a valid
+	// query using only the first MaxSiteDomains entries.
+	many := make([]string, MaxSiteDomains+5)
+	for i := range many {
+		many[i] = fmt.Sprintf("d%d.com", i)
+	}
+	got := BuildSitesQuery("hello", many)
+	count := strings.Count(got, "site:")
+	if count != MaxSiteDomains {
+		t.Errorf("BuildSitesQuery with %d domains produced %d site: operators, want %d", len(many), count, MaxSiteDomains)
 	}
 }
 

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -326,6 +326,9 @@ func buildWebHints(input webSearchInput, provider string, alternatives []string)
 	if input.Site != "" {
 		filters["site"] = input.Site
 	}
+	if len(input.Sites) > 0 {
+		filters["sites"] = strings.Join(input.Sites, ",")
+	}
 	if input.Lens != "" {
 		filters["lens"] = input.Lens
 	}

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -35,19 +35,20 @@ const (
 )
 
 type webSearchInput struct {
-	Query        string `json:"query" jsonschema:"The search query text (1-500 chars). Be specific with key terms and qualifiers for better results.,required"`
-	NumResults   int    `json:"num_results,omitempty" jsonschema:"Number of results to return (1-10). Default: 5. Higher values increase latency."`
-	TimeRange    string `json:"time_range,omitempty" jsonschema:"Restrict to a time period: day, week, month, or year. Omit for all-time results."`
-	Safe         string `json:"safe,omitempty" jsonschema:"SafeSearch level: off, medium (default), or high."`
-	Language     string `json:"language,omitempty" jsonschema:"Filter by language using ISO 639-1 code (e.g. en, fr, de)."`
-	Site         string `json:"site,omitempty" jsonschema:"Restrict to a single domain (e.g. stackoverflow.com). Cannot combine with lens."`
-	ExactTerms   string `json:"exact_terms,omitempty" jsonschema:"Phrase that must appear verbatim in results."`
-	ExcludeTerms string `json:"exclude_terms,omitempty" jsonschema:"Terms to exclude from results (space-separated)."`
-	Country      string `json:"country,omitempty" jsonschema:"Restrict to a country using ISO 3166-1 alpha-2 code (e.g. US, GB)."`
-	Lens         string `json:"lens,omitempty" jsonschema:"Focus your search on trusted sites in a specific field: docs, academic, academic-extended, clinical, security, journalism, programming, devops, news, tech, legal, medical, finance, science, government, awesome-lists. Only one lens can be active at a time (overrides the site parameter)."`
-	Provider     string `json:"provider,omitempty" jsonschema:"Choose which search engine to use for this query: google, brave, serper, searxng, searchapi, duckduckgo, tavily, exa, hackernews. Leave empty to use the default. Returns an error if the chosen provider isn't set up."`
-	SessionID    string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded in the session for recovery after context loss."`
-	Claim        string `json:"claim,omitempty" jsonschema:"Optional claim to evaluate against each result's snippet. When set, each result gains a claimSignal (the most claim-relevant snippet sentence) to help triage which links to read; for full-text evidence use search_and_scrape with claim. Evidence only — the server never decides supports/contradicts."`
+	Query        string   `json:"query" jsonschema:"The search query text (1-500 chars). Be specific with key terms and qualifiers for better results.,required"`
+	NumResults   int      `json:"num_results,omitempty" jsonschema:"Number of results to return (1-10). Default: 5. Higher values increase latency."`
+	TimeRange    string   `json:"time_range,omitempty" jsonschema:"Restrict to a time period: day, week, month, or year. Omit for all-time results."`
+	Safe         string   `json:"safe,omitempty" jsonschema:"SafeSearch level: off, medium (default), or high."`
+	Language     string   `json:"language,omitempty" jsonschema:"Filter by language using ISO 639-1 code (e.g. en, fr, de)."`
+	Site         string   `json:"site,omitempty" jsonschema:"Restrict to a single domain (e.g. stackoverflow.com). Cannot combine with sites."`
+	Sites        []string `json:"sites,omitempty" jsonschema:"Restrict to a set of domains (up to 10, OR-joined), e.g. [\"stackoverflow.com\", \"github.com\"]. Cannot combine with site."`
+	ExactTerms   string   `json:"exact_terms,omitempty" jsonschema:"Phrase that must appear verbatim in results."`
+	ExcludeTerms string   `json:"exclude_terms,omitempty" jsonschema:"Terms to exclude from results (space-separated)."`
+	Country      string   `json:"country,omitempty" jsonschema:"Restrict to a country using ISO 3166-1 alpha-2 code (e.g. US, GB)."`
+	Lens         string   `json:"lens,omitempty" jsonschema:"Focus your search on trusted sites in a specific field: docs, academic, academic-extended, clinical, security, journalism, programming, devops, news, tech, legal, medical, finance, science, government, awesome-lists. Only one lens can be active at a time (overrides the site/sites parameters)."`
+	Provider     string   `json:"provider,omitempty" jsonschema:"Choose which search engine to use for this query: google, brave, serper, searxng, searchapi, duckduckgo, tavily, exa, hackernews. Leave empty to use the default. Returns an error if the chosen provider isn't set up."`
+	SessionID    string   `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded in the session for recovery after context loss."`
+	Claim        string   `json:"claim,omitempty" jsonschema:"Optional claim to evaluate against each result's snippet. When set, each result gains a claimSignal (the most claim-relevant snippet sentence) to help triage which links to read; for full-text evidence use search_and_scrape with claim. Evidence only — the server never decides supports/contradicts."`
 }
 
 func registerWebSearch(srv *mcp.Server, deps Dependencies) {
@@ -66,6 +67,19 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 		if len(input.Query) > 500 {
 			return toolError("query must be 500 characters or less"), nil, nil
 		}
+		if input.Site != "" && len(input.Sites) > 0 {
+			return toolError("site and sites cannot be combined — use one or the other"), nil, nil
+		}
+		if len(input.Sites) > 0 {
+			if len(input.Sites) > search.MaxSiteDomains {
+				return toolError(fmt.Sprintf("sites accepts at most %d domains", search.MaxSiteDomains)), nil, nil
+			}
+			for i, d := range input.Sites {
+				if err := search.ValidateSiteDomain(d); err != nil {
+					return toolError(fmt.Sprintf("sites[%d]: %s", i, err)), nil, nil
+				}
+			}
+		}
 
 		numResults := input.NumResults
 		if numResults <= 0 {
@@ -79,7 +93,7 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 		// importantly the provider, so two providers queried with the same terms
 		// do not collide and serve each other's cached results (idempotency +
 		// consistency across calls).
-		cacheKey := searchCacheKey("web", input.Query, numResults, input.TimeRange, input.Safe, input.Language, input.Site, input.Lens, input.Provider, input.ExactTerms, input.ExcludeTerms, input.Country, input.Claim)
+		cacheKey := searchCacheKey("web", input.Query, numResults, input.TimeRange, input.Safe, input.Language, input.Site, strings.Join(input.Sites, ","), input.Lens, input.Provider, input.ExactTerms, input.ExcludeTerms, input.Country, input.Claim)
 		if cached, meta, ok := deps.Cache.GetWithMeta(ctx, cacheKey); ok {
 			deps.Metrics.RecordToolCall("web_search", time.Since(start), nil, "", true)
 			rt := routingMeta(search.RoutingDecision{}, time.Since(start), true)
@@ -95,6 +109,7 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 			Language:     input.Language,
 			Country:      input.Country,
 			Site:         input.Site,
+			Sites:        input.Sites,
 			ExactTerms:   input.ExactTerms,
 			ExcludeTerms: input.ExcludeTerms,
 		}
@@ -106,13 +121,14 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 				return toolError(fmt.Sprintf("unknown lens: %s. Available: %v", input.Lens, registry.List())), nil, nil
 			}
 
-			// A lens OVERRIDES the site parameter (per the schema contract): the
-			// lens already scopes the search to its own domain set, so a sibling
-			// site: filter would AND with it and over-constrain to nothing. Clear
-			// it on BOTH paths — the CX engine is itself the scope, the Goggle
-			// re-ranks server-side at Brave, and the operator-injection path bakes
-			// the lens domains into the query.
+			// A lens OVERRIDES the site/sites parameters (per the schema contract):
+			// the lens already scopes the search to its own domain set, so a
+			// sibling site: filter would AND with it and over-constrain to nothing.
+			// Clear both on BOTH paths — the CX engine is itself the scope, the
+			// Goggle re-ranks server-side at Brave, and the operator-injection path
+			// bakes the lens domains into the query.
 			params.Site = ""
+			params.Sites = nil
 			if lensData.CX != "" {
 				params.Query = input.Query
 			} else {

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -419,6 +419,160 @@ func TestWebSearchLensOverridesSite(t *testing.T) {
 	}
 }
 
+// TestWebSearchSitesSingle verifies a single-domain sites param OR-joins into
+// the same site: operator shape BuildSitesQuery produces (#374).
+func TestWebSearchSitesSingle(t *testing.T) {
+	ctx := context.Background()
+	cap := &captureProvider{}
+	deps := setupTestDeps()
+	deps.Search = cap
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "golang", "sites": []string{"stackoverflow.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if len(cap.last.Sites) != 1 || cap.last.Sites[0] != "stackoverflow.com" {
+		t.Errorf("expected Sites=[stackoverflow.com], got %v", cap.last.Sites)
+	}
+}
+
+// TestWebSearchSitesMultipleORJoined verifies multiple domains land in
+// WebSearchParams.Sites and buildQuery OR-joins them into the query text.
+func TestWebSearchSitesMultipleORJoined(t *testing.T) {
+	ctx := context.Background()
+	cap := &captureProvider{}
+	deps := setupTestDeps()
+	deps.Search = cap
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "golang", "sites": []string{"stackoverflow.com", "github.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if len(cap.last.Sites) != 2 {
+		t.Fatalf("expected 2 sites, got %v", cap.last.Sites)
+	}
+}
+
+// TestWebSearchSiteAndSitesRejected guards the mutual-exclusivity contract:
+// site and sites are alternative ways to scope a search, never both at once.
+func TestWebSearchSiteAndSitesRejected(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "golang", "site": "example.com", "sites": []string{"github.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error when combining site and sites")
+	}
+}
+
+// TestWebSearchSitesMalformedRejected guards ValidateSiteDomain enforcement:
+// a scheme or whitespace in a sites entry would break the injected site:
+// operator, so it must be rejected before reaching a provider.
+func TestWebSearchSitesMalformedRejected(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "golang", "sites": []string{"https://example.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error for a sites entry with a scheme")
+	}
+}
+
+// TestWebSearchSitesCapEnforced guards MaxSiteDomains: more than the cap must
+// be rejected outright rather than silently truncated, so a caller notices
+// instead of getting a narrower search than they asked for.
+func TestWebSearchSitesCapEnforced(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	tooMany := make([]string, search.MaxSiteDomains+1)
+	for i := range tooMany {
+		tooMany[i] = fmt.Sprintf("example%d.com", i)
+	}
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "golang", "sites": tooMany},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error when sites exceeds MaxSiteDomains")
+	}
+}
+
+// TestWebSearchLensOverridesSites mirrors TestWebSearchLensOverridesSite for
+// the new sites param: a lens must clear Sites too, not just Site.
+func TestWebSearchLensOverridesSites(t *testing.T) {
+	ctx := context.Background()
+	if err := search.GetLensRegistry().LoadEmbedded(); err != nil {
+		t.Fatalf("load embedded lenses: %v", err)
+	}
+	cap := &captureProvider{}
+	deps := setupTestDeps()
+	deps.Search = cap
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "ransomware", "lens": "security", "sites": []string{"example.com"}},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if len(cap.last.Sites) != 0 {
+		t.Errorf("lens must clear params.Sites, got %v", cap.last.Sites)
+	}
+	if strings.Contains(cap.last.Query, "example.com") {
+		t.Errorf("the overridden sites filter must not appear, got %q", cap.last.Query)
+	}
+}
+
 func TestWebSearchLongQuery(t *testing.T) {
 	ctx := context.Background()
 	deps := setupTestDeps()

--- a/python/web_researcher_mcp/client.py
+++ b/python/web_researcher_mcp/client.py
@@ -894,6 +894,7 @@ class WebResearcherClient:
         safe: str = None,
         sessionId: str = None,
         site: str = None,
+        sites: Optional[list] = None,
         time_range: str = None,
     ) -> WebSearchResponse:
         """Search the web and get a list of relevant pages with titles and snippets — without reading the full page content"""
@@ -912,6 +913,7 @@ class WebResearcherClient:
                 "safe": safe,
                 "sessionId": sessionId,
                 "site": site,
+                "sites": sites,
                 "time_range": time_range,
             },
         )
@@ -1637,6 +1639,7 @@ class SyncWebResearcherClient:
         safe: str = None,
         sessionId: str = None,
         site: str = None,
+        sites: Optional[list] = None,
         time_range: str = None,
     ) -> WebSearchResponse:
         return self._run(
@@ -1653,6 +1656,7 @@ class SyncWebResearcherClient:
             safe=safe,
             sessionId=sessionId,
             site=site,
+            sites=sites,
             time_range=time_range,
             )
         )


### PR DESCRIPTION
## Summary
- Adds a `sites []string` param to `web_search`, alongside the existing single-domain `site` param, for ad hoc multi-domain scoping without needing a curated lens.
- New shared primitives in `internal/search/lenses.go`: `ValidateSiteDomain` (per-domain validation), `BuildSitesQuery` (OR-join, capped at `MaxSiteDomains = 10`) — reused by both lens domain injection and the new `sites` param, so neither duplicates the other's logic.
- `buildQuery` (the shared chokepoint used by google/serper/searxng/searchapi/duckduckgo/tavily/exa) now OR-joins `Sites` the same way it already handles `Site`.
- `site` and `sites` are mutually exclusive — combining them is rejected with a validation error. A `lens` still overrides both (matches the existing `site`+`lens` precedent, unchanged).
- `sites` entries are validated (bare host, optional path prefix — no scheme, no whitespace) and rejected outright (not silently truncated) if the domain count exceeds the cap.
- Updated `docs/TOOLS.md` Tool 1 (`web_search`) section; regenerated the Python client (`make gen-python-client`).

## Test plan
- [x] New unit tests: single site via `sites`, multiple sites OR-joined, `site`+`sites` mutual-exclusivity rejection, malformed-domain rejection, cap enforcement, lens overrides `sites` (mirrors the existing lens-overrides-`site` test) — `internal/tools/tools_test.go`
- [x] New `internal/search` tests for `buildQuery`/`BuildSitesQuery` (single domain, multiple OR-joined, cap enforcement, `site` takes precedence when both set) — `internal/search/search_test.go`
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go tool golangci-lint run` — 0 issues
- [x] `make sec` (gosec) — clean
- [x] `go tool govulncheck ./...` — no vulnerabilities found
- [x] `make validate-lenses`
- [x] `go test -race ./...` — all packages pass
- [x] `make test-e2e`
- [x] `make check-python-drift` — clean
- [x] `make test-python` — 71 passed

Fixes #374