### PR TITLE
fix(search): set a descriptive User-Agent for ecosyste.ms requests

### DIFF
--- a/internal/search/ecosystems_awesome.go
+++ b/internal/search/ecosystems_awesome.go
@@ -162,16 +162,36 @@ func sortAwesomeLists(results []AwesomeListResult, sortBy string) {
 	}
 }
 
+// userAgent mirrors the crossref.go/retraction.go convention: embed the
+// contact email in parens when configured, matching ecosyste.ms's own
+// documented "polite" example (User-Agent: MyApp/1.0 (contact: you@example.com)).
+func (e *EcosystemsAwesomeProvider) userAgent() string {
+	if e.email == "" {
+		return "web-researcher-mcp/1.0"
+	}
+	return "web-researcher-mcp/1.0 (mailto:" + e.email + ")"
+}
+
 func (e *EcosystemsAwesomeProvider) get(ctx context.Context, path string) ([]byte, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", e.baseURL+path, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
-	// ecosyste.ms's edge WAF 429s Go's default User-Agent regardless of actual
-	// quota remaining; any descriptive UA passes. mailto is already sent as a
-	// query param (doSearch), so it isn't repeated here.
-	req.Header.Set("User-Agent", "web-researcher-mcp/1.0")
+	// Two independent gates in front of ecosyste.ms, both confirmed by direct
+	// curl A/B testing (varying only the header under test):
+	//  1. A literal-string block on Go's default "Go-http-client/*" User-Agent
+	//     — 429s even at the "polite" tier with >99% of quota remaining. Any
+	//     other UA string, descriptive or not, passes this gate.
+	//  2. The APISIX conditional-rate-limit.lua plugin, which classifies a
+	//     request "polite" (15,000/period) vs. "anonymous" (5,000/period)
+	//     based on an email-shaped string in the mailto param OR the
+	//     User-Agent header. mailto is already sent as a query param
+	//     (doSearch) and alone is sufficient for tier classification — the
+	//     email mirrored into the UA here is a second, redundant signal for
+	//     gate 2, matching ecosyste.ms's own documented example format, not a
+	//     workaround for gate 1.
+	req.Header.Set("User-Agent", e.userAgent())
 	if e.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+e.apiKey) // never logged
 	}

--- a/internal/search/ecosystems_awesome.go
+++ b/internal/search/ecosystems_awesome.go
@@ -168,6 +168,10 @@ func (e *EcosystemsAwesomeProvider) get(ctx context.Context, path string) ([]byt
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
+	// ecosyste.ms's edge WAF 429s Go's default User-Agent regardless of actual
+	// quota remaining; any descriptive UA passes. mailto is already sent as a
+	// query param (doSearch), so it isn't repeated here.
+	req.Header.Set("User-Agent", "web-researcher-mcp/1.0")
 	if e.apiKey != "" {
 		req.Header.Set("Authorization", "Bearer "+e.apiKey) // never logged
 	}

--- a/internal/search/ecosystems_awesome_test.go
+++ b/internal/search/ecosystems_awesome_test.go
@@ -64,6 +64,22 @@ func TestEcosystemsAwesomeSendsMailtoWhenConfigured(t *testing.T) {
 	}
 }
 
+func TestEcosystemsAwesomeSendsDescriptiveUserAgent(t *testing.T) {
+	// ecosyste.ms's edge WAF 429s Go's default "Go-http-client/*" User-Agent
+	// regardless of quota remaining; a descriptive UA is required to pass.
+	var gotUA string
+	p := newEcosystemsTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Write([]byte(`[]`))
+	})
+	if _, err := p.AwesomeLists(context.Background(), AwesomeListSearchParams{Topic: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.HasPrefix(gotUA, "web-researcher-mcp/") {
+		t.Errorf("User-Agent = %q, want a descriptive UA (not Go's default)", gotUA)
+	}
+}
+
 func TestEcosystemsAwesomeOmitsMailtoWhenUnset(t *testing.T) {
 	p := newEcosystemsTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Has("mailto") {

--- a/internal/search/ecosystems_awesome_test.go
+++ b/internal/search/ecosystems_awesome_test.go
@@ -65,8 +65,10 @@ func TestEcosystemsAwesomeSendsMailtoWhenConfigured(t *testing.T) {
 }
 
 func TestEcosystemsAwesomeSendsDescriptiveUserAgent(t *testing.T) {
-	// ecosyste.ms's edge WAF 429s Go's default "Go-http-client/*" User-Agent
-	// regardless of quota remaining; a descriptive UA is required to pass.
+	// ecosyste.ms hard-blocks the literal string "Go-http-client/*" with a
+	// 429 regardless of rate-limit tier or quota remaining (confirmed via
+	// direct curl A/B testing); any other User-Agent, descriptive or not,
+	// passes this specific gate.
 	var gotUA string
 	p := newEcosystemsTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
 		gotUA = r.Header.Get("User-Agent")
@@ -77,6 +79,26 @@ func TestEcosystemsAwesomeSendsDescriptiveUserAgent(t *testing.T) {
 	}
 	if !strings.HasPrefix(gotUA, "web-researcher-mcp/") {
 		t.Errorf("User-Agent = %q, want a descriptive UA (not Go's default)", gotUA)
+	}
+}
+
+func TestEcosystemsAwesomeEmbedsEmailInUserAgentWhenConfigured(t *testing.T) {
+	// ecosyste.ms's APISIX tier classifier detects an email in the mailto
+	// param OR the User-Agent header. mailto is already sent (see
+	// TestEcosystemsAwesomeSendsMailtoWhenConfigured) and is sufficient on
+	// its own for polite-tier classification; mirroring it into the UA too
+	// matches ecosyste.ms's own documented example verbatim ("User-Agent:
+	// MyApp/1.0 (contact: user@example.com)") as a redundant second signal.
+	var gotUA string
+	p := newEcosystemsTestProviderWithAuth(t, "", "you@example.com", func(w http.ResponseWriter, r *http.Request) {
+		gotUA = r.Header.Get("User-Agent")
+		w.Write([]byte(`[]`))
+	})
+	if _, err := p.AwesomeLists(context.Background(), AwesomeListSearchParams{Topic: "x"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(gotUA, "you@example.com") {
+		t.Errorf("User-Agent = %q, want it to contain the configured email", gotUA)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Live IRL testing of yesterday's `ECOSYSTEMS_EMAIL` polite-pool change (#380) surfaced a real bug: ecosyste.ms 429s Go's default `User-Agent` (`Go-http-client/2.0`/`1.1`) — every real request from this binary was silently blocked, regardless of quota.
- **Root cause, confirmed against ecosyste.ms's own published source** (`ecosyste-ms/ecosystems-go` client, `ecosyste-ms/conditional-rate-limit.lua` APISIX plugin) and independent curl A/B testing — there are two separate gates, not one:
  1. **A hard block on the literal string `Go-http-client/*`** — verified via curl to 429 even at the `polite` tier with 99%+ of quota remaining. Any other User-Agent string, descriptive or not, passes. This is the actual fix.
  2. **The APISIX tier classifier** (`conditional-rate-limit.lua`, public source) grants the `polite` tier (15,000/period vs. `anonymous` 5,000/period) when it detects an email-shaped string in the `mailto` query param **or** the `User-Agent` header. `mailto=` (already sent since #380) is sufficient on its own for this — confirmed live. Embedding the email into the UA too is a redundant second signal that matches ecosyste.ms's own documented example format (`User-Agent: MyApp/1.0 (contact: user@example.com)`) — not itself a fix for gate 1.
- Changes: set a non-Go descriptive `User-Agent` unconditionally (fixes gate 1, the real bug); when an email is configured, embed it in the UA in parens, matching the `crossref.go`/`retraction.go` convention already used elsewhere in this codebase (redundant-but-correct for gate 2).
- My first pass at this PR mischaracterized gate 1 as a "Cloudflare edge WAF" — corrected the code comments to describe both gates precisely, backed by the actual public source of the classifier and curl-verified behavior, not speculation.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l .` clean
- [x] `go test -race ./...` — all packages pass
- [x] `go tool golangci-lint run ./internal/search/...` — 0 issues
- [x] `go test ./internal/tools/... -run 'TestToolsDocMatchesRegistry|TestProvidersDocStructuredDomainTable|TestAllToolsHaveAnnotations'` — docs-drift gates pass
- [x] Live curl A/B against `awesome.ecosyste.ms`: `Go-http-client/*` → 429 at any tier; `mailto=` alone → `polite` tier (confirms gate 2 already worked via #380); email embedded in UA → also `polite` tier, confirming redundancy claim
- [x] New unit tests: `TestEcosystemsAwesomeSendsDescriptiveUserAgent`, `TestEcosystemsAwesomeEmbedsEmailInUserAgentWhenConfigured`
- [x] Full STDIO round-trip through the real installed binary using production MCP config — 4 live topic queries + 7 edge cases, all correct