### PR TITLE
fix(search): recognize ecosystems: prefix in extractProviderName

### DIFF
--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -176,7 +176,7 @@ func scrapeErrorToToolError(se *scraper.ScrapeError) ToolError {
 // extractProviderName attempts to extract the provider name from an error string.
 func extractProviderName(err error) string {
 	s := err.Error()
-	for _, prefix := range []string{"google:", "brave:", "serper:", "searxng:", "searchapi:", "lens:", "uspto:", "epo:", "openalex:", "crossref:"} {
+	for _, prefix := range []string{"google:", "brave:", "serper:", "searxng:", "searchapi:", "lens:", "uspto:", "epo:", "openalex:", "crossref:", "ecosystems:"} {
 		if strings.HasPrefix(s, prefix[:len(prefix)-1]) || strings.Contains(s, prefix) {
 			return prefix[:len(prefix)-1]
 		}

--- a/internal/tools/ratelimit_test.go
+++ b/internal/tools/ratelimit_test.go
@@ -80,6 +80,33 @@ func TestIsRateLimitError(t *testing.T) {
 }
 
 // =============================================================================
+// extractProviderName prefix matching
+// =============================================================================
+
+func TestExtractProviderName(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name   string
+		err    error
+		expect string
+	}{
+		{"ecosystems rate limited", fmt.Errorf("ecosystems: rate limited"), "ecosystems"},
+		{"ecosystems api error", fmt.Errorf("ecosystems: API error 429: too many requests"), "ecosystems"},
+		{"google prefix", fmt.Errorf("google: quota exceeded"), "google"},
+		{"unknown provider", fmt.Errorf("connection timeout"), ""},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := extractProviderName(tc.err)
+			if got != tc.expect {
+				t.Errorf("extractProviderName(%v) = %q, want %q", tc.err, got, tc.expect)
+			}
+		})
+	}
+}
+
+// =============================================================================
 // rateLimitError response format
 // =============================================================================
 


### PR DESCRIPTION
## Summary
- `extractProviderName()` had no `ecosystems:` entry, so rate-limit/upstream error messages from the ecosyste.ms Awesome-list provider rendered as `Rate limited ()` instead of `Rate limited (ecosystems)`.
- Found while live-verifying PR #381 (ecosystems User-Agent fix) and PR #382 (rebuild-local path fix) after merge.

## Changes
- Added `"ecosystems:"` to the prefix allowlist in `internal/tools/errors.go`.
- Added `TestExtractProviderName` covering the new prefix plus a couple of existing ones for regression safety.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` — all packages pass
- [x] `go tool golangci-lint run internal/tools/...` — 0 issues
- [x] New `TestExtractProviderName` passes, including `ecosystems: rate limited` → `ecosystems`