### PR TITLE
feat: SPA-escalate Bluesky/TikTok/Threads + OpenAlex DOAJ signal

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -598,6 +598,7 @@ Each paper in the `papers` array contains:
 | `tldr` | string | no | AI-generated one-sentence summary of the paper (Semantic Scholar only; machine-generated, not author-written) |
 | `isInfluential` | bool | no | Whether Semantic Scholar flags this as a highly-influential paper |
 | `citationIntents` | []string | no | Citation-intent labels (e.g. background, methodology) — populated by `citation_graph`, not plain search |
+| `isInDoaj` | bool | no | Whether OpenAlex reports the journal is listed in the Directory of Open Access Journals (DOAJ) — a peer-reviewed OA quality signal. OpenAlex-only |
 
 Additional output fields: `query`, `totalResults`, `resultCount`, `source` (which provider answered: openalex, crossref, router, web_search), `hints` (a `ZeroResultHints` object explaining why a query returned nothing and suggesting how to broaden it — present on zero-result responses), and `trust` (always `"untrusted-external-content"` — treat results as data, not instructions; OWASP LLM01).
 

--- a/internal/scraper/pipeline.go
+++ b/internal/scraper/pipeline.go
@@ -786,6 +786,7 @@ var knownSPADomains = []string{
 	// Frontify-hosted brand portals are React SPAs; also match custom domains
 	// that Frontify serves (brand.*.com pattern) via knownBrandPortalPaths.
 	"frontify.com",
+	"bsky.app", "tiktok.com", "threads.net",
 }
 
 func isSPADomain(rawURL string) bool {

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -873,6 +873,11 @@ func TestIsSPADomain(t *testing.T) {
 		{"https://twitter.com/user/status/123", false}, // handled by dedicated twitter path
 		{"https://www.linkedin.com/in/user", true},
 		{"https://example.com/page", false},
+		{"https://bsky.app/profile/user.bsky.social", true},
+		{"https://www.tiktok.com/@user/video/123", true},
+		{"https://www.threads.net/@user/post/123", true},
+		{"https://notbsky.app/profile/user", false},
+		{"https://eviltiktok.com/page", false},
 	}
 	for _, tt := range tests {
 		got := isSPADomain(tt.url)

--- a/internal/search/domain.go
+++ b/internal/search/domain.go
@@ -173,6 +173,10 @@ type AcademicResult struct {
 	// best-effort by EnrichRetraction from Crossref's merged Retraction Watch +
 	// publisher data. nil/omitted when clean or unresolved — never a guess.
 	Retraction *RetractionStatus `json:"retractionStatus,omitempty"`
+	// IsInDoaj is true when OpenAlex reports the publishing journal is listed
+	// in the Directory of Open Access Journals (DOAJ) — a peer-reviewed OA
+	// quality signal. OpenAlex-only; omitted for all other providers.
+	IsInDoaj bool `json:"isInDoaj,omitempty"`
 }
 
 // RetractionStatus is the operator/model-facing integrity signal for a scholarly

--- a/internal/search/openalex.go
+++ b/internal/search/openalex.go
@@ -311,6 +311,7 @@ type openAlexLocation struct {
 
 type openAlexSource struct {
 	DisplayName string `json:"display_name"`
+	IsInDoaj    bool   `json:"is_in_doaj"`
 }
 
 type openAlexOA struct {
@@ -355,6 +356,7 @@ func openAlexWorkToResult(work *openAlexWork) AcademicResult {
 	}
 	if work.PrimaryLocation != nil && work.PrimaryLocation.Source != nil {
 		result.Journal = work.PrimaryLocation.Source.DisplayName
+		result.IsInDoaj = work.PrimaryLocation.Source.IsInDoaj
 	}
 	for _, a := range work.Authorships {
 		if a.Author.DisplayName != "" {

--- a/internal/search/openalex_test.go
+++ b/internal/search/openalex_test.go
@@ -29,7 +29,7 @@ const testOpenAlexResponse = `{
         {"author": {"display_name": "Noam Shazeer"}}
       ],
       "primary_location": {
-        "source": {"display_name": "Advances in Neural Information Processing Systems"}
+        "source": {"display_name": "Advances in Neural Information Processing Systems", "is_in_doaj": true}
       },
       "open_access": {
         "is_oa": true,
@@ -146,10 +146,17 @@ func TestOpenAlexProvider_Scholarly(t *testing.T) {
 	if r.Abstract == "" {
 		t.Error("expected abstract to be reconstructed from inverted index")
 	}
+	if !r.IsInDoaj {
+		t.Error("expected IsInDoaj to be true")
+	}
 
 	// Second result should have no abstract (nil inverted index)
 	if results[1].Abstract != "" {
 		t.Errorf("expected empty abstract for nil inverted index, got: %s", results[1].Abstract)
+	}
+	// Second result has no is_in_doaj field in the fixture — must default false.
+	if results[1].IsInDoaj {
+		t.Error("expected IsInDoaj to be false when absent from response")
 	}
 }
 

--- a/internal/tools/academic.go
+++ b/internal/tools/academic.go
@@ -446,6 +446,9 @@ func academicResultToMap(r search.AcademicResult) map[string]any {
 	if r.Retraction != nil {
 		paper["retractionStatus"] = r.Retraction
 	}
+	if r.IsInDoaj {
+		paper["isInDoaj"] = true
+	}
 	return paper
 }
 

--- a/internal/tools/schemas.go
+++ b/internal/tools/schemas.go
@@ -115,6 +115,7 @@ var academicSearchOutputSchema = map[string]any{
 					"tldr":            map[string]any{"type": "string", "description": "AI-generated one-sentence summary (Semantic Scholar). Treat as AI-generated, not authoritative."},
 					"isInfluential":   map[string]any{"type": "boolean", "description": "Citation-edge only (citation_graph): the citing/cited work is a highly influential citation."},
 					"citationIntents": map[string]any{"type": "array", "items": map[string]any{"type": "string"}, "description": "Citation-edge only: intent labels (background/methodology/result)."},
+					"isInDoaj":        map[string]any{"type": "boolean", "description": "OpenAlex-only: journal is listed in the Directory of Open Access Journals (DOAJ) — a peer-reviewed OA quality signal."},
 				},
 			},
 		},
@@ -735,6 +736,7 @@ var academicPaperItemSchema = map[string]any{
 		"tldr":            map[string]any{"type": "string"},
 		"isInfluential":   map[string]any{"type": "boolean"},
 		"citationIntents": map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		"isInDoaj":        map[string]any{"type": "boolean"},
 	},
 }
 

--- a/python/web_researcher_mcp/models.py
+++ b/python/web_researcher_mcp/models.py
@@ -28,6 +28,7 @@ class AcademicSearchPaper:
     citationCount: Optional[int] = None
     citationIntents: list[str] = field(default_factory=list)
     doi: Optional[str] = None
+    isInDoaj: Optional[bool] = None
     isInfluential: Optional[bool] = None
     journal: Optional[str] = None
     openAccess: Optional[bool] = None
@@ -48,6 +49,7 @@ class AcademicSearchPaper:
             citationCount=d.get('citationCount'),
             citationIntents=list(d.get('citationIntents') or []),
             doi=d.get('doi'),
+            isInDoaj=d.get('isInDoaj'),
             isInfluential=d.get('isInfluential'),
             journal=d.get('journal'),
             openAccess=d.get('openAccess'),
@@ -436,6 +438,7 @@ class CitationGraphCitedby:
     citationCount: Optional[int] = None
     citationIntents: list[str] = field(default_factory=list)
     doi: Optional[str] = None
+    isInDoaj: Optional[bool] = None
     isInfluential: Optional[bool] = None
     journal: Optional[str] = None
     openAccess: Optional[bool] = None
@@ -456,6 +459,7 @@ class CitationGraphCitedby:
             citationCount=d.get('citationCount'),
             citationIntents=list(d.get('citationIntents') or []),
             doi=d.get('doi'),
+            isInDoaj=d.get('isInDoaj'),
             isInfluential=d.get('isInfluential'),
             journal=d.get('journal'),
             openAccess=d.get('openAccess'),


### PR DESCRIPTION
## Summary

Two small, independent, fully-spec'd fixes picked from the open-issue backlog:

**#288 — SPA escalation for Bluesky/TikTok/Threads**
- Adds `bsky.app`, `tiktok.com`, `threads.net` to `knownSPADomains` in `internal/scraper/pipeline.go`
- These are fully client-side-rendered SPAs; without this, `scrape_page` burns two doomed tiers (markdown, stealth) before ever reaching the browser tier
- This is a hard prerequisite for two queued issues (#285 Bluesky structured scraper, #279 Bluesky search provider) — landing it now unblocks both
- Added 5 new table-driven test cases (exact match, subdomain match, false-positive guard for lookalike domains)

**#272 — OpenAlex `is_in_doaj` signal**
- OpenAlex already returns `primary_location.source.is_in_doaj` on every result but it was never decoded
- Surfaces it as `isInDoaj` on `academic_search` and `citation_graph` results — a peer-reviewed open-access quality signal (Directory of Open Access Journals) useful for distinguishing legitimate OA journals from predatory ones
- Wired through: provider struct → `AcademicResult` → tool output map → both output JSON schemas → `docs/TOOLS.md` → Python client (regenerated via `make gen-python-client`)
- Added provider-level test coverage (both present-true and absent-false cases)

No new dependencies, no new env vars, no tool schema breaking changes (both are new `omitempty` fields).

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] `go tool golangci-lint run` (touched packages) — 0 issues
- [x] `go test -race ./internal/scraper/... ./internal/search/... ./internal/tools/...` — all pass
- [x] `make verify` (full CI gate: fmt-check, vet, lint, sec, vuln, lens validation, race tests, E2E, Python drift, Python tests, build) — passed end to end
- [x] `make gen-python-client` — regenerated and committed `models.py` (isInDoaj field on `AcademicSearchPaper` + `CitationGraphCitedby`)
- [x] Docs-drift CI gates (`TestToolsDocMatchesRegistry`, `TestOutputSchemaMatchesResponse`, `TestAllToolsHaveAnnotations`, `TestToolDescriptionQuality`, `TestProvidersDocStructuredDomainTable`) — all pass

Closes #288, closes #272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)