### PR TITLE
fix(scraper): trigger iframe-follow inline per-tier, not post-loop (#399)

### DIFF
--- a/internal/scraper/html.go
+++ b/internal/scraper/html.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"time"
 	"unicode/utf8"
@@ -28,6 +29,11 @@ const (
 	maxMetaProps           = 64        // cap entry count per meta map (og/article and citation independently)
 	maxMetaValueBytes      = 2 * 1024  // truncate any single meta content value beyond 2KB
 )
+
+// maxIframeCandidates bounds how many cross-origin <iframe src> URLs are kept
+// per page (issue #399) — real wrapper pages (HuggingFace Spaces, CodeSandbox,
+// Stripe Checkout) carry 1-2, so this is generous headroom, not a real limit.
+const maxIframeCandidates = 2
 
 func (p *Pipeline) scrapeHTML(ctx context.Context, url string, maxLength int) (*ScrapeResult, error) {
 	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
@@ -79,6 +85,10 @@ func (p *Pipeline) scrapeHTML(ctx context.Context, url string, maxLength int) (*
 	// MUST precede the script Remove() below (#46): JSON-LD lives in <script
 	// type="application/ld+json">, which the Remove() call strips. Capture first.
 	sd := extractStructuredData(doc)
+	// MUST precede the iframe Remove() below (#399): a cross-origin <iframe src>
+	// carrying the real content (e.g. a HuggingFace Space wrapper) is stripped
+	// by that same call. Capture first.
+	iframes := extractIframeCandidates(doc, url)
 
 	doc.Find("script, style, nav, footer, aside, header, noscript, iframe, form").Remove()
 	doc.Find("[role='navigation'], [role='banner'], [role='complementary']").Remove()
@@ -106,7 +116,8 @@ func (p *Pipeline) scrapeHTML(ctx context.Context, url string, maxLength int) (*
 		// Surface the decompressed HTML size so the pipeline can detect a
 		// JS-rendered SPA shell (large HTML, little extracted text) and keep
 		// escalating to the browser tier (see looksLikePartialShell).
-		rawHTMLBytes: len(body),
+		rawHTMLBytes:     len(body),
+		iframeCandidates: iframes,
 	}
 	// Attach structured data only when something was captured, so ordinary pages
 	// leave the pointer nil (the clean "absent" signal).
@@ -392,6 +403,51 @@ func extractStructuredData(doc *goquery.Document) *StructuredData {
 	})
 
 	return sd
+}
+
+// extractIframeCandidates lifts up to maxIframeCandidates absolute http(s)
+// URLs from <iframe src="..."> in the parsed document (#399). MUST be called
+// BEFORE the iframe-stripping Remove() in scrapeHTML/extractArticleContent —
+// same precedent as extractStructuredData for JSON-LD. Relative src values
+// are resolved against baseURL. data:/about:/javascript:/blob:/mailto:/empty
+// are dropped. Pure, reentrant, never panics. Returns nil when nothing usable.
+func extractIframeCandidates(doc *goquery.Document, baseURL string) []string {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return nil
+	}
+
+	var candidates []string
+	seen := map[string]bool{}
+	doc.Find("iframe[src]").EachWithBreak(func(_ int, s *goquery.Selection) bool {
+		if len(candidates) >= maxIframeCandidates {
+			return false
+		}
+		src := strings.TrimSpace(mustAttr(s, "src"))
+		if src == "" {
+			return true
+		}
+		ref, err := url.Parse(src)
+		if err != nil {
+			return true
+		}
+		resolved := base.ResolveReference(ref)
+		scheme := strings.ToLower(resolved.Scheme)
+		if scheme != "http" && scheme != "https" {
+			return true
+		}
+		if resolved.Hostname() == "" {
+			return true
+		}
+		abs := resolved.String()
+		if seen[abs] {
+			return true
+		}
+		seen[abs] = true
+		candidates = append(candidates, abs)
+		return true
+	})
+	return candidates
 }
 
 // mustAttr returns the attribute value or "" when absent (goquery returns

--- a/internal/scraper/pipeline.go
+++ b/internal/scraper/pipeline.go
@@ -121,6 +121,16 @@ type ScrapeResult struct {
 	// for tiers that don't parse raw HTML (markdown, browser, document, youtube,
 	// twitter, raw). Unexported: pipeline-internal provenance, never serialized.
 	rawHTMLBytes int
+	// iframeCandidates holds up to maxIframeCandidates absolute http(s) URLs
+	// lifted from server-rendered <iframe src> elements (#399) by the stealth
+	// and html tiers, captured before their existing iframe-stripping step.
+	// When the accumulated best-of result is a partial shell
+	// (looksLikePartialShell) and carries candidates, tieredFallback
+	// recursively re-scrapes up to maxIframeCandidates of them at one
+	// recursion depth to recover real content hiding behind a cross-origin
+	// wrapper (e.g. a HuggingFace Space). Unexported: pipeline-internal
+	// provenance, never serialized.
+	iframeCandidates []string
 }
 
 // StructuredData is page-embedded, machine-readable metadata lifted verbatim
@@ -291,7 +301,17 @@ func stampSparsity(r *ScrapeResult) {
 	}
 }
 
+// scrapeWithTieredFallback runs the free-tier ladder (markdown -> stealth ->
+// html -> browser -> optional paid Exa), following up to maxIframeCandidates
+// cross-origin <iframe src> URLs one level deep the moment ANY tier's own
+// result looks like a partial shell (#399). Thin wrapper preserving the
+// original 3-arg signature for its existing call sites; depth-aware
+// recursion lives in tieredFallback.
 func (p *Pipeline) scrapeWithTieredFallback(ctx context.Context, url string, maxLength int) (*ScrapeResult, error) {
+	return p.tieredFallback(ctx, url, maxLength, 0)
+}
+
+func (p *Pipeline) tieredFallback(ctx context.Context, url string, maxLength, depth int) (*ScrapeResult, error) {
 	type namedTier struct {
 		name string
 		fn   func(context.Context, string, int) (*ScrapeResult, error)
@@ -319,8 +339,11 @@ func (p *Pipeline) scrapeWithTieredFallback(ctx context.Context, url string, max
 	// Exa /contents is the LAST tier: a paid neural extractor that recovers the
 	// hard pages the free tiers cannot. It runs only when configured and only
 	// after every free tier has failed to extract >100 bytes — so the common
-	// path never incurs Exa cost.
-	if p.config.ExaAPIKey != "" {
+	// path never incurs Exa cost. Skipped on a recursive iframe-follow call
+	// (depth > 0, #399): the paid tier is reserved for the top-level URL the
+	// caller actually asked for, not spent on a candidate the pipeline chose
+	// to follow speculatively.
+	if p.config.ExaAPIKey != "" && depth == 0 {
 		tiers = append(tiers, namedTier{"exa", p.scrapeExa})
 	}
 
@@ -337,6 +360,12 @@ func (p *Pipeline) scrapeWithTieredFallback(ctx context.Context, url string, max
 	// and the browser tier is unavailable): we return the most content extracted,
 	// never silently drop to an error.
 	var best *ScrapeResult
+	// iframeSeen dedupes candidate URLs across tiers within this one call: the
+	// stealth and html tiers typically parse the same markup and extract the
+	// same <iframe src> values, so without this a shell flagged by both would
+	// re-fetch (and re-run the full recursive tier ladder against) the same
+	// candidate twice. Populated lazily; nil until the first shell is seen.
+	var iframeSeen map[string]bool
 
 	for _, tier := range tiers {
 		result, err := tier.fn(ctx, url, maxLength)
@@ -348,19 +377,53 @@ func (p *Pipeline) scrapeWithTieredFallback(ctx context.Context, url string, max
 			outcomes = append(outcomes, tierOutcome{tier.name, nil, blockedError(url, tier.name, nil, "bot/JS-wall interstitial")})
 			continue
 		}
-		if err == nil && result != nil && len(result.Content) > 100 {
+		// A shell's own extracted text is often well under 100 bytes (e.g. a
+		// one-line "Refreshing" blurb) — the byte-count floor below exists to
+		// weed out truly-empty tier failures, not shells, so it is relaxed
+		// whenever the tier found iframe candidates worth following. Without
+		// this, a thin-but-iframe-bearing result would fall straight to the
+		// generic best-of branch and never reach looksLikePartialShell/
+		// followIframeCandidates at all (the exact gap stealth.go's own
+		// early-return fix already addresses one layer down, at extraction
+		// time — this is the matching fix at the tier-loop layer).
+		if err == nil && result != nil && (len(result.Content) > 100 || len(result.iframeCandidates) > 0) {
 			stamped := stampTier(result, tier.name)
-			// Confident, complete content wins immediately — same latency as before
-			// for the overwhelming majority of pages. A partial SPA shell (a large
-			// HTML payload that yielded little extracted text) does NOT short-circuit:
-			// it is kept as the fallback while the pipeline keeps escalating toward
-			// the JS-executing browser tier, which can render the real content.
-			if !looksLikePartialShell(stamped) {
-				return stamped, nil
+			if looksLikePartialShell(stamped) {
+				// This tier's own result looks like a shell (SPA stub, or — as with
+				// Exa, #399 live-testing finding — a thin neural-extraction result
+				// that happens to clear looksLikePartialShell's word-count bar for
+				// non-HTML-parsing tiers). Try iframe-follow right here, at the
+				// point of detection, rather than deferring to a single post-loop
+				// check: deferring meant that whichever tier happened to run last
+				// decided whether iframe-follow ever got a turn at all, regardless
+				// of what an earlier tier had already found. See #399 comment
+				// thread for the live case this fixes.
+				if depth == 0 && len(stamped.iframeCandidates) > 0 {
+					if iframeSeen == nil {
+						iframeSeen = make(map[string]bool)
+					}
+					if inner := p.followIframeCandidates(ctx, stamped, maxLength, depth, iframeSeen); inner != nil {
+						merged := betterResult(stamped, inner)
+						if merged == inner && !looksLikePartialShell(inner) {
+							// Recovered content beat the shell on quality AND is itself
+							// confidently complete — return immediately, skipping any
+							// remaining tiers (including browser and the paid Exa tier).
+							return inner, nil
+						}
+						// Either the shell text still scores higher (e.g. a
+						// decorative/near-empty iframe), or the recovered content is
+						// itself thin — keep escalating to remaining tiers, but carry
+						// forward whichever of the two is better quality.
+						stamped = merged
+					}
+				}
+				best = betterResult(best, stamped)
+				outcomes = append(outcomes, tierOutcome{tier.name, stamped, nil})
+				continue
 			}
-			best = betterResult(best, stamped)
-			outcomes = append(outcomes, tierOutcome{tier.name, stamped, nil})
-			continue
+			// Confident, complete content wins immediately — same latency as before
+			// for the overwhelming majority of pages.
+			return stamped, nil
 		}
 		outcomes = append(outcomes, tierOutcome{tier.name, result, err})
 		if result != nil && len(result.Content) > 0 && !looksLikeBotWall(result.Content) {
@@ -429,6 +492,55 @@ func (p *Pipeline) scrapeWithTieredFallback(ctx context.Context, url string, max
 	}
 
 	return nil, &ScrapeError{Kind: highestKind, Message: msg, URL: url}
+}
+
+// followIframeCandidates tries up to maxIframeCandidates server-rendered
+// cross-origin <iframe src> URLs carried on shell — the wrapper-page pattern
+// behind e.g. HuggingFace Spaces, where the real content lives at a different
+// origin (#399). Called from tieredFallback the moment ANY tier's own result
+// is flagged a shell, not after the whole tier loop completes — so no later
+// tier (including a paid Exa result that clears looksLikePartialShell's
+// word-count bar without actually being useful content) can prevent this from
+// running just by returning first.
+//
+// seen dedupes candidate URLs across multiple tiers' calls within one
+// tieredFallback invocation (stealth and html routinely parse the same
+// markup and extract the same iframe src values); it is mutated in place and
+// must be reused across calls at the same depth, never reset per-tier.
+//
+// Each candidate passes the same validateScrapeURL + isDomainAllowed gates
+// every other scrape entry point uses, and the actual fetch goes through the
+// same SSRF-safe client — a private/blocked-IP target is refused at connect
+// time like any other URL. Evaluates every candidate up to the cap (not just
+// the first success) and returns whichever recursed result scores highest via
+// betterResult/contentQuality — so a decorative candidate (ad slot, payment
+// frame) loses to a real-content candidate on its own merits, with no
+// denylist needed. Returns nil if no candidate produced usable content.
+func (p *Pipeline) followIframeCandidates(ctx context.Context, shell *ScrapeResult, maxLength, depth int, seen map[string]bool) *ScrapeResult {
+	tried := 0
+	var best *ScrapeResult
+	for _, candidate := range shell.iframeCandidates {
+		if tried >= maxIframeCandidates {
+			break
+		}
+		if seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		if err := validateScrapeURL(candidate); err != nil {
+			continue
+		}
+		if !p.isDomainAllowed(candidate) {
+			continue
+		}
+		tried++
+		inner, ierr := p.tieredFallback(ctx, candidate, maxLength, depth+1)
+		if ierr != nil || inner == nil || looksLikeBotWall(inner.Content) {
+			continue
+		}
+		best = betterResult(best, inner)
+	}
+	return best
 }
 
 // shell-detection thresholds. Deliberately fixed constants, not tunables: the

--- a/internal/scraper/pipeline.go
+++ b/internal/scraper/pipeline.go
@@ -421,6 +421,18 @@ func (p *Pipeline) tieredFallback(ctx context.Context, url string, maxLength, de
 				outcomes = append(outcomes, tierOutcome{tier.name, stamped, nil})
 				continue
 			}
+			// The >100-byte floor above is relaxed only to let a thin-but-
+			// iframe-bearing result reach the shell check. A result that
+			// clears that relaxed gate, is NOT a shell, but is still <=100
+			// bytes (e.g. a short genuinely-complete page carrying an
+			// unrelated ad/chat iframe) is not confidently complete on its
+			// own — record it as a fallback candidate and keep escalating,
+			// exactly as any other short result would (see #400 review).
+			if len(stamped.Content) <= 100 {
+				best = betterResult(best, stamped)
+				outcomes = append(outcomes, tierOutcome{tier.name, stamped, nil})
+				continue
+			}
 			// Confident, complete content wins immediately — same latency as before
 			// for the overwhelming majority of pages.
 			return stamped, nil

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -3663,3 +3663,57 @@ func TestPipeline_IframeFollow_WinsOverThinExaResult(t *testing.T) {
 		t.Errorf("expected Exa to never be invoked once an earlier tier's iframe-follow recovered real content, got %d hits", hits)
 	}
 }
+
+// TestPipeline_ThinIframeBearingNonShellStillEscalates is the regression test
+// for a bug flagged in #400 code review: the tier loop's >100-byte confidence
+// floor is deliberately relaxed to len(Content) > 100 || len(iframeCandidates) > 0
+// so a thin SHELL carrying an iframe candidate can reach looksLikePartialShell
+// instead of short-circuiting past it. But a short, genuinely-complete page
+// that merely happens to embed an unrelated iframe (e.g. an ad or chat widget)
+// is NOT a shell — looksLikePartialShell correctly returns false for it — yet
+// without this fix it still cleared the relaxed gate and was returned
+// immediately as "confidently complete" purely because it had an iframe,
+// even though it never crossed the pre-existing >100-byte bar. This must
+// instead be treated like any other short result: recorded as a fallback
+// candidate while the pipeline keeps escalating to later tiers.
+func TestPipeline_ThinIframeBearingNonShellStillEscalates(t *testing.T) {
+	// Low HTML:text ratio (well under shellMinHTMLRatio) with an unrelated
+	// iframe and <=100 bytes of extracted text — not a shell by
+	// looksLikePartialShell's ratio check, but still short.
+	text := strings.Repeat("x", 90)
+	html := `<!DOCTYPE html><html><head><title>T</title></head><body><p>` + text +
+		`</p><iframe src="https://ads.example.com/widget"></iframe></body></html>`
+
+	var htmlHits atomic.Int32
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		htmlHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(html))
+	}))
+	defer ts.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), ts.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected best-of fallback, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, text) {
+		t.Fatalf("expected the short page's own content as fallback, got: %+v", result)
+	}
+	if !result.Partial {
+		t.Error("expected Partial=true: a <=100-byte non-shell result must not be treated as confidently complete")
+	}
+	// stealth + html (each server hit once) proves escalation happened instead
+	// of short-circuiting at stealth purely because an iframe was present.
+	if got := htmlHits.Load(); got != 2 {
+		t.Errorf("expected escalation past stealth to the html tier (2 requests), got %d", got)
+	}
+}

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -3126,3 +3126,540 @@ func TestLooksLikePartialShell_BrowserTierExempt(t *testing.T) {
 		t.Error("expected the same short markdown-tier result to still be flagged as a partial shell")
 	}
 }
+
+// =============================================================================
+// Cross-Origin Iframe Follow Tests (#399)
+// =============================================================================
+
+// iframeShellHTML builds a partial-shell wrapper page (large inert blob to
+// trip looksLikePartialShell's ratio, tiny visible text) embedding one or more
+// cross-origin iframes pointing at the given src values verbatim (so callers
+// can pass absolute URLs, relative paths, or non-http(s) schemes to test
+// extraction/dropping).
+func iframeShellHTML(title, blurb string, iframeSrcs ...string) string {
+	bulk := strings.Repeat("/*hydration state padding*/\n", 600) // ~16KB of script
+	var iframes strings.Builder
+	for _, src := range iframeSrcs {
+		iframes.WriteString(`<iframe src="` + src + `"></iframe>`)
+	}
+	return `<!DOCTYPE html><html><head><title>` + title + `</title>` +
+		`<script type="application/json" id="__NEXT_DATA__">` + bulk + `</script>` +
+		`</head><body><div id="root"><p>` + blurb + `</p>` + iframes.String() + `</div></body></html>`
+}
+
+func TestExtractIframeCandidates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		html string
+		base string
+		want []string
+	}{
+		{
+			name: "absolute http(s) src kept",
+			html: `<iframe src="https://embed.example.com/widget"></iframe>`,
+			base: "https://wrapper.example.com/page",
+			want: []string{"https://embed.example.com/widget"},
+		},
+		{
+			name: "relative src resolved against base",
+			html: `<iframe src="/embed"></iframe><iframe src="embed2.html"></iframe>`,
+			base: "https://wrapper.example.com/dir/page",
+			want: []string{"https://wrapper.example.com/embed", "https://wrapper.example.com/dir/embed2.html"},
+		},
+		{
+			name: "data/about/javascript/mailto/empty dropped",
+			html: `<iframe src="data:text/html,hi"></iframe>` +
+				`<iframe src="about:blank"></iframe>` +
+				`<iframe src="javascript:void(0)"></iframe>` +
+				`<iframe src="blob:https://x/y"></iframe>` +
+				`<iframe src="mailto:a@b.com"></iframe>` +
+				`<iframe src=""></iframe>`,
+			base: "https://wrapper.example.com/page",
+			want: nil,
+		},
+		{
+			name: "duplicate absolute src deduped",
+			html: `<iframe src="https://embed.example.com/widget"></iframe>` +
+				`<iframe src="https://embed.example.com/widget"></iframe>`,
+			base: "https://wrapper.example.com/page",
+			want: []string{"https://embed.example.com/widget"},
+		},
+		{
+			name: "capped at maxIframeCandidates",
+			html: `<iframe src="https://a.example.com/1"></iframe>` +
+				`<iframe src="https://b.example.com/2"></iframe>` +
+				`<iframe src="https://c.example.com/3"></iframe>`,
+			base: "https://wrapper.example.com/page",
+			want: []string{"https://a.example.com/1", "https://b.example.com/2"},
+		},
+		{
+			name: "no iframe present returns nil",
+			html: `<p>no iframes here</p>`,
+			base: "https://wrapper.example.com/page",
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			doc, err := goQueryFromString(tt.html)
+			if err != nil {
+				t.Fatalf("goQueryFromString error: %v", err)
+			}
+			got := extractIframeCandidates(doc, tt.base)
+			if len(got) != len(tt.want) {
+				t.Fatalf("extractIframeCandidates() = %v, want %v", got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("candidate[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestPipeline_IframeFollow_HappyPath(t *testing.T) {
+	articleContent := strings.Repeat("Real article content recovered from the iframe target. ", 20)
+	innerHTML := `<!DOCTYPE html><html><head><title>Inner</title></head><body><article><p>` +
+		articleContent + `</p></article></body></html>`
+
+	inner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(innerHTML))
+	}))
+	defer inner.Close()
+
+	var wrapperHTML string
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+	wrapperHTML = iframeShellHTML("Wrapper", "Above-the-fold blurb.", inner.URL)
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Real article content recovered") {
+		t.Fatalf("expected recursed iframe content to win, got: %+v", result)
+	}
+	if strings.Contains(result.Content, "Above-the-fold blurb") {
+		t.Error("expected the shell blurb to lose to the iframe's real content")
+	}
+}
+
+// TestPipeline_IframeFollow_PrivateIPCandidateSkipped proves the recursive
+// iframe-follow goes through the same SSRF-safe dial path as every other
+// scrape entry point. The wrapper itself is a normal reachable loopback
+// server (AllowPrivateIPs: true, so it succeeds like any other test in this
+// file), but its iframe candidate points at a cloud-metadata literal
+// (169.254.169.254) that isBlockedHostname rejects unconditionally,
+// regardless of AllowPrivateIPs — so the candidate is refused before any
+// connection is attempted, and the pipeline falls back to the wrapper shell.
+func TestPipeline_IframeFollow_PrivateIPCandidateSkipped(t *testing.T) {
+	wrapperHTML := iframeShellHTML("Wrapper", "Above-the-fold blurb.", "http://169.254.169.254/latest/meta-data/")
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected best-of fallback to the wrapper shell, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Above-the-fold blurb") {
+		t.Fatalf("expected the wrapper shell to be returned since the only candidate is blocked, got: %+v", result)
+	}
+}
+
+// TestPipeline_IframeFollow_AllowedDomainsRejection proves the allowlist gate
+// applies to a recursed iframe candidate exactly as it does to any other
+// scrape target. Both servers run on loopback in this test process, so the
+// wrapper is addressed as "127.0.0.1" and the inner candidate is addressed as
+// "localhost" (same loopback network, textually distinct hostname) — letting
+// AllowedDomains, which matches on hostname text, allow the former and reject
+// the latter even though both are in fact reachable.
+func TestPipeline_IframeFollow_AllowedDomainsRejection(t *testing.T) {
+	var innerHits atomic.Int32
+	innerContent := strings.Repeat("Real article content behind a disallowed iframe origin. ", 20)
+	inner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		innerHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, innerContent)
+	}))
+	defer inner.Close()
+	innerPort := strings.TrimPrefix(inner.URL, "http://127.0.0.1:")
+	innerURLViaLocalhost := "http://localhost:" + innerPort
+
+	wrapperHTML := iframeShellHTML("Wrapper", "Above-the-fold blurb.", innerURLViaLocalhost)
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{
+		MaxConcurrency:  2,
+		AllowPrivateIPs: true,
+		AllowedDomains:  []string{"127.0.0.1"},
+		ChromePath:      chromeDisabled,
+	})
+
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected best-of fallback to the wrapper shell, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Above-the-fold blurb") {
+		t.Fatalf("expected the wrapper shell to be returned since its only candidate is not allowlisted, got: %+v", result)
+	}
+	if innerHits.Load() != 0 {
+		t.Errorf("expected the iframe candidate to never be dialed when its domain is not allowlisted, got %d hits", innerHits.Load())
+	}
+}
+
+func TestPipeline_IframeFollow_DepthCap(t *testing.T) {
+	var thirdHits atomic.Int32
+	thirdContent := strings.Repeat("Content behind a second-level iframe that must never be followed. ", 10)
+	third := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		thirdHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, thirdContent)
+	}))
+	defer third.Close()
+
+	var secondHTML string
+	second := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(secondHTML))
+	}))
+	defer second.Close()
+	secondHTML = iframeShellHTML("Second", "Second-level blurb.", third.URL)
+
+	var firstHTML string
+	first := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(firstHTML))
+	}))
+	defer first.Close()
+	firstHTML = iframeShellHTML("First", "First-level blurb.", second.URL)
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), first.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected best-of fallback to succeed, got error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if strings.Contains(result.Content, "second-level iframe that must never be followed") {
+		t.Error("expected the third-level page to never be reached (depth cap of 1)")
+	}
+	if thirdHits.Load() != 0 {
+		t.Errorf("expected the third-level iframe to never be dialed (depth cap of 1), got %d hits", thirdHits.Load())
+	}
+}
+
+func TestPipeline_IframeFollow_TwoCandidateCap(t *testing.T) {
+	var hits [3]atomic.Int32
+	makeInner := func(idx int) *httptest.Server {
+		content := strings.Repeat(fmt.Sprintf("Content from inner iframe number %d. ", idx), 20)
+		return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			hits[idx].Add(1)
+			w.Header().Set("Content-Type", "text/html")
+			fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, content)
+		}))
+	}
+	inner0 := makeInner(0)
+	defer inner0.Close()
+	inner1 := makeInner(1)
+	defer inner1.Close()
+	inner2 := makeInner(2)
+	defer inner2.Close()
+
+	wrapperHTML := iframeShellHTML("Wrapper", "Above-the-fold blurb.", inner0.URL, inner1.URL, inner2.URL)
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	_, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	// extractIframeCandidates itself caps at maxIframeCandidates(2), so only
+	// the first two <iframe src> elements ever become candidates regardless of
+	// how many appear in the markup — the third is never even extracted, let
+	// alone dialed.
+	if hits[2].Load() != 0 {
+		t.Errorf("expected the third iframe (beyond the cap of 2) to never be dialed, got %d hits", hits[2].Load())
+	}
+}
+
+func TestPipeline_IframeFollow_DecorativeIframeLoses(t *testing.T) {
+	decorative := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><p>Ad</p></body></html>`))
+	}))
+	defer decorative.Close()
+
+	realContent := strings.Repeat("Genuine article content that should win the contentQuality comparison. ", 20)
+	real := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, realContent)
+	}))
+	defer real.Close()
+
+	wrapperHTML := iframeShellHTML("Wrapper", "Above-the-fold blurb.", decorative.URL, real.URL)
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Genuine article content") {
+		t.Fatalf("expected the real-content iframe to win via contentQuality scoring, got: %+v", result)
+	}
+}
+
+// TestScrapeStealth_ThinContentWithIframeCandidates is a regression test for
+// the stealth-tier early-return fix (#399): a near-empty extracted-text shell
+// that carries iframe candidates must still produce a result (not nil), so
+// the signal survives to the tiered-fallback loop that acts on it.
+func TestScrapeStealth_ThinContentWithIframeCandidates(t *testing.T) {
+	html := `<!DOCTYPE html><html><head><title>Thin</title></head><body>` +
+		`<p>Hi.</p><iframe src="https://embed.example.com/real"></iframe></body></html>`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(html))
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	result, err := p.scrapeStealth(context.Background(), ts.URL, 50000)
+	if err != nil {
+		t.Fatalf("scrapeStealth error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected a non-nil result carrying iframe candidates, not the old nil-on-thin-content behavior")
+	}
+	if len(result.iframeCandidates) != 1 || result.iframeCandidates[0] != "https://embed.example.com/real" {
+		t.Errorf("expected iframeCandidates=[https://embed.example.com/real], got %v", result.iframeCandidates)
+	}
+}
+
+// TestScrapeStealth_ThinContentNoIframeStillNil is the inverse regression
+// check: a near-empty shell with NO iframe candidates must still return nil,
+// exactly as before this fix — nothing changed for the common thin-page case.
+func TestScrapeStealth_ThinContentNoIframeStillNil(t *testing.T) {
+	html := `<!DOCTYPE html><html><head><title>Thin</title></head><body><p>Short.</p></body></html>`
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		w.Write([]byte(html))
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	result, err := p.scrapeStealth(context.Background(), ts.URL, 50000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result != nil {
+		t.Errorf("expected nil result for thin content with no iframe candidates, got: %+v", result)
+	}
+}
+
+// TestPipeline_IframeFollow_DedupedAcrossTiers proves that when multiple
+// tiers (stealth and html both parse the wrapper's markup and both extract
+// the same iframe src) independently flag the same shell, the shared
+// candidate is dialed exactly once — not once per tier. Without the
+// iframeSeen dedup map in tieredFallback, a wrapper page whose stealth AND
+// html tiers both trip looksLikePartialShell would redundantly re-run the
+// full recursive tier ladder against the same candidate URL for each tier.
+func TestPipeline_IframeFollow_DedupedAcrossTiers(t *testing.T) {
+	var innerHits atomic.Int32
+	innerContent := strings.Repeat("Real article content recovered from the shared iframe target. ", 20)
+	inner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		innerHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, innerContent)
+	}))
+	defer inner.Close()
+
+	var wrapperHTML string
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+	// stealth and html both parse this same markup and will both independently
+	// extract inner.URL as an iframe candidate before either strips <iframe>.
+	wrapperHTML = iframeShellHTML("Wrapper", "Above-the-fold blurb.", inner.URL)
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Real article content recovered") {
+		t.Fatalf("expected recursed iframe content to win, got: %+v", result)
+	}
+	// The stealth tier runs before html and should recover the content itself,
+	// returning immediately and never letting html get a turn at all — so this
+	// also proves the early-exit-on-success behavior. Either way, the shared
+	// candidate must be dialed exactly once.
+	if hits := innerHits.Load(); hits != 1 {
+		t.Errorf("expected the shared iframe candidate to be dialed exactly once across tiers, got %d hits", hits)
+	}
+}
+
+// TestPipeline_IframeFollow_WinsOverThinExaResult is the regression test for
+// the exact live bug found in real-user MCP testing (#399 follow-up): when
+// EXA_API_KEY is configured, Exa's ScrapeResult never sets rawHTMLBytes, so
+// looksLikePartialShell falls into its word-count-only branch for Exa
+// results — a thin-but-not-quite-30-words-short Exa result used to read as
+// "confidently complete" and short-circuit the tier loop via the old
+// post-loop-only iframe-follow trigger, before the earlier stealth tier's
+// already-found iframe candidate ever got a chance to run. With iframe-follow
+// now triggered inline the moment stealth's own result is flagged a shell,
+// the free-tier recovery must win and complete before Exa is ever invoked.
+func TestPipeline_IframeFollow_WinsOverThinExaResult(t *testing.T) {
+	var exaHits atomic.Int32
+	exa := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		exaHits.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		// A thin-but-word-count-passing body mirroring the real HF Space case:
+		// enough words to clear shellMaxWords (30) so looksLikePartialShell
+		// would (incorrectly) call this "not a shell" if it were ever reached.
+		fmt.Fprint(w, `{"results":[{"id":"x","text":"`+
+			strings.Repeat("Refreshing wrapper placeholder word. ", 6)+`"}]}`)
+	}))
+	defer exa.Close()
+	withExaEndpoint(t, exa.URL)
+
+	var innerHits atomic.Int32
+	innerContent := strings.Repeat("Real article content recovered from the free-tier iframe target. ", 20)
+	inner := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		innerHits.Add(1)
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><body><article>%s</article></body></html>`, innerContent)
+	}))
+	defer inner.Close()
+
+	var wrapperHTML string
+	wrapper := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.Header.Get("Accept"), "text/markdown") {
+			w.WriteHeader(406)
+			return
+		}
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(wrapperHTML))
+	}))
+	defer wrapper.Close()
+	wrapperHTML = iframeShellHTML("Wrapper", "Refreshing", inner.URL)
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled, ExaAPIKey: "test-key"})
+	result, err := p.Scrape(context.Background(), wrapper.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected success, got error: %v", err)
+	}
+	if result == nil || !strings.Contains(result.Content, "Real article content recovered") {
+		t.Fatalf("expected recursed free-tier iframe content to win over the thin Exa result, got: %+v", result)
+	}
+	if hits := exaHits.Load(); hits != 0 {
+		t.Errorf("expected Exa to never be invoked once an earlier tier's iframe-follow recovered real content, got %d hits", hits)
+	}
+}

--- a/internal/scraper/stealth.go
+++ b/internal/scraper/stealth.go
@@ -68,9 +68,17 @@ func (p *Pipeline) scrapeStealth(ctx context.Context, url string, maxLength int)
 	// (JSON-LD lives in a stripped <script>). The stealth tier wins for most
 	// real pages, so structuredData is populated here too, not only the HTML tier.
 	sd := extractStructuredData(doc)
+	// Capture cross-origin iframe candidates (#399) BEFORE extractArticleContent
+	// strips <iframe> — same precedent as structured data above.
+	iframes := extractIframeCandidates(doc, url)
 
 	content := extractArticleContent(doc)
-	if len(content) < 100 {
+	// A near-empty shell with no iframe candidates has nothing further to
+	// recover from this tier — bail as before. But when iframes were found,
+	// fall through and build the result anyway: the shell's own thin content
+	// is exactly the case the pipeline needs iframeCandidates to escalate past
+	// (issue #399) — returning nil here would silently discard that signal.
+	if len(content) < 100 && len(iframes) == 0 {
 		return nil, nil
 	}
 
@@ -92,7 +100,8 @@ func (p *Pipeline) scrapeStealth(ctx context.Context, url string, maxLength int)
 		// Surface the decompressed HTML size so the pipeline can detect a
 		// JS-rendered SPA shell (large HTML, little extracted text) and keep
 		// escalating to the browser tier (see looksLikePartialShell).
-		rawHTMLBytes: len(body),
+		rawHTMLBytes:     len(body),
+		iframeCandidates: iframes,
 	}
 	if !sd.IsEmpty() {
 		res.StructuredData = sd


### PR DESCRIPTION
Fixes #399

## Summary
- Fixes a live bug found in real-user MCP testing of #399: when `EXA_API_KEY` is configured, a thin-but-word-count-passing Exa result short-circuits `tieredFallback` before the (previously post-loop-only) iframe-follow logic ever runs, even when an earlier tier already flagged the page as a shell with a good iframe candidate.
- Moves the iframe-follow trigger inline: the moment ANY tier's own result is flagged a shell by `looksLikePartialShell`, iframe-follow runs immediately at that point in the loop — order-independent, no dependency on which tier happens to run last.
- Adds cross-tier `iframeSeen` dedup (stealth and html routinely extract the same candidate from the same markup) and an early exit once recovered content beats the shell on quality, skipping remaining tiers including the paid Exa call.
- Full architecture writeup posted to the issue before implementation: https://github.com/zoharbabin/web-researcher-mcp/issues/399#issuecomment-5003697008

## Test plan
- [x] `go build ./...`, `go vet ./internal/scraper/...` clean
- [x] `go test ./internal/scraper/... -race -count=1` — full suite green, including all pre-existing `TestPipeline_IframeFollow_*` / `TestLooksLikePartialShell*` regression tests
- [x] `go tool golangci-lint run ./internal/scraper/...` — 0 issues
- [x] `go tool govulncheck ./...` — no vulnerabilities found
- [x] New regression test `TestPipeline_IframeFollow_WinsOverThinExaResult` reproduces the exact live bug (thin Exa result on a shell page) and proves it fails on the old code path, passes on the fix
- [x] New regression test `TestPipeline_IframeFollow_DedupedAcrossTiers` proves a shared iframe candidate flagged by both `stealth` and `html` is dialed exactly once
- [x] Live-verified via the real `scrape_page` MCP tool against `https://huggingface.co/spaces/ICML-2026-agent-repro/challenge` (the original motivating case, with `EXA_API_KEY` configured): now returns real page content via `extractedBy: "stealth"` instead of the old 45-word `exa:cached` shell, with Exa never invoked
- [x] Broader live regression pass across `web_search`, `news_search`, `academic_search`, `patent_search`, `image_search`, `search_and_scrape`, `verify_citation`, `memory_recall`, plus non-shell edge cases (404, unresolvable domain, real auth wall, legitimately-thin page) — all correct, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)
