### PR TITLE
fix(ci): filter nixpkgs PR lookup by owner in jq, not gh pr list --head

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -869,9 +869,13 @@ jobs:
           # This branch is stable across releases (see previous step) — check for
           # an existing open PR from it before creating a new one, so a re-run just
           # refreshes the same PR's commit/body instead of opening a duplicate.
+          # `gh pr list --head owner:branch` does not reliably match on a repo
+          # this large (NixOS/nixpkgs) — filter by plain branch name, then
+          # cross-check the fork owner in jq instead.
           EXISTING_PR="$(gh pr list --repo NixOS/nixpkgs \
-            --head "${fork_user}:${pr_branch}" --state open \
-            --json url --jq '.[0].url' || true)"
+            --head "${pr_branch}" --state open \
+            --json url,headRepositoryOwner \
+            --jq "[.[] | select(.headRepositoryOwner.login == \"${fork_user}\")][0].url" || true)"
 
           if [ -n "${EXISTING_PR}" ]; then
             echo "Existing open PR found — updating body/title: ${EXISTING_PR}"


### PR DESCRIPTION
## Summary
- `gh pr list --head "owner:branch"` doesn't reliably match on NixOS/nixpkgs (too many forks/branches). During the v1.44.0 release, this silently returned empty, so the existing-PR check fell through to `gh pr create`, which failed since the PR already existed — leaving nixpkgs#542615's title/body stuck at "init at 1.43.0" instead of updating to 1.44.0.
- Filters by plain branch name instead and cross-checks the fork owner (`headRepositoryOwner.login`) in jq.

## Fix applied out-of-band
Manually corrected the live PR title/body to v1.44.0: https://github.com/NixOS/nixpkgs/pull/542615

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [x] Reproduced the `gh pr list --head owner:branch` failure live against NixOS/nixpkgs, confirmed the plain-branch + jq-filter form returns the correct PR URL
- [ ] Will be exercised for real on the next release's `nixpkgs proper` job

🤖 Generated with [Claude Code](https://claude.com/claude-code)