### PR TITLE
chore: remove broken Star History chart from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -768,18 +768,6 @@ Contributions are welcome. Please see [CONTRIBUTING.md](CONTRIBUTING.md) for cod
 
 ---
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=zoharbabin%2Fweb-researcher-mcp&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=zoharbabin/web-researcher-mcp&type=date&theme=dark&legend=top-left&sealed_token=_gSupJoamTdZ8GxNNbPc4UwcO3zMRgrPJtbSWAmygDwRwSku6h6a0hU7Uy6I5321R7qFTeKiv70I2k8C-JiM2e65oWvx2MYDdhUnSZZ23rpr7ZhBA1NBA0ggFLevMDUV6AHI6Kiy3WjPsGbIyXEQ7b6ZWrzR-fINC3tGLBkRGCU0CgavjG3EWhlNi2vD" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=zoharbabin/web-researcher-mcp&type=date&legend=top-left&sealed_token=_gSupJoamTdZ8GxNNbPc4UwcO3zMRgrPJtbSWAmygDwRwSku6h6a0hU7Uy6I5321R7qFTeKiv70I2k8C-JiM2e65oWvx2MYDdhUnSZZ23rpr7ZhBA1NBA0ggFLevMDUV6AHI6Kiy3WjPsGbIyXEQ7b6ZWrzR-fINC3tGLBkRGCU0CgavjG3EWhlNi2vD" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=zoharbabin/web-researcher-mcp&type=date&legend=top-left&sealed_token=_gSupJoamTdZ8GxNNbPc4UwcO3zMRgrPJtbSWAmygDwRwSku6h6a0hU7Uy6I5321R7qFTeKiv70I2k8C-JiM2e65oWvx2MYDdhUnSZZ23rpr7ZhBA1NBA0ggFLevMDUV6AHI6Kiy3WjPsGbIyXEQ7b6ZWrzR-fINC3tGLBkRGCU0CgavjG3EWhlNi2vD" />
- </picture>
-</a>
-
----
-
 <p align="center">
   Built with <a href="https://go.dev">Go</a> and the <a href="https://modelcontextprotocol.io/">Model Context Protocol</a>
   <br/><br/>


### PR DESCRIPTION
## Summary
- GitHub restricted the `/stargazers` endpoint (June 2026) to a repo's own admins/collaborators with a valid token — this broke star-history.com's embed for every repo regardless of who owns it or which token is supplied (confirmed: regenerating the embed token still 500s; other star-chart sites are broken the same way).
- Removes the dead chart section from the bottom of the README. The shields.io stars badge at the top already shows the live count and needs no token.

## Test plan
- [x] Visual diff only — no code/schema changes, no CI drift gates reference this section