### PR TITLE
feat(search): add CORE.ac.uk academic provider (#267)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,6 +51,8 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 # PUBMED_API_KEY=...                 # optional: raises the rate (~10 req/s). Get one at
 #                                    # ncbi.nlm.nih.gov/account (Settings → API Key Management).
 # PUBMED_EMAIL=you@example.com       # optional NCBI contact (recommended); falls back to OPENALEX_EMAIL.
+# CORE (core.ac.uk) — 300M+ open-access works with full text; ALWAYS available (keyless, lower shared rate).
+# CORE_API_KEY=...                   # optional: raises the rate limit. Free registration at core.ac.uk.
 # (Exa also serves academic_search via the research-paper category when EXA_API_KEY is set —
 #  a neural-web alternate to the above, not a curated bibliographic database.)
 #

--- a/cmd/web-researcher-mcp/main.go
+++ b/cmd/web-researcher-mcp/main.go
@@ -259,6 +259,7 @@ func main() {
 		SemanticScholarAPIKey: cfg.Search.SemanticScholarAPIKey,
 		PubMedAPIKey:          cfg.Search.PubMedAPIKey,
 		PubMedEmail:           cfg.Search.PubMedEmail,
+		COREAPIKey:            cfg.Search.COREAPIKey,
 	}
 	academicProviders := search.AvailableAcademicProviders(academicCfg, searchDeps)
 

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -152,12 +152,14 @@ Which tools each web search provider enables. `—` means the provider returns e
 | **[CrossRef](https://www.crossref.org/)** | ✓ | ✓ (authoritative) | — | — | — | No (email for polite pool) |
 | **[Semantic Scholar](https://www.semanticscholar.org/)** | ✓ | — | ✓ (rich edges) | — | ✓ (tldr) | No (key raises limits) |
 | **[PubMed](https://pubmed.ncbi.nlm.nih.gov/)** | ✓ | — | — | — | — | No (key raises limits) |
+| **[CORE](https://core.ac.uk/)** | ✓ | — | — | ✓ (native `fullText`) | — | No (key raises limits) |
 | **[Exa](https://exa.ai/)** | ✓ | — | — | — | — | Yes (`EXA_API_KEY`) |
 
 **Notes:**
 - CrossRef is the official DOI registration agency — the authoritative source for DOI metadata. Every DOI-registered work appears here.
 - Semantic Scholar enriches results with AI-generated `tldr` summaries and citation intent/influence edges, which power `citation_graph`. OpenAlex also implements `citation_graph` support with citation-count edges as a fallback.
-- Only OpenAlex implements the `DOIResolver` interface (exact-entity lookup via `/works/doi:{doi}`). CrossRef, Semantic Scholar, and PubMed do not.
+- Only OpenAlex implements the `DOIResolver` interface (exact-entity lookup via `/works/doi:{doi}`). CrossRef, Semantic Scholar, PubMed, and CORE do not.
+- CORE's every result is open access by definition — it aggregates OA repositories exclusively — and its `pdfUrl` links directly to full text, no Unpaywall enrichment needed.
 - Exa routes academic queries using its `research-paper` category — useful when its neural index surfaces papers the bibliographic databases miss.
 - [Unpaywall](https://unpaywall.org/) OA enrichment runs as a post-processing step on any DOI-bearing result — not a separate provider to select.
 
@@ -169,6 +171,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 | **[CrossRef](https://www.crossref.org/)** | 140M+ DOI-registered works | Peer-reviewed literature; authoritative DOI metadata |
 | **[Semantic Scholar](https://www.semanticscholar.org/)** | 200M+ papers | Broad; strong on CS, medicine, biology |
 | **[PubMed](https://pubmed.ncbi.nlm.nih.gov/)** | 35M+ citations | Biomedical and life science only |
+| **[CORE](https://core.ac.uk/)** | 300M+ OA outputs | Open-access works aggregated from repositories worldwide; all results are OA |
 | **[Exa](https://exa.ai/)** | Neural web index | Research-paper category; surfaces papers outside bibliographic DBs |
 
 ### Academic Routing

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -602,7 +602,7 @@ On a zero-result response, `hints` carries the same `ZeroResultHints` object as 
 | `pdf_only` | bool | no | false | — |
 | `sort_by` | string | no | `relevance` | relevance, date |
 | `open_access` | bool | no | false | Only return open-access papers |
-| `provider` | string | no | — | Force provider: openalex, crossref, pubmed, semanticscholar, exa (academic APIs), or google, brave, serper, searxng, searchapi, duckduckgo, tavily (web fallback) |
+| `provider` | string | no | — | Force provider: openalex, crossref, pubmed, semanticscholar, core, exa (academic APIs), or google, brave, serper, searxng, searchapi, duckduckgo, tavily (web fallback) |
 | `sessionId` | string | no | — | Link results to a `sequential_search` session; sources are auto-recorded for recovery after context loss |
 
 ### Output Fields
@@ -634,7 +634,8 @@ Additional output fields: `query`, `totalResults`, `resultCount`, `source` (whic
 - When academic providers (OpenAlex, CrossRef, PubMed, Semantic Scholar) are configured, returns rich metadata (DOI, authors, citations, OA status)
 - Metadata richness varies by provider: OpenAlex returns abstracts, citation counts, and authors consistently; Semantic Scholar adds `tldr` and `isInfluential`; CrossRef is a DOI registry and may omit abstracts/citation counts; PubMed returns biomedical records (title, authors, year, venue, DOI) — no abstract in the summary response. Automatic selection prefers OpenAlex; others answer when explicitly forced or as a fallback. Field absence reflects the provider, not an error.
 - Without academic env vars, falls back to site-restricted web search (identical to previous behavior)
-- OpenAlex/CrossRef require only an email address (no API key); PubMed and Semantic Scholar work key-free at a lower shared rate (`PUBMED_API_KEY` / `SEMANTIC_SCHOLAR_API_KEY` raise the respective limit). PubMed DOIs feed the same retraction enrichment as every other provider.
+- OpenAlex/CrossRef require only an email address (no API key); PubMed, Semantic Scholar, and CORE work key-free at a lower shared rate (`PUBMED_API_KEY` / `SEMANTIC_SCHOLAR_API_KEY` / `CORE_API_KEY` raise the respective limit). PubMed DOIs feed the same retraction enrichment as every other provider.
+- CORE (core.ac.uk) aggregates 300M+ open-access works from repositories worldwide; every result has `openAccess:true`, and `pdfUrl` links directly to full text when available. It does not resolve DOI entities or provide citation-graph edges — use OpenAlex or Semantic Scholar for those.
 - **Open-access enrichment (Unpaywall):** when `UNPAYWALL_EMAIL` (or `OPENALEX_EMAIL`) is set, DOI-bearing results that lack a PDF link are enriched with the best open-access PDF Unpaywall knows about. Best-effort: never overwrites a provider-supplied `pdfUrl`, never fails the search, and runs *before* the `pdf_only` filter so resolved PDFs are counted. No-op when unconfigured.
 - `source` filter: when set (e.g., "arxiv"), OpenAlex filters by source ID; web fallback restricts to that source's domain
 - `sort_by=date`: OpenAlex sorts by `publication_date:desc`; CrossRef uses `published:desc`

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -154,6 +154,7 @@ type SearchConfig struct {
 	UnpaywallEmail        string // open-access PDF resolution; falls back to OpenAlexEmail when unset
 	PubMedAPIKey          string // optional; PubMed E-utilities work keyless (~3 req/s), a key raises it (~10 req/s)
 	PubMedEmail           string // optional NCBI contact (tool/email params) — falls back to OpenAlexEmail
+	COREAPIKey            string // optional; CORE.ac.uk works keyless at a lower shared rate, a key raises the limit
 
 	// Structured-domain providers (optional, enable filing/case/economic search)
 	EDGARContactEmail  string // SEC EDGAR requires a contact email for its required User-Agent
@@ -376,6 +377,7 @@ func Load() (*Config, error) {
 			UnpaywallEmail:        envOrDefault("UNPAYWALL_EMAIL", os.Getenv("OPENALEX_EMAIL")),
 			PubMedAPIKey:          os.Getenv("PUBMED_API_KEY"),
 			PubMedEmail:           envOrDefault("PUBMED_EMAIL", os.Getenv("OPENALEX_EMAIL")),
+			COREAPIKey:            os.Getenv("CORE_API_KEY"),
 			EDGARContactEmail:     envOrDefault("EDGAR_CONTACT_EMAIL", os.Getenv("OPENALEX_EMAIL")),
 			CourtListenerToken:    os.Getenv("COURTLISTENER_API_TOKEN"),
 			FREDAPIKey:            os.Getenv("FRED_API_KEY"),

--- a/internal/search/core.go
+++ b/internal/search/core.go
@@ -1,0 +1,179 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+const coreMaxBody = 2 << 20 // 2 MiB, see issue #267 Performance rule
+
+// COREProvider implements AcademicProvider using the CORE.ac.uk v3 API — the
+// largest aggregator of open-access research outputs (300M+ works across
+// global repositories). Works keyless at a lower shared rate; supply an API
+// key (free registration at core.ac.uk) for higher limits. Does not implement
+// DOIResolver or CitationSearcher: CORE v3 has no deterministic DOI-entity
+// endpoint and no citation graph (see issue #267).
+type COREProvider struct {
+	apiKey  string
+	baseURL string
+	deps    Deps
+}
+
+// NewCOREProvider creates the provider. apiKey is optional — CORE works
+// keyless at a lower shared rate; a key raises the limit.
+func NewCOREProvider(apiKey string, deps Deps) *COREProvider {
+	return &COREProvider{
+		apiKey:  apiKey,
+		baseURL: "https://api.core.ac.uk/v3",
+		deps:    deps,
+	}
+}
+
+// SetBaseURL overrides the API base URL (testing).
+func (p *COREProvider) SetBaseURL(base string) { p.baseURL = base }
+
+func (p *COREProvider) Name() string { return "core" }
+
+func (p *COREProvider) Metadata() ProviderMeta {
+	return ProviderMeta{
+		Regions:      []string{"*"},
+		Capabilities: []string{"academic", "fulltext"},
+		RateClass:    "free",
+		Description:  "CORE.ac.uk — 300M+ open-access research outputs with full text, aggregated from repositories worldwide",
+	}
+}
+
+func (p *COREProvider) Scholarly(ctx context.Context, params AcademicSearchParams) ([]AcademicResult, error) {
+	var results []AcademicResult
+	err := p.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = p.doSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+func (p *COREProvider) doSearch(ctx context.Context, params AcademicSearchParams) ([]AcademicResult, error) {
+	q := strings.TrimSpace(params.Query)
+	if q == "" {
+		return nil, nil // honor empty: no query, no results (no fallback)
+	}
+
+	if params.YearFrom > 0 && params.YearTo > 0 {
+		q = fmt.Sprintf("%s AND yearPublished>=%d AND yearPublished<=%d", q, params.YearFrom, params.YearTo)
+	} else if params.YearFrom > 0 {
+		q = fmt.Sprintf("%s AND yearPublished>=%d", q, params.YearFrom)
+	} else if params.YearTo > 0 {
+		q = fmt.Sprintf("%s AND yearPublished<=%d", q, params.YearTo)
+	}
+
+	qs := url.Values{}
+	qs.Set("q", q)
+	qs.Set("limit", strconv.Itoa(clamp(params.NumResults, 1, 25)))
+	qs.Set("fields", "title,abstract,fullText,doi,authors,yearPublished,downloadUrl")
+	if params.SortBy == "date" {
+		qs.Set("sort", "yearPublished:desc")
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, p.baseURL+"/search/works?"+qs.Encode(), nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/json")
+	if p.apiKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.apiKey)
+	}
+
+	resp, err := p.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("core: request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 512))
+		return nil, fmt.Errorf("core: API error %d: %s", resp.StatusCode, string(b))
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, coreMaxBody))
+	if err != nil {
+		return nil, fmt.Errorf("core: read body: %w", err)
+	}
+
+	var out coreSearchResponse
+	if err := json.Unmarshal(body, &out); err != nil {
+		return nil, fmt.Errorf("core: parse response: %w", err)
+	}
+	return coreWorksToResults(out.Results), nil
+}
+
+// coreSearchResponse models the CORE v3 /search/works response envelope.
+type coreSearchResponse struct {
+	Results []coreWork `json:"results"`
+}
+
+type coreWork struct {
+	Title         string       `json:"title"`
+	Abstract      string       `json:"abstract"`
+	FullText      string       `json:"fullText"`
+	DOI           string       `json:"doi"`
+	Authors       []coreAuthor `json:"authors"`
+	YearPublished int          `json:"yearPublished"`
+	DownloadURL   string       `json:"downloadUrl"`
+}
+
+type coreAuthor struct {
+	Name string `json:"name"`
+}
+
+// coreWorksToResults maps CORE works to AcademicResult, skipping any work with
+// neither a DOI nor a download URL (nothing to link the result to).
+func coreWorksToResults(works []coreWork) []AcademicResult {
+	out := make([]AcademicResult, 0, len(works))
+	for _, w := range works {
+		doi := strings.TrimSpace(w.DOI)
+		downloadURL := strings.TrimSpace(w.DownloadURL)
+
+		resultURL := downloadURL
+		if doi != "" {
+			resultURL = "https://doi.org/" + doi
+		}
+		if resultURL == "" {
+			continue // nothing to link this result to
+		}
+
+		abstract := strings.TrimSpace(w.Abstract)
+		if abstract == "" && w.FullText != "" {
+			abstract = truncateText(strings.TrimSpace(w.FullText), 500)
+		} else if abstract != "" {
+			abstract = truncateText(abstract, 500)
+		}
+
+		authors := make([]string, 0, len(w.Authors))
+		for _, a := range w.Authors {
+			if name := strings.TrimSpace(a.Name); name != "" {
+				authors = append(authors, name)
+			}
+		}
+
+		out = append(out, AcademicResult{
+			Title:      truncateText(strings.TrimSpace(w.Title), 300),
+			URL:        resultURL,
+			DOI:        doi,
+			Authors:    authors,
+			Year:       w.YearPublished,
+			Abstract:   abstract,
+			Source:     "core",
+			OpenAccess: true, // all CORE content is OA by definition
+			PDFUrl:     downloadURL,
+		})
+	}
+	return out
+}
+
+var _ AcademicProvider = (*COREProvider)(nil)

--- a/internal/search/core_live_test.go
+++ b/internal/search/core_live_test.go
@@ -1,0 +1,62 @@
+//go:build live
+
+// Live external-API integration test — excluded from the default suite.
+// Run with `make test-live`. CORE.ac.uk is keyless (works at a lower shared
+// rate); an optional CORE_API_KEY raises the limit. No skip on a missing key
+// — keyless mode must be exercised (see issue #267 Standards Checklist).
+package search
+
+import (
+	"context"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+func newCORELiveProvider() *COREProvider {
+	return NewCOREProvider(os.Getenv("CORE_API_KEY"), Deps{
+		HTTPClient: &http.Client{Timeout: 30 * time.Second},
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+}
+
+func TestCOREProvider_Live_Scholarly(t *testing.T) {
+	p := newCORELiveProvider()
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "climate change", NumResults: 3})
+	if err != nil {
+		t.Skipf("CORE unreachable (skipping): %v", err)
+	}
+	if len(res) == 0 {
+		t.Fatal("expected CORE results for 'climate change'")
+	}
+	for _, r := range res {
+		t.Logf("%d | %s | openAccess=%v | %s", r.Year, r.Title, r.OpenAccess, r.URL)
+		if r.URL == "" {
+			t.Errorf("result missing URL: %+v", r)
+		}
+		if !r.OpenAccess {
+			t.Errorf("every CORE result must be OpenAccess=true: %+v", r)
+		}
+	}
+}
+
+func TestCOREProvider_Live_Scholarly_WithYearFilter(t *testing.T) {
+	p := newCORELiveProvider()
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{
+		Query: "renewable energy", YearFrom: 2020, YearTo: 2023, NumResults: 5,
+	})
+	if err != nil {
+		t.Skipf("CORE unreachable (skipping): %v", err)
+	}
+	if len(res) == 0 {
+		t.Skip("CORE returned no results for the filtered query")
+	}
+	for _, r := range res {
+		if r.Year != 0 && r.Year < 2020 {
+			t.Errorf("year %d is below the requested 2020 floor", r.Year)
+		}
+	}
+}

--- a/internal/search/core_test.go
+++ b/internal/search/core_test.go
@@ -1,0 +1,201 @@
+package search
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+func newCORETestProvider(t *testing.T, apiKey string, handler http.HandlerFunc) *COREProvider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := NewCOREProvider(apiKey, Deps{
+		HTTPClient: srv.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+	p.SetBaseURL(srv.URL)
+	return p
+}
+
+func TestCOREProvider_Scholarly_Basic(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		if !strings.Contains(r.URL.Path, "/search/works") {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Write([]byte(`{"results":[
+			{"title":"Deep Learning for OA Discovery","abstract":"` + strings.Repeat("a", 600) + `","doi":"10.1234/abc","authors":[{"name":"Jane Doe"},{"name":"John Roe"}],"yearPublished":2024,"downloadUrl":"https://core.ac.uk/download/1.pdf"}
+		]}`))
+	})
+
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "machine learning", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("want 1 result, got %d", len(res))
+	}
+	r := res[0]
+	if !r.OpenAccess {
+		t.Error("OpenAccess must be true for every CORE result")
+	}
+	if r.URL != "https://doi.org/10.1234/abc" {
+		t.Errorf("URL = %q, want DOI-derived URL", r.URL)
+	}
+	if len([]rune(r.Abstract)) > 503 { // 500 + "..."
+		t.Errorf("abstract not truncated: %d runes", len([]rune(r.Abstract)))
+	}
+	if len(r.Authors) != 2 {
+		t.Errorf("Authors = %v, want 2", r.Authors)
+	}
+	if r.Source != "core" {
+		t.Errorf("Source = %q, want core", r.Source)
+	}
+}
+
+func TestCOREProvider_Scholarly_NoKey(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("no Authorization header expected, got %q", r.Header.Get("Authorization"))
+		}
+		w.Write([]byte(`{"results":[]}`))
+	})
+	if _, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCOREProvider_Scholarly_WithKey(t *testing.T) {
+	p := newCORETestProvider(t, "test-key", func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("Authorization"); got != "Bearer test-key" {
+			t.Errorf("Authorization = %q, want Bearer test-key", got)
+		}
+		w.Write([]byte(`{"results":[]}`))
+	})
+	if _, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCOREProvider_Scholarly_YearFilter(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query().Get("q")
+		if !strings.Contains(q, "yearPublished>=2020") || !strings.Contains(q, "yearPublished<=2023") {
+			t.Errorf("q = %q, want year-range clauses", q)
+		}
+		w.Write([]byte(`{"results":[]}`))
+	})
+	_, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", YearFrom: 2020, YearTo: 2023, NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCOREProvider_Scholarly_SortByDate(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Query().Get("sort") != "yearPublished:desc" {
+			t.Errorf("sort = %q, want yearPublished:desc", r.URL.Query().Get("sort"))
+		}
+		w.Write([]byte(`{"results":[]}`))
+	})
+	_, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", SortBy: "date", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestCOREProvider_Scholarly_FallbackURL(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"results":[{"title":"No DOI Work","downloadUrl":"https://core.ac.uk/download/2.pdf"}]}`))
+	})
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 || res[0].URL != "https://core.ac.uk/download/2.pdf" {
+		t.Fatalf("want downloadUrl fallback, got %+v", res)
+	}
+}
+
+func TestCOREProvider_Scholarly_AbstractFallback(t *testing.T) {
+	longText := strings.Repeat("full text body ", 60)
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"results":[{"title":"Full Text Only","doi":"10.1/xyz","fullText":"` + longText + `"}]}`))
+	})
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 || res[0].Abstract == "" {
+		t.Fatalf("want abstract derived from fullText, got %+v", res)
+	}
+	if len([]rune(res[0].Abstract)) > 503 {
+		t.Errorf("fullText-derived abstract not truncated: %d runes", len([]rune(res[0].Abstract)))
+	}
+}
+
+func TestCOREProvider_Scholarly_SkipsEmptyURL(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"results":[{"title":"No DOI No Download"},{"title":"Has DOI","doi":"10.1/ok"}]}`))
+	})
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(res) != 1 {
+		t.Fatalf("want the empty-URL work excluded, got %d results", len(res))
+	}
+}
+
+func TestCOREProvider_Scholarly_NonOKStatus(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte("rate limited"))
+	})
+	if _, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5}); err == nil {
+		t.Error("want error on HTTP 429")
+	}
+}
+
+func TestCOREProvider_Scholarly_MalformedJSON(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{broken json`))
+	})
+	if _, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "x", NumResults: 5}); err == nil {
+		t.Error("want error on malformed JSON")
+	}
+}
+
+func TestCOREProvider_Scholarly_EmptyQuery(t *testing.T) {
+	p := newCORETestProvider(t, "", func(w http.ResponseWriter, r *http.Request) {
+		t.Error("empty query must not hit the API")
+	})
+	res, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "   ", NumResults: 5})
+	if err != nil || res != nil {
+		t.Errorf("empty query should be a no-op, got res=%v err=%v", res, err)
+	}
+}
+
+func TestCOREProvider_Name(t *testing.T) {
+	p := NewCOREProvider("", Deps{})
+	if p.Name() != "core" {
+		t.Errorf("Name() = %q, want core", p.Name())
+	}
+}
+
+func TestCOREProvider_Metadata(t *testing.T) {
+	p := NewCOREProvider("", Deps{})
+	if !p.Metadata().HasCapability("fulltext") {
+		t.Error("Metadata capabilities should include fulltext")
+	}
+}
+
+func TestCOREKeyless(t *testing.T) {
+	if p := NewAcademicProviderByName("core", AcademicProviderConfig{}, Deps{}); p == nil {
+		t.Error("core should construct without any key")
+	}
+}

--- a/internal/search/domain.go
+++ b/internal/search/domain.go
@@ -213,15 +213,17 @@ type AcademicProviderConfig struct {
 	SemanticScholarAPIKey string // Semantic Scholar — optional; works keyless at a lower shared rate
 	PubMedAPIKey          string // PubMed E-utilities — optional; keyless by default, a key raises the rate
 	PubMedEmail           string // PubMed — optional NCBI contact (tool/email params), recommended not required
+	COREAPIKey            string // CORE.ac.uk — optional; keyless by default at a lower shared rate, a key raises the rate
 }
 
 // SupportedAcademicProviders lists all academic provider names. openalex and
 // crossref are authoritative bibliographic databases; pubmed is the biomedical
 // authority (NCBI E-utilities, keyless); semanticscholar adds AI-enrichment
-// (TLDR, citation intent/influence); exa is a neural-web alternate (research-paper
+// (TLDR, citation intent/influence); core is the largest OA full-text
+// aggregator (keyless); exa is a neural-web alternate (research-paper
 // category) — listed last so it sorts after them when no explicit routing is
 // configured.
-var SupportedAcademicProviders = []string{"openalex", "crossref", "pubmed", "semanticscholar", "exa"}
+var SupportedAcademicProviders = []string{"openalex", "crossref", "pubmed", "semanticscholar", "core", "exa"}
 
 // NewAcademicProviderByName creates an academic provider by name if configured.
 // Semantic Scholar is constructed even without an API key (it works at a lower
@@ -241,6 +243,9 @@ func NewAcademicProviderByName(name string, cfg AcademicProviderConfig, deps Dep
 		return NewPubMedProvider(cfg.PubMedAPIKey, cfg.PubMedEmail, deps)
 	case "semanticscholar":
 		return NewSemanticScholarProvider(cfg.SemanticScholarAPIKey, deps)
+	case "core":
+		// Keyless by default at a lower shared rate; a key raises it.
+		return NewCOREProvider(cfg.COREAPIKey, deps)
 	case "exa":
 		if cfg.ExaAPIKey != "" {
 			return NewExaProvider(cfg.ExaAPIKey, deps)

--- a/internal/search/domain_test.go
+++ b/internal/search/domain_test.go
@@ -108,6 +108,34 @@ func TestNewPatentProviderByName(t *testing.T) {
 	}
 }
 
+func TestSupportedAcademicProviders_IncludesCORE(t *testing.T) {
+	t.Parallel()
+
+	found := false
+	for _, name := range SupportedAcademicProviders {
+		if name == "core" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error(`SupportedAcademicProviders should include "core"`)
+	}
+}
+
+func TestAvailableAcademicProviders_IncludesCORE(t *testing.T) {
+	t.Parallel()
+
+	providers := AvailableAcademicProviders(AcademicProviderConfig{}, Deps{HTTPClient: nil})
+	p, ok := providers["core"]
+	if !ok {
+		t.Fatal(`AvailableAcademicProviders should construct "core" without any credentials`)
+	}
+	if p.Name() != "core" {
+		t.Errorf("Name() = %q, want core", p.Name())
+	}
+}
+
 func TestNewPatentProviderByName_MissingCredentials(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tools/academic.go
+++ b/internal/tools/academic.go
@@ -48,7 +48,7 @@ type academicSearchInput struct {
 	Source     string `json:"source,omitempty" jsonschema:"Restrict to an academic source: all (default), arxiv, pubmed, ieee, nature, springer."`
 	PDFOnly    bool   `json:"pdf_only,omitempty" jsonschema:"Only return papers with direct PDF links (default: false). Useful when you plan to scrape the full paper."`
 	SortBy     string `json:"sort_by,omitempty" jsonschema:"Sort order: relevance (default) or date (newest first)."`
-	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific provider. Academic: openalex, crossref, pubmed, semanticscholar, exa. Web fallback: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use automatic selection (recommended)."`
+	Provider   string `json:"provider,omitempty" jsonschema:"Force a specific provider. Academic: openalex, crossref, pubmed, semanticscholar, core, exa. Web fallback: google, brave, serper, searxng, searchapi, duckduckgo, tavily. Omit to use automatic selection (recommended)."`
 	OpenAccess bool   `json:"open_access,omitempty" jsonschema:"Only return open-access papers with free full-text (default: false)."`
 	SessionID  string `json:"sessionId,omitempty" jsonschema:"Link results to a sequential_search session. Sources are automatically recorded for recovery after context loss."`
 }
@@ -393,6 +393,8 @@ func academicProviderEnvHint(name string) string {
 		return "Set CROSSREF_EMAIL to your contact email."
 	case "semanticscholar":
 		return "Semantic Scholar works without a key at a lower shared rate; set SEMANTIC_SCHOLAR_API_KEY to raise the limit."
+	case "core":
+		return "CORE works without a key at a lower shared rate; set CORE_API_KEY to raise the limit."
 	case "exa":
 		return "Set EXA_API_KEY to your Exa API key."
 	default:

--- a/scripts/harness-413.sh
+++ b/scripts/harness-413.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Permanent regression gate for v1.45.0 "Academic Research Depth" (see issue
+# #413 and its tracked issues #267, #268, #269, #270, #283, #284, #286, #318,
+# #323, #352). Runs 6 independent gates in order; fails loud (non-zero exit)
+# on the first gate that fails. Re-run after every change to
+# internal/search/{core,pubmed,monarch,ct_logs,wayback_cdx,router}.go,
+# internal/scraper/{jina,youtube,pipeline}.go,
+# internal/tools/{paper_fulltext,monarchsearch,syllabus_search,gag_order_search,company_recon}.go,
+# lenses/{biomed,curriculum}.json, or their supporting tests.
+#
+# Usage: bash scripts/harness-413.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="$REPO_ROOT/.harness-out"
+mkdir -p "$OUT_DIR"
+
+GATE=0
+FAILED=0
+
+run_gate() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    local status=$?
+    echo "    FAIL (exit ${status}) — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+# go test with -run exits 0 and prints "no tests to run" when the pattern
+# matches nothing — a silent no-op that would let this gate rubber-stamp
+# tests that were never written. Treat that output as an explicit failure.
+require_tests_ran() {
+  if grep -q "no tests to run" "$1"; then
+    echo "no tests matched the -run pattern (target tests not written yet)" >>"$1"
+    return 1
+  fi
+  return 0
+}
+
+run_gate_requiring_tests() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1 && require_tests_ran "$logfile"; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    echo "    FAIL — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+run_gate "Lint (golangci-lint)" \
+  "$OUT_DIR/01-lint.log" \
+  make lint
+
+run_gate "SAST (gosec) + pattern checks (rules 2.1/2.2/2.3/2.4/2.5, 4.1/4.4)" \
+  "$OUT_DIR/02-sast.log" \
+  bash -c '
+    set -e
+    make sec
+    make vuln
+    echo "--- grep: no http.DefaultClient in new provider/scraper files (rule 2.4) ---"
+    ! grep -rln "http\.DefaultClient" internal/search/core.go internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go internal/scraper/jina.go 2>/dev/null
+    echo "--- grep: io.LimitReader present on every new response body (rule 4.1) ---"
+    for f in internal/search/core.go internal/search/monarch.go internal/scraper/jina.go; do
+      if [ -f "$f" ]; then
+        grep -q "io.LimitReader(resp.Body" "$f" || { echo "missing io.LimitReader cap in $f"; exit 1; }
+      fi
+    done
+    echo "--- grep: CURIE/domain input validated before URL interpolation (rule 2.2) ---"
+    for f in internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go; do
+      if [ -f "$f" ]; then
+        grep -qE "regexp\.MustCompile|url\.PathEscape|url\.Values\{\}" "$f" || { echo "missing input-validation/escaping pattern in $f"; exit 1; }
+      fi
+    done
+    echo "--- grep: no bearer/API key literals or key values in log/error strings (rule 2.3) ---"
+    ! grep -rnE "(Sprintf|Errorf|log\.).*\b(APIKey|apiKey|Bearer)\b.*%s" internal/search/core.go internal/search/monarch.go internal/scraper/jina.go internal/tools/syllabus_search.go internal/tools/gag_order_search.go 2>/dev/null
+    echo "--- grep: no TODO/FIXME left in new v1.45.0 files ---"
+    ! grep -rn "TODO\|FIXME" internal/search/core.go internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go internal/scraper/jina.go internal/tools/paper_fulltext.go internal/tools/monarchsearch.go internal/tools/syllabus_search.go internal/tools/gag_order_search.go internal/tools/company_recon.go 2>/dev/null
+  '
+
+run_gate_requiring_tests "Multi-instance isolation tests (rule 1.1/1.2/1.3)" \
+  "$OUT_DIR/03-isolation.log" \
+  go test ./internal/search/... ./internal/scraper/... ./internal/tools/... -run 'TestMultiInstance.*|TestAvailableAcademicProviders|TestAvailableProviders|TestConcurrentAccess|TestRouter_WebPerProviderCap_DoesNotMutateOriginalParams' -v -count=1
+
+run_gate "Dead-code scan (go vet + staticcheck via lint)" \
+  "$OUT_DIR/04-deadcode.log" \
+  go vet ./...
+
+run_gate "Unit/integration tests (Phase-1 rules 2-6)" \
+  "$OUT_DIR/05-unit.log" \
+  go test -race ./internal/search/... ./internal/scraper/... ./internal/tools/... ./internal/config/... ./internal/resources/... -count=1
+
+run_gate_requiring_tests "E2E (new tools reachable end-to-end, recorded proof)" \
+  "$OUT_DIR/06-e2e.log" \
+  go test -tags=e2e -run 'TestPaperFulltext|TestMonarchSearch|TestCompanyRecon|TestSyllabusSearch|TestGagOrderSearch' ./tests/e2e/... -v -count=1
+
+echo
+if [ "$FAILED" -ne 0 ]; then
+  echo "HARNESS FAILED — see logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+  exit 1
+fi
+
+echo "HARNESS PASSED — all 6 gates green. Logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+exit 0


### PR DESCRIPTION
## Summary
- Adds `COREProvider` (`internal/search/core.go`) implementing `search.AcademicProvider` — CORE.ac.uk, 300M+ open-access works with native full text, keyless by default (`CORE_API_KEY` raises the shared rate limit).
- Registers `core` in `SupportedAcademicProviders` / `NewAcademicProviderByName` / `AvailableAcademicProviders` (`internal/search/domain.go`), wired through `internal/config/config.go`, `cmd/web-researcher-mcp/main.go`, and the `academic_search` tool's provider enum/hint (`internal/tools/academic.go`).
- Docs: `.env.example`, `docs/TOOLS.md`, `docs/PROVIDERS.md` updated with CORE's capability row, coverage, and DOIResolver-exclusion note.
- `make gen-python-client` produces no diff (description-only schema change).

Part of the v1.45.0 Academic Research Depth milestone — spec and harness tracked in #413. Deliberately deviates from #267's Key Signatures sample: omitted stub `Citations()`/`References()`/`ResolveDOI()` methods since CORE implements neither `CitationSearcher` nor `DOIResolver` (per the issue's own "What" section) and `AcademicProvider` doesn't require them — avoids dead code. Will be called out in #413's Phase 4 closing comment.

Includes the cherry-picked harness commit from #414 (`scripts/harness-413.sh`) so the regression gate could run against this module during implementation; that file will show as already-merged once either PR lands first.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` clean
- [x] `go test -race ./internal/search/... ./internal/tools/... ./internal/config/...` — all pass, including new `TestCOREProvider_*` (14 cases) and `TestAvailableAcademicProviders_IncludesCORE` / `TestSupportedAcademicProviders_IncludesCORE`
- [x] `scripts/harness-413.sh` re-run: gates 1/2/4/5 pass; gates 3/6 still fail only on the 9 other unimplemented milestone modules (expected — tracked in #413)
- [x] `make gen-python-client` — zero diff

Closes part of #413 (module 1 of 10). Next: #268.

🤖 Generated with [Claude Code](https://claude.com/claude-code)