### PR TITLE
feat(scraper): add Jina Reader extraction tier (#270)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,6 +30,9 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 #                           # independent `answer` (grounded Q&A) and `structured_search` (schema
 #                           # extraction + company entities) tools, and a paid /contents fallback
 #                           # tier for scrape_page.
+# JINA_API_KEY=...          # optional; the Jina Reader scrape_page tier (r.jina.ai) works keyless
+#                           # on its free tier — a key only raises the rate limit (get from
+#                           # jina.ai/reader). Never required.
 # SEARXNG_URL=http://localhost:8080
 # If your SearXNG sits behind HTTP Basic auth (issue #109), supply the credential:
 # SEARXNG_BASIC_AUTH=user:password

--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,9 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 # MAX_SCRAPE_CONCURRENCY=5
 # MAX_HTML_BYTES sets the decompressed HTML body read cap per tier (default 8388608 = 8 MB)
 # MAX_DOCUMENT_BYTES sets the document (PDF/DOCX/PPTX) download cap (default 52428800 = 50 MB)
+# JINA_READER_DISABLED=true          # Turn off the Jina Reader scrape_page tier (r.jina.ai)
+                                    # entirely, e.g. for hardened deploys or network-free tests.
+                                    # Default false: the tier runs keyless unless disabled.
 
 # ── Search Lenses ────────────────────────────────────────────────────────────
 # A directory of your own lens JSON files (same shape as the bundled lenses/),

--- a/cmd/web-researcher-mcp/main.go
+++ b/cmd/web-researcher-mcp/main.go
@@ -384,6 +384,7 @@ func main() {
 		ChromePath:       cfg.ChromePath,
 		ExaAPIKey:        cfg.Search.ExaAPIKey,  // enables the paid Exa /contents fallback tier
 		JinaAPIKey:       cfg.Search.JinaAPIKey, // raises the keyless Jina Reader tier's rate limit
+		JinaDisabled:     cfg.JinaDisabled,      // JINA_READER_DISABLED: opt out of the Jina Reader tier entirely
 		MaxHTMLBytes:     cfg.MaxHTMLBytes,
 		MaxDocumentBytes: cfg.MaxDocumentBytes,
 		GitHubToken:      cfg.Search.GitHubToken, // raises GitHub's unauth rate limit for native README/blob/gist routing (#395)

--- a/cmd/web-researcher-mcp/main.go
+++ b/cmd/web-researcher-mcp/main.go
@@ -382,7 +382,8 @@ func main() {
 		AllowPrivateIPs:  cfg.AllowPrivateIPs,
 		AllowedDomains:   cfg.AllowedDomains,
 		ChromePath:       cfg.ChromePath,
-		ExaAPIKey:        cfg.Search.ExaAPIKey, // enables the paid Exa /contents fallback tier
+		ExaAPIKey:        cfg.Search.ExaAPIKey,  // enables the paid Exa /contents fallback tier
+		JinaAPIKey:       cfg.Search.JinaAPIKey, // raises the keyless Jina Reader tier's rate limit
 		MaxHTMLBytes:     cfg.MaxHTMLBytes,
 		MaxDocumentBytes: cfg.MaxDocumentBytes,
 		GitHubToken:      cfg.Search.GitHubToken, // raises GitHub's unauth rate limit for native README/blob/gist routing (#395)

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -522,6 +522,7 @@ DAILY_QUOTA_PER_TENANT=10000
 | `ALLOW_PRIVATE_IPS` | Disable SSRF protection | `false` |
 | `ALLOWED_DOMAINS` | Domain whitelist (comma-separated) | — (all allowed) |
 | `CHROME_PATH` | Custom Chrome/Chromium binary path; set to `"disabled"` to turn the browser tier off entirely (no autodetect, no download) | auto-detect |
+| `JINA_READER_DISABLED` | Set `true` to turn off the Jina Reader scrape tier (r.jina.ai) entirely, e.g. for hardened deploys or network-free tests | `false` |
 | `MAX_SCRAPE_CONCURRENCY` | Parallel scrape limit | `5` |
 | `MAX_HTML_BYTES` | Decompressed HTML body read cap per scrape tier | `8388608` (8 MB) |
 | `MAX_DOCUMENT_BYTES` | Document (PDF/DOCX/PPTX) download cap | `52428800` (50 MB) |

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -144,7 +144,7 @@ type ScrapeOutput struct {
     SizeCategory    string    `json:"sizeCategory"`   // small, medium, large, very_large
     Citation        *Citation `json:"citation"`       // always present
     Raw             bool      `json:"raw,omitempty"`  // true only in raw mode; omitted otherwise
-    ExtractedBy     string    `json:"extractedBy,omitempty"` // extraction tier: markdown|stealth|html|browser|exa:cached|exa:crawled; omitted when unknown
+    ExtractedBy     string    `json:"extractedBy,omitempty"` // extraction tier: markdown|stealth|jina|html|browser|exa:cached|exa:crawled; omitted when unknown
     ExtractionQuality string  `json:"extractionQuality,omitempty"` // complete when the pipeline returned a confident extraction; partial when every tier was exhausted and the best-quality candidate was returned instead. Never an error. Omitted in raw mode.
     WordCount         int     `json:"wordCount,omitempty"`         // words in the extracted content (#358); orthogonal to ExtractionQuality — a "complete" extraction can still be a thin paywall/bot-wall stub. Omitted in raw mode.
     SparsityWarning   string  `json:"sparsityWarning,omitempty"`   // present only when WordCount is below ~150 — the content may be too thin for a reliable claim check (#358). Omitted in raw mode and whenever content is not thin.
@@ -216,7 +216,7 @@ In `raw` mode the output additionally carries `"raw": true`, and `contentType` i
 
 **Structured data (#46).** When the page embeds machine-readable metadata, the response carries a `structuredData` object alongside `content`: `jsonLd` (each `<script type="application/ld+json">` block, kept verbatim — invalid JSON is skipped, never failing the scrape), `openGraph` (`og:*`/`article:*` meta, keys keep their prefix), and `citation` (Highwire `citation_*` meta — DOI, authors, journal). The whole object is omitted when no such markup is present, and each sub-field is omitted when empty. It is produced by the HTML-extraction tiers only (absent for `raw` mode, PDFs, YouTube, and markdown-tier results), is independently size-bounded so a pathological page cannot blow the response budget, and is **untrusted external data** under the same trust boundary as `content`.
 
-**Extraction provenance (`extractedBy`).** When known, the response names the tier that produced the content: `markdown`, `stealth`, `html`, `browser`, `github:raw`/`github:contents-api`/`github:gist-api`, or — for the paid Exa fallback — `exa:cached` / `exa:crawled`. It lets a caller see whether content came from a free local tier or the metered Exa `/contents` API (Tier 5, present only when `EXA_API_KEY` is set). Omitted when unknown (e.g. document/YouTube routes).
+**Extraction provenance (`extractedBy`).** When known, the response names the tier that produced the content: `markdown`, `stealth`, `jina`, `html`, `browser`, `github:raw`/`github:contents-api`/`github:gist-api`, or — for the paid Exa fallback — `exa:cached` / `exa:crawled`. It lets a caller see whether content came from a free local tier or the metered Exa `/contents` API (Tier 5, present only when `EXA_API_KEY` is set). Omitted when unknown (e.g. document/YouTube routes).
 
 **Content-volume signal (#358).** `wordCount` is emitted for every non-raw scrape and is a cheap, deterministic proxy for how much prose was actually extracted — it is **orthogonal** to `extractionQuality`, which reflects pipeline tier exhaustion, not content volume: a `complete` extraction can still be a thin paywall/bot-wall stub (a few sentences behind a subscribe wall) if that stub was returned confidently by an early tier. When `wordCount` falls below ~150, `sparsityWarning` is added with a human-readable note that claim checks against this source may be unreliable. Both fields are omitted in raw mode. `verify_citation`, `audit_bibliography`, and `search_and_scrape` surface the same signal (see their sections below) so a caller can tell a thin stub from a genuinely well-supported claim check.
 
@@ -272,7 +272,7 @@ Raw responses are keyed like any other scrape: the cache key includes `mode` (so
    ├─ .docx / application/vnd.openxmlformats* → DOCX parser
    └─ .pptx / application/vnd.ms-powerpoint → PPTX parser
 
-3. WEB PAGE EXTRACTION (4 free tiers, ordered by speed; + optional paid Exa tier last)
+3. WEB PAGE EXTRACTION (5 free tiers, ordered by speed; + optional paid Exa tier last)
    a) Tier 1: MARKDOWN NEGOTIATION (fastest, ~200ms)
       ├─ Send GET with Accept: text/markdown
       ├─ 5-second timeout
@@ -287,7 +287,15 @@ Raw responses are keyed like any other scrape: the cache key includes `mode` (so
       ├─ SSRF protection via safe dialer when AllowPrivateIPs=false
       └─ If below 100-char threshold → next tier
 
-   c) Tier 3: HTML EXTRACTION via goquery (standard, ~500ms)
+   c) Tier 2.5: JINA READER (cloud proxy, free/keyless, ~1-3s) — skipped when
+      JINA_READER_DISABLED is set (#270)
+      ├─ POST to r.jina.ai with the target URL; returns clean extracted markdown
+      ├─ Recovers Cloudflare/JS-heavy pages the local HTTP tiers (a, b) cannot,
+      │  without paying for the browser tier
+      ├─ Keyless free tier; optional JINA_API_KEY only raises the rate limit
+      └─ If empty content or HTTP error → next tier
+
+   d) Tier 3: HTML EXTRACTION via goquery (standard, ~500ms)
       ├─ Fetch page with standard Accept header
       ├─ Parse with goquery
       ├─ Extract: article > main > body (priority order)
@@ -295,7 +303,7 @@ Raw responses are keyed like any other scrape: the cache key includes `mode` (so
       ├─ Minimum content: 100 bytes, 10% meaningful text ratio
       └─ If below threshold → next tier
 
-   d) Tier 4: HEADLESS BROWSER via go-rod + stealth (slow, ~5s)
+   e) Tier 4: HEADLESS BROWSER via go-rod + stealth (slow, ~5s)
       ├─ Browser pool with lazy init + singleton pattern
       ├─ go-rod/stealth plugin (navigator spoofing, WebGL masking)
       ├─ Used for: Known SPA domains, JS-rendered content, bot challenges
@@ -303,7 +311,7 @@ Raw responses are keyed like any other scrape: the cache key includes `mode` (so
       ├─ Extract: rendered DOM via JavaScript evaluation
       └─ Graceful cleanup via Pipeline.Close()
 
-   e) Tier 5: EXA /contents (PAID, opt-in, last resort) — only when EXA_API_KEY is set
+   f) Tier 5: EXA /contents (PAID, opt-in, last resort) — only when EXA_API_KEY is set
       ├─ Neural extractor: POST https://api.exa.ai/contents (x-api-key auth)
       ├─ Runs ONLY after every free tier above failed to extract >100 bytes,
       │  so the common path never incurs Exa cost

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -135,6 +135,7 @@ type SearchConfig struct {
 	SearchAPIKey       string
 	TavilyAPIKey       string
 	ExaAPIKey          string
+	JinaAPIKey         string // optional; the Jina Reader scraper tier works keyless, a key raises its rate limit
 	SearXNGURL         string
 	SearXNGBasicAuth   string            // raw "user:password" for a SearXNG behind HTTP Basic auth; "" => none (never logged)
 	SearXNGHeaders     map[string]string // validated static request headers for SearXNG; nil/empty => none
@@ -361,6 +362,7 @@ func Load() (*Config, error) {
 			SearchAPIKey:          searchAPIKey,
 			TavilyAPIKey:          tavilyKey,
 			ExaAPIKey:             exaKey,
+			JinaAPIKey:            os.Getenv("JINA_API_KEY"),
 			SearXNGURL:            searxngURL,
 			SearXNGBasicAuth:      searxngBasicAuth,
 			SearXNGHeaders:        searxngHeaders,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -30,6 +30,7 @@ type Config struct {
 	AllowPrivateIPs        bool
 	AllowedDomains         []string
 	ChromePath             string
+	JinaDisabled           bool
 	MaxScrapeConcurrency   int
 	MaxHTMLBytes           int
 	MaxDocumentBytes       int
@@ -433,6 +434,7 @@ func Load() (*Config, error) {
 		AllowPrivateIPs:      envBool("ALLOW_PRIVATE_IPS", false),
 		AllowedDomains:       splitCSV(os.Getenv("ALLOWED_DOMAINS")),
 		ChromePath:           os.Getenv("CHROME_PATH"),
+		JinaDisabled:         envBool("JINA_READER_DISABLED", false),
 		MaxScrapeConcurrency: envInt("MAX_SCRAPE_CONCURRENCY", 5),
 		MaxHTMLBytes:         envInt("MAX_HTML_BYTES", 8<<20),
 		MaxDocumentBytes:     envInt("MAX_DOCUMENT_BYTES", 50<<20),

--- a/internal/scraper/exa_test.go
+++ b/internal/scraper/exa_test.go
@@ -135,7 +135,9 @@ func TestScrapeExaFallthrough(t *testing.T) {
 	withExaEndpoint(t, exa.URL)
 
 	// ChromePath:"disabled" removes the browser tier so the run is deterministic;
-	// Exa is the only configured fallback after markdown/stealth/html fail.
+	// Exa is the only configured fallback after markdown/stealth/jina/html fail.
+	// The Jina tier (now unconditionally in the ladder, #270) falls through on
+	// TestMain's package-wide empty-content stub, same as the free HTTP tiers.
 	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: "disabled", ExaAPIKey: "k"})
 	res, err := p.Scrape(context.Background(), page.URL, 5000)
 	if err != nil {
@@ -165,7 +167,9 @@ func TestScrapeExaTierAbsentWhenUnconfigured(t *testing.T) {
 	}))
 	defer page.Close()
 
-	// No ExaAPIKey ⇒ tier not appended.
+	// No ExaAPIKey ⇒ tier not appended. The Jina tier (now unconditionally in
+	// the ladder, #270) falls through on TestMain's package-wide empty-content
+	// stub, same as the free HTTP tiers.
 	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: "disabled"})
 	_, _ = p.Scrape(context.Background(), page.URL, 5000)
 	if exaCalled {

--- a/internal/scraper/jina.go
+++ b/internal/scraper/jina.go
@@ -1,0 +1,105 @@
+package scraper
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+// JinaReaderURL is Jina Reader's content-extraction endpoint: a target URL is
+// appended to the path and clean extracted markdown comes back. It sits
+// between the stealth and html tiers in the pipeline (#270) because it is a
+// cloud proxy that resolves Cloudflare/JS-heavy pages the local HTTP tiers
+// cannot, without paying for the browser tier. Keyless free tier; an optional
+// JinaAPIKey raises the rate limit only.
+//
+// Exported (unlike exaContentsURL) and a package var rather than a
+// PipelineConfig field: the Jina tier is unconditional — unlike Exa (gated on
+// an API key) or the browser tier (gated on Chrome availability), every
+// pipeline test everywhere reaches it, including dozens of pre-existing
+// internal/tools tests that construct their own scraper.Pipeline against
+// local httptest servers. A single exported var lets any package redirect it
+// with one TestMain, instead of threading a new config field through every
+// existing call site.
+var JinaReaderURL = "https://r.jina.ai/"
+
+// scrapeJina extracts page content via Jina Reader. It runs unconditionally
+// (no API key required) as the pipeline's "tier 2.5", after stealth and before
+// the html tier.
+//
+// The same SSRF/allowlist guards as every other tier already ran in Scrape
+// before this tier is reached; this method only performs the outbound request
+// to the fixed, trusted r.jina.ai host, not a direct fetch of the user URL.
+func (p *Pipeline) scrapeJina(ctx context.Context, pageURL string, maxLength int) (*ScrapeResult, error) {
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := JinaReaderURL + url.QueryEscape(pageURL)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, networkError(pageURL, "jina", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("X-Return-Format", "markdown")
+	if p.config.JinaAPIKey != "" {
+		req.Header.Set("Authorization", "Bearer "+p.config.JinaAPIKey) // never logged
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return nil, networkError(pageURL, "jina", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		return nil, rateLimitError(pageURL, "jina")
+	}
+	if resp.StatusCode >= 400 {
+		return nil, classifyHTTPStatus(resp.StatusCode, pageURL, "jina")
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+	if err != nil {
+		return nil, networkError(pageURL, "jina", err)
+	}
+
+	var jr jinaResponse
+	if err := json.Unmarshal(body, &jr); err != nil {
+		return nil, contentError(pageURL, fmt.Sprintf("jina: parse response: %v", err))
+	}
+	if jr.Data.Content == "" {
+		return nil, contentError(pageURL, "jina returned no extractable content")
+	}
+
+	content := jr.Data.Content
+	truncated := false
+	if maxLength > 0 && len(content) > maxLength {
+		content = truncateBytes(content, maxLength)
+		truncated = true
+	}
+
+	return &ScrapeResult{
+		URL:         pageURL,
+		Content:     content,
+		ContentType: "text/markdown",
+		Title:       jr.Data.Title,
+		Tier:        "jina",
+		Truncated:   truncated,
+	}, nil
+}
+
+type jinaResponse struct {
+	Code   int      `json:"code"`
+	Status int      `json:"status"`
+	Data   jinaData `json:"data"`
+}
+
+type jinaData struct {
+	Title   string `json:"title"`
+	URL     string `json:"url"`
+	Content string `json:"content"`
+}

--- a/internal/scraper/jina.go
+++ b/internal/scraper/jina.go
@@ -34,7 +34,20 @@ var JinaReaderURL = "https://r.jina.ai/"
 // The same SSRF/allowlist guards as every other tier already ran in Scrape
 // before this tier is reached; this method only performs the outbound request
 // to the fixed, trusted r.jina.ai host, not a direct fetch of the user URL.
+//
+// JinaDisabled is the tier's kill switch (JINA_READER_DISABLED env var),
+// mirroring ChromePath=disabled for the browser tier: unlike Exa (opt-in via
+// an API key), Jina runs unconditionally, so a deployment or test context
+// that wants zero dependency on this third-party proxy needs an explicit way
+// to turn it off. It also keeps e2e tests deterministic: e2e spawns a real
+// subprocess against local httptest servers, so JinaReaderURL cannot be
+// stubbed there the way unit tests do via TestMain — without a kill switch,
+// the tier makes a genuine call to production r.jina.ai during those tests.
 func (p *Pipeline) scrapeJina(ctx context.Context, pageURL string, maxLength int) (*ScrapeResult, error) {
+	if p.config.JinaDisabled {
+		return nil, contentError(pageURL, "jina tier disabled")
+	}
+
 	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/scraper/jina_test.go
+++ b/internal/scraper/jina_test.go
@@ -1,0 +1,195 @@
+package scraper
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+)
+
+// TestMain redirects the package-wide default JinaReaderURL to a local stub
+// server for the whole test binary (#270): the Jina tier is unconditionally in
+// scrapeWithTieredFallback's ladder, so without this every existing pipeline
+// test that doesn't already stub a specific tier would otherwise make a real
+// network call to r.jina.ai. The stub returns empty content, so it behaves
+// like Jina having nothing to add — tiers earlier/later in the ladder decide
+// the result exactly as they did before this tier existed. Individual tests
+// override it via withJinaEndpoint when they need to assert Jina-specific
+// behavior.
+func TestMain(m *testing.M) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":""}}`))
+	}))
+	JinaReaderURL = stub.URL + "/"
+	code := m.Run()
+	stub.Close()
+	os.Exit(code)
+}
+
+// withJinaEndpoint points the Jina Reader base URL at a test server for the
+// duration of the test, restoring it afterward.
+func withJinaEndpoint(t *testing.T, url string) {
+	t.Helper()
+	prev := JinaReaderURL
+	JinaReaderURL = url
+	t.Cleanup(func() { JinaReaderURL = prev })
+}
+
+func TestScrapeJinaSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("X-Return-Format") != "markdown" {
+			t.Errorf("missing X-Return-Format: markdown, got %q", r.Header.Get("X-Return-Format"))
+		}
+		if r.Header.Get("Authorization") != "" {
+			t.Errorf("no key configured, Authorization must be absent, got %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"title":"T","url":"https://x.example","content":"extracted markdown body"}}`))
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	res, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "extracted markdown body" {
+		t.Errorf("content mismatch: %q", res.Content)
+	}
+	if res.Tier != "jina" {
+		t.Errorf("tier should be jina, got %q", res.Tier)
+	}
+	if res.Title != "T" {
+		t.Errorf("title mismatch: %+v", res)
+	}
+}
+
+func TestScrapeJinaWithAPIKey(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get("Authorization") != "Bearer k123" {
+			t.Errorf("missing bearer key, got %q", r.Header.Get("Authorization"))
+		}
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":"keyed body"}}`))
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, JinaAPIKey: "k123"})
+	res, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if res.Content != "keyed body" {
+		t.Errorf("content mismatch: %q", res.Content)
+	}
+}
+
+func TestScrapeJinaEmptyContent(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":""}}`))
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	_, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	if err == nil {
+		t.Fatal("empty content should error so the orchestrator can keep falling back")
+	}
+}
+
+func TestScrapeJinaRateLimit(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(429)
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	_, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	se, ok := err.(*ScrapeError)
+	if !ok || se.Kind != ErrRateLimit {
+		t.Errorf("429 should map to ErrRateLimit, got %v", err)
+	}
+}
+
+func TestScrapeJinaHTTPError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(403)
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	_, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	se, ok := err.(*ScrapeError)
+	if !ok || se.Kind != ErrBlocked {
+		t.Errorf("403 should map to ErrBlocked, got %v", err)
+	}
+}
+
+func TestScrapeJinaTruncation(t *testing.T) {
+	longContent := ""
+	for i := 0; i < 100; i++ {
+		longContent += "0123456789"
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":"` + longContent + `"}}`))
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	res, err := p.scrapeJina(context.Background(), "https://x.example", 50)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.Truncated {
+		t.Error("expected Truncated=true")
+	}
+	if len(res.Content) != 50 {
+		t.Errorf("expected content capped at 50 bytes, got %d", len(res.Content))
+	}
+}
+
+func TestScrapeJinaNetworkError(t *testing.T) {
+	withJinaEndpoint(t, "http://127.0.0.1:1/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	_, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	se, ok := err.(*ScrapeError)
+	if !ok || se.Kind != ErrNetwork {
+		t.Errorf("connection refused should map to ErrNetwork, got %v", err)
+	}
+}
+
+// TestScrapeJinaFallthrough verifies the Jina tier fires between stealth and
+// html: a page the free stealth/markdown tiers cannot extract (empty body)
+// falls through to Jina, and the result carries the jina tier.
+func TestScrapeJinaFallthrough(t *testing.T) {
+	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body></body></html>"))
+	}))
+	defer page.Close()
+
+	jina := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":"recovered by jina reader tier"}}`))
+	}))
+	defer jina.Close()
+	withJinaEndpoint(t, jina.URL+"/")
+
+	// ChromePath:"disabled" removes the browser tier so the run is deterministic.
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: "disabled"})
+	res, err := p.Scrape(context.Background(), page.URL, 5000)
+	if err != nil {
+		t.Fatalf("expected Jina fallback to recover content, got: %v", err)
+	}
+	if res.Content != "recovered by jina reader tier" {
+		t.Errorf("content should come from Jina tier, got %q", res.Content)
+	}
+	if res.Tier != "jina" {
+		t.Errorf("tier should be jina, got %q", res.Tier)
+	}
+}

--- a/internal/scraper/jina_test.go
+++ b/internal/scraper/jina_test.go
@@ -164,6 +164,28 @@ func TestScrapeJinaNetworkError(t *testing.T) {
 	}
 }
 
+// TestScrapeJinaDisabled verifies the JinaDisabled kill switch short-circuits
+// before any network call, so a deployment or test context can opt out of
+// the tier's dependency on r.jina.ai entirely (mirrors ChromePath="disabled").
+func TestScrapeJinaDisabled(t *testing.T) {
+	called := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":"should not be reached"}}`))
+	}))
+	defer srv.Close()
+	withJinaEndpoint(t, srv.URL+"/")
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, JinaDisabled: true})
+	_, err := p.scrapeJina(context.Background(), "https://x.example", 5000)
+	if err == nil {
+		t.Fatal("expected error when Jina tier is disabled")
+	}
+	if called {
+		t.Error("scrapeJina made a network call despite JinaDisabled=true")
+	}
+}
+
 // TestScrapeJinaFallthrough verifies the Jina tier fires between stealth and
 // html: a page the free stealth/markdown tiers cannot extract (empty body)
 // falls through to Jina, and the result carries the jina tier.

--- a/internal/scraper/pipeline.go
+++ b/internal/scraper/pipeline.go
@@ -32,6 +32,12 @@ type PipelineConfig struct {
 	// raises the free-tier rate limit via the Authorization header. Empty
 	// (default) ⇒ requests are sent unauthenticated.
 	JinaAPIKey string
+	// JinaDisabled turns the Jina Reader tier off entirely (JINA_READER_DISABLED
+	// env var), mirroring ChromePath=disabled for the browser tier. Unlike Exa
+	// (opt-in via an API key), Jina runs unconditionally by default, so this is
+	// the only way to remove its outbound dependency on r.jina.ai — e.g. for
+	// hardened deployments or e2e tests that must stay network-free.
+	JinaDisabled bool
 	// MaxHTMLBytes bounds the decompressed HTML body each HTML-parsing tier reads
 	// before extraction (stealth, html, patents). Zero ⇒ the NewPipeline default.
 	MaxHTMLBytes int

--- a/internal/scraper/pipeline.go
+++ b/internal/scraper/pipeline.go
@@ -27,6 +27,11 @@ type PipelineConfig struct {
 	// pages, and Exa only spends a request on the hard pages they cannot extract.
 	// Empty (default) ⇒ the tier is absent and no Exa request is ever made.
 	ExaAPIKey string
+	// JinaAPIKey is optional (#270): the Jina Reader tier ("jina") is always
+	// present in the pipeline, keyless free tier included — JinaAPIKey only
+	// raises the free-tier rate limit via the Authorization header. Empty
+	// (default) ⇒ requests are sent unauthenticated.
+	JinaAPIKey string
 	// MaxHTMLBytes bounds the decompressed HTML body each HTML-parsing tier reads
 	// before extraction (stealth, html, patents). Zero ⇒ the NewPipeline default.
 	MaxHTMLBytes int
@@ -335,6 +340,7 @@ func (p *Pipeline) tieredFallback(ctx context.Context, url string, maxLength, de
 	tiers := []namedTier{
 		{"markdown", p.scrapeMarkdown},
 		{"stealth", p.scrapeStealth},
+		{"jina", p.scrapeJina},
 		{"html", p.scrapeHTML},
 	}
 

--- a/internal/tools/schemas.go
+++ b/internal/tools/schemas.go
@@ -196,7 +196,7 @@ var scrapePageOutputSchema = map[string]any{
 		"estimatedTokens":   map[string]any{"type": "integer"},
 		"sizeCategory":      map[string]any{"type": "string"},
 		"raw":               map[string]any{"type": "boolean"},
-		"extractedBy":       map[string]any{"type": "string", "description": "Which extraction tier produced the content (markdown, stealth, html, browser, or exa:cached/exa:crawled for the paid Exa fallback). Provenance only; omitted when unknown."},
+		"extractedBy":       map[string]any{"type": "string", "description": "Which extraction tier produced the content (markdown, stealth, jina, html, browser, or exa:cached/exa:crawled for the paid Exa fallback). Provenance only; omitted when unknown."},
 		"citation": map[string]any{
 			"type": "object",
 			"properties": map[string]any{

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strings"
 	"sync"
 	"testing"
@@ -30,6 +31,23 @@ import (
 	"github.com/zoharbabin/web-researcher-mcp/internal/useranalytics"
 	"github.com/zoharbabin/web-researcher-mcp/internal/workspace"
 )
+
+// TestMain redirects scraper.JinaReaderURL to a local stub for the whole test
+// binary (#270): the Jina Reader scrape tier is unconditional (no API-key
+// gate), so every test in this package that builds a scraper.Pipeline against
+// a local httptest server would otherwise leak a real network call to
+// r.jina.ai. The stub returns empty content, so it behaves like Jina having
+// nothing to add — the remaining tiers decide the result exactly as they did
+// before this tier existed.
+func TestMain(m *testing.M) {
+	stub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"code":200,"status":20000,"data":{"content":""}}`))
+	}))
+	scraper.JinaReaderURL = stub.URL + "/"
+	code := m.Run()
+	stub.Close()
+	os.Exit(code)
+}
 
 type mockProvider struct{}
 

--- a/scripts/harness-413.sh
+++ b/scripts/harness-413.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Permanent regression gate for v1.45.0 "Academic Research Depth" (see issue
+# #413 and its tracked issues #267, #268, #269, #270, #283, #284, #286, #318,
+# #323, #352). Runs 6 independent gates in order; fails loud (non-zero exit)
+# on the first gate that fails. Re-run after every change to
+# internal/search/{core,pubmed,monarch,ct_logs,wayback_cdx,router}.go,
+# internal/scraper/{jina,youtube,pipeline}.go,
+# internal/tools/{paper_fulltext,monarchsearch,syllabus_search,gag_order_search,company_recon}.go,
+# lenses/{biomed,curriculum}.json, or their supporting tests.
+#
+# Usage: bash scripts/harness-413.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="$REPO_ROOT/.harness-out"
+mkdir -p "$OUT_DIR"
+
+GATE=0
+FAILED=0
+
+run_gate() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    local status=$?
+    echo "    FAIL (exit ${status}) — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+# go test with -run exits 0 and prints "no tests to run" when the pattern
+# matches nothing — a silent no-op that would let this gate rubber-stamp
+# tests that were never written. Treat that output as an explicit failure.
+require_tests_ran() {
+  if grep -q "no tests to run" "$1"; then
+    echo "no tests matched the -run pattern (target tests not written yet)" >>"$1"
+    return 1
+  fi
+  return 0
+}
+
+run_gate_requiring_tests() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1 && require_tests_ran "$logfile"; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    echo "    FAIL — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+run_gate "Lint (golangci-lint)" \
+  "$OUT_DIR/01-lint.log" \
+  make lint
+
+run_gate "SAST (gosec) + pattern checks (rules 2.1/2.2/2.3/2.4/2.5, 4.1/4.4)" \
+  "$OUT_DIR/02-sast.log" \
+  bash -c '
+    set -e
+    make sec
+    make vuln
+    echo "--- grep: no http.DefaultClient in new provider/scraper files (rule 2.4) ---"
+    ! grep -rln "http\.DefaultClient" internal/search/core.go internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go internal/scraper/jina.go 2>/dev/null
+    echo "--- grep: io.LimitReader present on every new response body (rule 4.1) ---"
+    for f in internal/search/core.go internal/search/monarch.go internal/scraper/jina.go; do
+      if [ -f "$f" ]; then
+        grep -q "io.LimitReader(resp.Body" "$f" || { echo "missing io.LimitReader cap in $f"; exit 1; }
+      fi
+    done
+    echo "--- grep: CURIE/domain input validated before URL interpolation (rule 2.2) ---"
+    for f in internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go; do
+      if [ -f "$f" ]; then
+        grep -qE "regexp\.MustCompile|url\.PathEscape|url\.Values\{\}" "$f" || { echo "missing input-validation/escaping pattern in $f"; exit 1; }
+      fi
+    done
+    echo "--- grep: no bearer/API key literals or key values in log/error strings (rule 2.3) ---"
+    ! grep -rnE "(Sprintf|Errorf|log\.).*\b(APIKey|apiKey|Bearer)\b.*%s" internal/search/core.go internal/search/monarch.go internal/scraper/jina.go internal/tools/syllabus_search.go internal/tools/gag_order_search.go 2>/dev/null
+    echo "--- grep: no TODO/FIXME left in new v1.45.0 files ---"
+    ! grep -rn "TODO\|FIXME" internal/search/core.go internal/search/monarch.go internal/search/ct_logs.go internal/search/wayback_cdx.go internal/scraper/jina.go internal/tools/paper_fulltext.go internal/tools/monarchsearch.go internal/tools/syllabus_search.go internal/tools/gag_order_search.go internal/tools/company_recon.go 2>/dev/null
+  '
+
+run_gate_requiring_tests "Multi-instance isolation tests (rule 1.1/1.2/1.3)" \
+  "$OUT_DIR/03-isolation.log" \
+  go test ./internal/search/... ./internal/scraper/... ./internal/tools/... -run 'TestMultiInstance.*|TestAvailableAcademicProviders|TestAvailableProviders|TestConcurrentAccess|TestRouter_WebPerProviderCap_DoesNotMutateOriginalParams' -v -count=1
+
+run_gate "Dead-code scan (go vet + staticcheck via lint)" \
+  "$OUT_DIR/04-deadcode.log" \
+  go vet ./...
+
+run_gate "Unit/integration tests (Phase-1 rules 2-6)" \
+  "$OUT_DIR/05-unit.log" \
+  go test -race ./internal/search/... ./internal/scraper/... ./internal/tools/... ./internal/config/... ./internal/resources/... -count=1
+
+run_gate_requiring_tests "E2E (new tools reachable end-to-end, recorded proof)" \
+  "$OUT_DIR/06-e2e.log" \
+  go test -tags=e2e -run 'TestPaperFulltext|TestMonarchSearch|TestCompanyRecon|TestSyllabusSearch|TestGagOrderSearch' ./tests/e2e/... -v -count=1
+
+echo
+if [ "$FAILED" -ne 0 ]; then
+  echo "HARNESS FAILED — see logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+  exit 1
+fi
+
+echo "HARNESS PASSED — all 6 gates green. Logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+exit 0

--- a/tests/e2e/scrape_errors_e2e_test.go
+++ b/tests/e2e/scrape_errors_e2e_test.go
@@ -14,7 +14,11 @@ func TestScrapeErrors_E2E(t *testing.T) {
 	// These subtests point the scraper at local httptest servers (127.0.0.1) to
 	// exercise per-status error handling. Allow private IPs so the SSRF guard
 	// doesn't block the loopback target before the scraper sees the response.
-	h := newMCPTestHarness(t, "ALLOW_PRIVATE_IPS=true")
+	// Disable the Jina Reader tier: it would otherwise make a genuine outbound
+	// call to production r.jina.ai for these fixtures, which is both slow and
+	// non-deterministic (Jina's own anti-abuse network checks can 403 requests
+	// unrelated to the fixture's actual response).
+	h := newMCPTestHarness(t, "ALLOW_PRIVATE_IPS=true", "JINA_READER_DISABLED=true")
 
 	// Initialize
 	h.send(jsonRPCRequest{


### PR DESCRIPTION
## Summary
- Adds an unconditional `jina` tier (`r.jina.ai`) to the scrape pipeline's tier ladder — `markdown → stealth → jina → html → [browser] → [exa]` — for Cloudflare/JS-heavy pages the local HTTP tiers can't resolve, without paying for the browser tier.
- Keyless free tier; optional `JINA_API_KEY` only raises the rate limit via the `Authorization` header (never logged).
- Part of the v1.45.0 "Academic Research Depth" harnessed build (tracker: #413, harness: #414). Module 3 of 10 in the build order.

## Spec deviation (found mid-implementation)
Issue #270 describes mirroring `exa.go`'s pattern (unexported package var for the endpoint, test-redirected per-package). Exa can get away with an unexported var because it's gated behind `ExaAPIKey` — in test environments with no key configured, the tier is never appended to the ladder, so no test accidentally reaches the real API.

Jina has no such gate — it's unconditional. Making the var unexported would mean every pre-existing `internal/tools` test that constructs its own `scraper.Pipeline` against a local `httptest` server (29 call sites) would silently fall through to a real network call to `r.jina.ai`. This surfaced as a real regression: `go test -race ./...` run across the full repo (not just `internal/scraper` in isolation) failed `TestScrapeTool_ThinContent_ReturnsContentError` because the real Jina endpoint returned an HTTP 403, corrupting the test's expected tier-ladder behavior.

Fix: exported the var as `scraper.JinaReaderURL` and added a package-wide `TestMain` in both `internal/scraper/jina_test.go` and `internal/tools/tools_test.go` that redirects it to a local stub returning empty content — this makes Jina behave like "nothing to add" for tests that don't specifically exercise it, exactly as it did before the tier existed. This was a smaller, more surgical fix than threading a new `PipelineConfig` field through all 29 existing call sites.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `gofmt -l` (clean)
- [x] `go tool golangci-lint run` (0 issues)
- [x] `go tool govulncheck ./...` (no vulnerabilities)
- [x] `go test -race ./...` (all packages pass)
- [x] `internal/tools/metadata_test.go` drift gates: `TestOutputSchemaMatchesResponse`, `TestToolsDocMatchesRegistry`, `TestProvidersDocStructuredDomainTable`, `TestAllToolsHaveAnnotations` — all pass (no tool schema changed, so no Python client regen needed)
- [x] New unit tests in `internal/scraper/jina_test.go`: success, API-key header, empty-content error, 429 rate limit, HTTP error classification, truncation, network error, and full-pipeline fallthrough (jina fires between stealth and html)
- [x] `internal/scraper/exa_test.go` fallthrough tests updated with comments noting the new unconditional jina tier in the ladder

## Harness (`scripts/harness-413.sh`) gate-by-gate status
| Gate | Result | Note |
|---|---|---|
| 1. Lint | PASS | |
| 2. SAST + pattern checks | PASS | |
| 3. Multi-instance isolation | FAIL (expected) | Fails only on `-run` patterns for tools not yet built (`paper_fulltext`, `monarch_search`, etc.) — out of scope for #270 |
| 4. Dead-code scan | PASS | |
| 5. Unit/integration tests | PASS | Covers #270's new tests |
| 6. E2E | FAIL (expected) | Same reason as gate 3 — target tools not yet implemented |

Gates 3 and 6 will go green once all 10 modules in the build order are shipped; this is consistent with the harness design (it's the permanent regression gate for the whole v1.45.0 milestone, not per-module).