### PR TITLE
fix(company_recon): give Wayback CDX resolver a 90s HTTP timeout

### DIFF
--- a/cmd/web-researcher-mcp/main.go
+++ b/cmd/web-researcher-mcp/main.go
@@ -343,8 +343,11 @@ func main() {
 		HTTPClient: searchDeps.HTTPClient,
 		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
 	})
+	// Wayback CDX's observed p50-p99 latency (30-60s+) regularly exceeds the
+	// 30s shared SSRF client timeout, so this resolver gets its own longer-
+	// timeout client rather than starving on searchDeps.HTTPClient's deadline.
 	archiveResolver := search.NewWaybackCDXResolver(search.Deps{
-		HTTPClient: searchDeps.HTTPClient,
+		HTTPClient: scraper.NewSSRFSafeClientWithTimeout(cfg.AllowPrivateIPs, 90*time.Second),
 		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
 	})
 

--- a/internal/scraper/ssrf.go
+++ b/internal/scraper/ssrf.go
@@ -30,9 +30,16 @@ var blockedHostnames = []string{
 }
 
 func NewSSRFSafeClient(allowPrivate bool) *http.Client {
+	return NewSSRFSafeClientWithTimeout(allowPrivate, 30*time.Second)
+}
+
+// NewSSRFSafeClientWithTimeout is NewSSRFSafeClient with a caller-chosen
+// timeout, for upstreams whose observed latency (e.g. Wayback CDX under load)
+// regularly exceeds the 30s default.
+func NewSSRFSafeClientWithTimeout(allowPrivate bool, timeout time.Duration) *http.Client {
 	return &http.Client{
 		Transport: newSSRFSafeTransport(allowPrivate),
-		Timeout:   30 * time.Second,
+		Timeout:   timeout,
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			if len(via) >= 5 {
 				return fmt.Errorf("too many redirects")


### PR DESCRIPTION
## Summary
- Live MCP testing (comprehensive IRL progression/regression pass ahead of the v1.45.0 release) found `company_recon`'s `archives` phase silently returning zero results for every domain tried (anthropic.com, github.com, wikipedia.org, example.com).
- Root cause: `web.archive.org/cdx` real-world latency is routinely 30-60s+ (confirmed via repeated direct curl: 15s, 35s, 36s, one 504 after 60s), but `WaybackCDXResolver` shared the 30s `scraper.NewSSRFSafeClient` timeout used by every other subsystem. Nearly every real call timed out and was swallowed by `company_recon`'s per-phase soft-fail design — which is working exactly as documented, but it masked this defect from both the tool's output and `diagnostics://errors/recent` (0 errors recorded).
- Fix: added `scraper.NewSSRFSafeClientWithTimeout(allowPrivate, timeout)` (the existing `NewSSRFSafeClient` now delegates to it with the same 30s default, so no other caller's behavior changes) and gave the Wayback CDX resolver its own client with a 90s timeout in `main.go`.
- Verified live: with the fix, a direct resolver call against `github.com` returns real archive data (`{URL:http://github.com/ Timestamp:20080514210148 ...}`); before the fix it reliably returned 0 entries / no error.

## Test plan
- [x] `go test ./internal/scraper/... ./internal/search/... ./cmd/...` — all pass
- [x] Live resolver call against `github.com` with a 90s-timeout client returns real Wayback CDX data
- [x] Confirmed `NewSSRFSafeClient`'s default (30s) is unchanged for every other existing caller (`linkverify.go`, `pipeline.go`, `gag_order_search.go`, `brand_research.go`, `syllabus_search.go`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)