### PR TITLE
fix(scraper,search): resolve YouTube caption PO Token block, improve PubMed full-text hit rate

### DIFF
--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -160,7 +160,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 - Semantic Scholar enriches results with AI-generated `tldr` summaries and citation intent/influence edges, which power `citation_graph`. OpenAlex also implements `citation_graph` support with citation-count edges as a fallback.
 - Only OpenAlex implements the `DOIResolver` interface (exact-entity lookup via `/works/doi:{doi}`). CrossRef, Semantic Scholar, PubMed, and CORE do not.
 - CORE's every result is open access by definition — it aggregates OA repositories exclusively — and its `pdfUrl` links directly to full text, no Unpaywall enrichment needed.
-- PubMed fetches full text from PubMed Central when `full_text=true` and a result carries a PMCID: a third call (`efetch` against PMC) retrieves the JATS XML, populating `fullText`. Best-effort — an article without a PMCID, or an efetch failure, is returned without `fullText`.
+- PubMed fetches full text from PubMed Central when `full_text=true`: the search itself is narrowed with PubMed's `"pubmed pmc"[sb]` filter to bias results toward PMC-deposited papers, then a third call (`efetch` against PMC) retrieves the JATS XML for any result with a PMCID, populating `fullText`. Best-effort — an article without a PMCID, or an efetch failure, is returned without `fullText`.
 - Semantic Scholar also implements `PaperFetcher` (fetch full metadata by DOI/paper ID), behind the single-call `paper_fulltext` tool rather than `academic_search`.
 - Exa routes academic queries using its `research-paper` category — useful when its neural index surfaces papers the bibliographic databases miss.
 - [Unpaywall](https://unpaywall.org/) OA enrichment runs as a post-processing step on any DOI-bearing result — not a separate provider to select.

--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -262,11 +262,12 @@ Raw responses are keyed like any other scrape: the cache key includes `mode` (so
    └─ Block: loopback, link-local, RFC1918, metadata endpoints
 
 2. CONTENT TYPE DETECTION
-   ├─ YouTube URL → YouTube extractor (3-strategy fallback):
+   ├─ YouTube URL → YouTube extractor (4-strategy fallback):
+   │     Strategy 0: InnerTube ANDROID_VR client (youtubei/v1/player) — not PO-Token-gated, tried first
    │     Strategy 1: Player response captions (primary + alt regex), fmt=vtt (WebVTT)
    │     Strategy 2: Direct timedtext API (en, en-US, en-GB), fmt=vtt (WebVTT)
    │     Strategy 3: Video description (shortDescription JSON field)
-   │     Strategies 1-2 additionally score the transcript into up to 5 highlights (#284)
+   │     Strategies 0-2 additionally score the transcript into up to 5 highlights (#284)
    ├─ news.ycombinator.com → native HN API (Firebase REST + Algolia; no API key required):
    │     /item/<id>  → story metadata (title, URL, score, author, date) + top 10 comments
    │     /           → top 20 stories from the HN top-stories list (parallel Firebase fetch)

--- a/internal/scraper/scraper_test.go
+++ b/internal/scraper/scraper_test.go
@@ -1403,6 +1403,110 @@ ytInitialPlayerResponse = {"playabilityStatus":{"status":"OK"},"videoDetails":{"
 	}
 }
 
+// TestYouTubeScrape_InnerTubeStrategy0Success verifies the ANDROID_VR InnerTube
+// path (Strategy 0): GET the ANDROID_VR watch page for the API key, POST
+// youtubei/v1/player for a player response, then fetch the caption track's
+// baseUrl as VTT — all served by one test server, all ahead of the legacy web
+// player-response scrape.
+func TestYouTubeScrape_InnerTubeStrategy0Success(t *testing.T) {
+	captionVTT := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:03.000\nInnerTube ANDROID_VR caption text here.\n\n" +
+		"00:00:03.000 --> 00:00:07.000\nThis came from the youtubei player endpoint.\n\n" +
+		"00:00:07.000 --> 00:00:10.000\nNot from the legacy web scrape strategy.\n"
+
+	var sawPlayerPOST bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "youtubei/v1/player") && r.Method == http.MethodPost:
+			sawPlayerPOST = true
+			captionURL := "http://" + r.Host + "/captions"
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":%q,"languageCode":"en"}]}}}`, captionURL)
+		case strings.Contains(r.URL.Path, "captions"):
+			w.Header().Set("Content-Type", "text/vtt")
+			w.Write([]byte(captionVTT))
+		case strings.Contains(r.URL.Path, "watch"):
+			w.Header().Set("Content-Type", "text/html")
+			// Legacy web scrape would find no ytInitialPlayerResponse here — the
+			// InnerTube API key is present so Strategy 0 must resolve the
+			// transcript without ever needing this page's captions.
+			w.Write([]byte(`<!DOCTYPE html><html><head><title>InnerTube Video - YouTube</title></head>
+<body><script>var ytcfg = {"INNERTUBE_API_KEY":"test-api-key","VISITOR_DATA":"visitor-abc"};</script></body></html>`))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	p.client = ts.Client()
+	p.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = ts.Listener.Addr().String()
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	result, err := p.scrapeYouTube(context.Background(), "https://www.youtube.com/watch?v=abc123def45", 50000)
+	if err != nil {
+		t.Fatalf("scrapeYouTube error: %v", err)
+	}
+	if !sawPlayerPOST {
+		t.Fatal("expected a POST to youtubei/v1/player")
+	}
+	if !strings.Contains(result.Content, "InnerTube ANDROID_VR caption text") {
+		t.Errorf("expected InnerTube-sourced transcript, got %q", result.Content)
+	}
+}
+
+// TestYouTubeScrape_InnerTubeFailureFallsBackToWebStrategy verifies that when
+// the InnerTube ANDROID_VR path fails (no API key resolvable), scrapeYouTube
+// falls through to the legacy web player-response strategy rather than
+// erroring out.
+func TestYouTubeScrape_InnerTubeFailureFallsBackToWebStrategy(t *testing.T) {
+	captionVTT := "WEBVTT\n\n" +
+		"00:00:00.000 --> 00:00:03.000\nLegacy web strategy caption text.\n\n" +
+		"00:00:03.000 --> 00:00:07.000\nUsed because InnerTube had no API key.\n\n" +
+		"00:00:07.000 --> 00:00:10.000\nFallthrough must still succeed.\n"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch {
+		case strings.Contains(r.URL.Path, "youtubei/v1/player"):
+			w.WriteHeader(500) // must not be reached: no API key was found
+		case strings.Contains(r.URL.Path, "captions"):
+			w.Header().Set("Content-Type", "text/vtt")
+			w.Write([]byte(captionVTT))
+		case strings.Contains(r.URL.Path, "watch") || r.URL.Query().Get("v") != "":
+			captionURL := "http://" + r.Host + "/captions"
+			playerResp := `{"captions":{"playerCaptionsTracklistRenderer":{"captionTracks":[{"baseUrl":"` + captionURL + `","languageCode":"en"}]}}}`
+			html := `<!DOCTYPE html><html><head><title>Legacy Path - YouTube</title></head><body>
+<script>ytInitialPlayerResponse = ` + playerResp + `;</script>
+</body></html>`
+			// No INNERTUBE_API_KEY anywhere on this host's pages — Strategy 0 must fail cleanly.
+			w.Header().Set("Content-Type", "text/html")
+			w.Write([]byte(html))
+		default:
+			w.WriteHeader(404)
+		}
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true})
+	p.client = ts.Client()
+	p.client.Transport = roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		req.URL.Scheme = "http"
+		req.URL.Host = ts.Listener.Addr().String()
+		return http.DefaultTransport.RoundTrip(req)
+	})
+
+	result, err := p.scrapeYouTube(context.Background(), "https://www.youtube.com/watch?v=abc123def45", 50000)
+	if err != nil {
+		t.Fatalf("scrapeYouTube error: %v", err)
+	}
+	if !strings.Contains(result.Content, "Legacy web strategy caption text") {
+		t.Errorf("expected fallback to legacy web strategy, got %q", result.Content)
+	}
+}
+
 func TestYouTubeScrape_TranscriptStrategy1(t *testing.T) {
 	captionVTT := "WEBVTT\n\n" +
 		"00:00:00.000 --> 00:00:03.000\nWelcome to this video about testing strategies in Go.\n\n" +

--- a/internal/scraper/youtube.go
+++ b/internal/scraper/youtube.go
@@ -1,10 +1,12 @@
 package scraper
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -28,6 +30,27 @@ var (
 const (
 	maxHighlights        = 5
 	minHighlightSegments = 5
+)
+
+// InnerTube ANDROID_VR client identity. As of 2026, YouTube's `web` client
+// requires a BotGuard-attested PO Token for caption/player requests (see
+// yt-dlp's PO Token Guide), which this unauthenticated scraper cannot
+// generate. ANDROID_VR is one of the InnerTube client contexts that does NOT
+// require a PO Token, so Strategy 0 impersonates it via the public
+// youtubei/v1/player endpoint instead of scraping the (POT-gated) web
+// watch-page captions. clientVersion is pinned to a known-good build; YouTube
+// tolerates a stale-but-valid version far longer than it tolerates a missing
+// PO Token.
+const (
+	innertubeBaseURL       = "https://m.youtube.com"
+	androidVRClientName    = "ANDROID_VR"
+	androidVRClientVersion = "1.65.10"
+	androidVRUserAgent     = "com.google.android.apps.youtube.vr.oculus/1.65.10 (Linux; U; Android 12L; eureka-user Build/SQ3A.220605.009.A1) gzip"
+)
+
+var (
+	innertubeAPIKeyRe      = regexp.MustCompile(`"INNERTUBE_API_KEY":"([^"]+)"`)
+	innertubeVisitorDataRe = regexp.MustCompile(`"VISITOR_DATA":"([^"]+)"`)
 )
 
 // TranscriptHighlight is a top-scored transcript segment returned by
@@ -75,39 +98,31 @@ func (p *Pipeline) scrapeYouTube(ctx context.Context, rawURL string, maxLength i
 	pageHTML := string(body)
 	title := extractYouTubeTitle(pageHTML)
 
-	// Strategy 1: Extract transcript from player response captions
-	transcript, err := extractTranscript(ctx, p.client, pageHTML)
+	// Strategy 0: InnerTube ANDROID_VR client (not PO-Token-gated; see the
+	// androidVRClientVersion doc comment). Tried first because the `web`
+	// client strategies below (1-2) are known to be blocked by YouTube's PO
+	// Token enforcement as of 2026 and return an empty caption body rather
+	// than an error, so they cannot be distinguished from "no captions exist"
+	// without this independent, differently-gated path.
+	transcript, err := fetchInnerTubeCaptions(ctx, p.client, videoID)
 	if err == nil && len(transcript) > 100 {
-		highlights := scoreTranscriptHighlights(transcript, "")
-		content := transcript
-		if len(content) > maxLength {
-			content = truncateBytes(content, maxLength)
-		}
-		return &ScrapeResult{
-			URL:         rawURL,
-			Content:     content,
-			ContentType: "youtube",
-			Title:       title,
-			Highlights:  highlights,
-		}, nil
+		return youtubeTranscriptResult(rawURL, title, transcript, maxLength), nil
 	}
+	logYouTubeStrategyFailure(videoID, "innertube_android_vr", transcript, err)
+
+	// Strategy 1: Extract transcript from player response captions
+	transcript, err = extractTranscript(ctx, p.client, pageHTML)
+	if err == nil && len(transcript) > 100 {
+		return youtubeTranscriptResult(rawURL, title, transcript, maxLength), nil
+	}
+	logYouTubeStrategyFailure(videoID, "web_player_response", transcript, err)
 
 	// Strategy 2: Direct timedtext API
 	transcript, err = fetchTimedTextAPI(ctx, p.client, videoID)
 	if err == nil && len(transcript) > 100 {
-		highlights := scoreTranscriptHighlights(transcript, "")
-		content := transcript
-		if len(content) > maxLength {
-			content = truncateBytes(content, maxLength)
-		}
-		return &ScrapeResult{
-			URL:         rawURL,
-			Content:     content,
-			ContentType: "youtube",
-			Title:       title,
-			Highlights:  highlights,
-		}, nil
+		return youtubeTranscriptResult(rawURL, title, transcript, maxLength), nil
 	}
+	logYouTubeStrategyFailure(videoID, "timedtext_api", transcript, err)
 
 	// Strategy 3: Fall back to video description
 	description := extractDescription(pageHTML)
@@ -125,6 +140,158 @@ func (p *Pipeline) scrapeYouTube(ctx context.Context, rawURL string, maxLength i
 	}
 
 	return nil, fmt.Errorf("no transcript or description available for %s", videoID)
+}
+
+func youtubeTranscriptResult(rawURL, title, transcript string, maxLength int) *ScrapeResult {
+	highlights := scoreTranscriptHighlights(transcript, "")
+	content := transcript
+	if len(content) > maxLength {
+		content = truncateBytes(content, maxLength)
+	}
+	return &ScrapeResult{
+		URL:         rawURL,
+		Content:     content,
+		ContentType: "youtube",
+		Title:       title,
+		Highlights:  highlights,
+	}
+}
+
+// logYouTubeStrategyFailure records why a caption strategy did not produce a
+// usable transcript, distinguishing a hard error from the "request succeeded
+// but returned an empty/short body" symptom of PO Token enforcement — the
+// two look identical to the caller (both just fall through) but are very
+// different failures to diagnose from logs alone.
+func logYouTubeStrategyFailure(videoID, strategy, transcript string, err error) {
+	if err != nil {
+		slog.Debug("youtube caption strategy failed", "videoId", videoID, "strategy", strategy, "error", err)
+		return
+	}
+	slog.Debug("youtube caption strategy returned no usable transcript", "videoId", videoID, "strategy", strategy, "transcriptLen", len(transcript))
+}
+
+// innerTubeWatchContext holds the values scraped from the ANDROID_VR watch
+// page that the youtubei/v1/player call needs: the InnerTube API key
+// (required) and visitor data (optional, improves acceptance).
+type innerTubeWatchContext struct {
+	apiKey      string
+	visitorData string
+}
+
+// fetchInnerTubeCaptions retrieves captions via YouTube's InnerTube API using
+// the ANDROID_VR client context, which YouTube does not currently gate behind
+// a PO Token (unlike the public `web` client the other two strategies use).
+// Two calls: (1) GET the ANDROID_VR watch page to harvest the API key/visitor
+// data YouTube ties to that client identity, (2) POST youtubei/v1/player with
+// a matching client context to get a player response whose caption track
+// baseUrl is fetched the same way as the web-client strategy.
+func fetchInnerTubeCaptions(ctx context.Context, client *http.Client, videoID string) (string, error) {
+	watchCtx, err := fetchInnerTubeWatchContext(ctx, client, videoID)
+	if err != nil {
+		return "", err
+	}
+	playerResp, err := fetchInnerTubePlayerResponse(ctx, client, videoID, watchCtx)
+	if err != nil {
+		return "", err
+	}
+	captionURL := findCaptionURL(playerResp)
+	if captionURL == "" {
+		return "", fmt.Errorf("innertube: no captions in player response")
+	}
+	return fetchCaptionTrackVTT(ctx, client, captionURL)
+}
+
+func fetchInnerTubeWatchContext(ctx context.Context, client *http.Client, videoID string) (innerTubeWatchContext, error) {
+	watchURL := innertubeBaseURL + "/watch?v=" + url.QueryEscape(videoID) + "&hl=en"
+	req, err := http.NewRequestWithContext(ctx, "GET", watchURL, nil)
+	if err != nil {
+		return innerTubeWatchContext{}, err
+	}
+	req.Header.Set("User-Agent", androidVRUserAgent)
+	req.Header.Set("Accept-Language", "en-US,en;q=0.9")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return innerTubeWatchContext{}, fmt.Errorf("innertube: watch page request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return innerTubeWatchContext{}, fmt.Errorf("innertube: watch page returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+	if err != nil {
+		return innerTubeWatchContext{}, err
+	}
+	html := string(body)
+
+	apiKey := firstSubmatch(innertubeAPIKeyRe, html)
+	if apiKey == "" {
+		return innerTubeWatchContext{}, fmt.Errorf("innertube: API key not found in watch page")
+	}
+	return innerTubeWatchContext{
+		apiKey:      apiKey,
+		visitorData: firstSubmatch(innertubeVisitorDataRe, html),
+	}, nil
+}
+
+func fetchInnerTubePlayerResponse(ctx context.Context, client *http.Client, videoID string, watchCtx innerTubeWatchContext) (map[string]any, error) {
+	clientCtx := map[string]any{
+		"clientName":    androidVRClientName,
+		"clientVersion": androidVRClientVersion,
+		"hl":            "en",
+		"gl":            "US",
+	}
+	if watchCtx.visitorData != "" {
+		clientCtx["visitorData"] = watchCtx.visitorData
+	}
+	payload := map[string]any{
+		"context": map[string]any{"client": clientCtx},
+		"videoId": videoID,
+	}
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, fmt.Errorf("innertube: marshal player request: %w", err)
+	}
+
+	endpoint := innertubeBaseURL + "/youtubei/v1/player?key=" + url.QueryEscape(watchCtx.apiKey)
+	req, err := http.NewRequestWithContext(ctx, "POST", endpoint, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", androidVRUserAgent)
+	if watchCtx.visitorData != "" {
+		req.Header.Set("X-Goog-Visitor-Id", watchCtx.visitorData)
+	}
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("innertube: player request failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode >= 400 {
+		return nil, fmt.Errorf("innertube: player request returned %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+	if err != nil {
+		return nil, err
+	}
+	var playerResp map[string]any
+	if err := json.Unmarshal(body, &playerResp); err != nil {
+		return nil, fmt.Errorf("innertube: failed to parse player response: %w", err)
+	}
+	return playerResp, nil
+}
+
+func firstSubmatch(re *regexp.Regexp, s string) string {
+	m := re.FindStringSubmatch(s)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
 }
 
 func extractVideoID(rawURL string) string {
@@ -166,11 +333,27 @@ func extractTranscript(ctx context.Context, client *http.Client, pageHTML string
 	if captionURL == "" {
 		return "", fmt.Errorf("no captions found")
 	}
-	if strings.Contains(captionURL, "?") {
-		captionURL += "&fmt=vtt"
-	} else {
-		captionURL += "?fmt=vtt"
+	return fetchCaptionTrackVTT(ctx, client, captionURL)
+}
+
+// fetchCaptionTrackVTT fetches a caption track's baseUrl as VTT and returns
+// the parsed plain-text transcript. Shared by the web-player-response
+// strategy and the InnerTube ANDROID_VR strategy, since both parse the same
+// captionTracks[].baseUrl shape from a player response. The baseUrl from the
+// InnerTube ANDROID_VR player response already carries its own fmt=srv3
+// param, so fmt=vtt must be set via query-param mutation (override), not
+// naive string concatenation — appending "&fmt=vtt" would leave two "fmt"
+// params, and YouTube honors the first (srv3 XML), not the last, silently
+// returning JATS-like XML instead of VTT.
+func fetchCaptionTrackVTT(ctx context.Context, client *http.Client, captionURL string) (string, error) {
+	parsed, err := url.Parse(captionURL)
+	if err != nil {
+		return "", fmt.Errorf("caption url parse: %w", err)
 	}
+	q := parsed.Query()
+	q.Set("fmt", "vtt")
+	parsed.RawQuery = q.Encode()
+	captionURL = parsed.String()
 
 	req, err := http.NewRequestWithContext(ctx, "GET", captionURL, nil)
 	if err != nil {

--- a/internal/search/pubmed.go
+++ b/internal/search/pubmed.go
@@ -29,10 +29,12 @@ import (
 // sortpubdate. Both calls return HTTP 200 even for errors/empty, so the JSON body
 // is inspected (esearchresult.ERROR, empty idlist, per-record error).
 //
-// When AcademicSearchParams.FullText is true and a result has a PMCID (present in
-// articleids[] when the article is deposited in PubMed Central), a third call —
-// efetch.fcgi against PMC — fetches the JATS XML full text. Best-effort: articles
-// without a PMCID or with an efetch failure are returned without FullText set.
+// When AcademicSearchParams.FullText is true, the esearch term is narrowed with
+// PubMed's "pubmed pmc"[sb] filter so results are biased toward PMC-deposited
+// papers, and a third call — efetch.fcgi against PMC — fetches the JATS XML full
+// text for any result with a PMCID (present in articleids[]). Best-effort:
+// articles without a PMCID or with an efetch failure are returned without
+// FullText set.
 type PubMedProvider struct {
 	baseURL string
 	apiKey  string
@@ -117,12 +119,20 @@ type esearchResponse struct {
 	} `json:"esearchresult"`
 }
 
-// esearch maps a query (+ optional year range) to a list of PMIDs.
+// esearch maps a query (+ optional year range) to a list of PMIDs. When
+// FullText is requested, the query is narrowed with PubMed's own "pubmed
+// pmc"[sb] search field — documented at pubmed.ncbi.nlm.nih.gov/help/ — so the
+// search itself surfaces PMC-deposited (full-text-available) papers instead of
+// leaving full-text attachment to chance in doScholarly.
 func (p *PubMedProvider) esearch(ctx context.Context, params AcademicSearchParams) ([]string, error) {
 	num := clamp(params.NumResults, 1, 50)
+	term := params.Query
+	if params.FullText {
+		term += ` AND "pubmed pmc"[sb]`
+	}
 	q := url.Values{}
 	q.Set("db", "pubmed")
-	q.Set("term", params.Query)
+	q.Set("term", term)
 	q.Set("retmode", "json")
 	q.Set("retmax", strconv.Itoa(num))
 	if params.SortBy == "date" {

--- a/internal/search/pubmed_test.go
+++ b/internal/search/pubmed_test.go
@@ -317,6 +317,37 @@ func TestPubMedSearchFullTextCalledWhenTrue(t *testing.T) {
 	}
 }
 
+func TestPubMedEsearchPMCFilter(t *testing.T) {
+	tests := []struct {
+		name     string
+		fullText bool
+		want     bool
+	}{
+		{"appended when full text requested", true, true},
+		{"absent when full text not requested", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := newPubMedTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+				if !strings.Contains(r.URL.Path, "/esearch.fcgi") {
+					t.Errorf("unexpected path: %s", r.URL.Path)
+					return
+				}
+				term := r.URL.Query().Get("term")
+				got := strings.Contains(term, `"pubmed pmc"[sb]`)
+				if got != tt.want {
+					t.Errorf("term = %q, want pmc filter present=%v", term, tt.want)
+				}
+				w.Write([]byte(`{"esearchresult":{"count":"0","idlist":[]}}`))
+			})
+			_, err := p.Scholarly(context.Background(), AcademicSearchParams{Query: "CRISPR", NumResults: 5, FullText: tt.fullText})
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
 func TestPubMedAuthParams(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Query().Get("api_key") != "k123" {


### PR DESCRIPTION
## Summary
- Closes #427. YouTube's `web` client now requires a BotGuard-attested PO Token for caption/player requests, which `scrape_page`'s existing strategies (web watch-page scrape, direct `timedtext` API) cannot obtain — both consistently return empty bodies. Adds a new Strategy 0 that calls YouTube's InnerTube API (`youtubei/v1/player`) impersonating the `ANDROID_VR` client, which is not currently PO-Token-gated, ahead of the existing strategies. Verified live against multiple real videos (transcripts + highlights now populate correctly).
- Along the way, fixed a latent bug in the shared caption-VTT fetch helper: `ANDROID_VR` caption `baseUrl`s already carry their own `fmt=srv3` query param, so the old naive `"&fmt=vtt"` string concatenation produced a URL with two `fmt` params — YouTube honored the first (`srv3` XML) and returned unparsed XML instead of VTT. Now overrides the param via proper URL query mutation.
- `academic_search`'s PubMed provider now appends PubMed's documented `"pubmed pmc"[sb]` search filter to the query when `full_text=true`, so the search itself is biased toward PMC-deposited (full-text-available) papers instead of relying on incidental PMCID presence in whatever results happen to come back.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go tool golangci-lint run` — 0 issues
- [x] `go test -race ./internal/scraper/... ./internal/search/...` — all pass, including 2 new InnerTube strategy tests (success + fallback-on-failure) and 1 new PubMed PMC-filter test
- [x] `make verify` — full CI gate green (lint, sec, vuln, e2e, python-drift, python tests, build)
- [x] Live-verified the InnerTube fix against real YouTube videos (not just mocks) — confirmed transcripts + highlights now populate for videos that previously fell back to description-only
- [x] Updated `docs/TOOLS.md` (4-strategy YouTube chain) and `docs/PROVIDERS.md` (PubMed PMC filter) to match

🤖 Generated with [Claude Code](https://claude.com/claude-code)