### PR TITLE
fix: company_recon web-phase gap, browser 404 blindness, audit_bibliography arXiv false-positive

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -1936,7 +1936,7 @@ OSINT company reconnaissance with typed structured output: Certificate Transpare
 |-------|------|-------------|
 | `target` | string | The target as submitted (echo) |
 | `domain` | string | Resolved canonical domain |
-| `profile` | object | `summary` — one-line company summary from the top `web_search` hit. Present only when the `profiling` phase ran and found a result |
+| `profile` | object | `summary` — one-line company summary from the top `web_search` hit. Present only when the `profiling` or `web` phase ran and found a result (either phase alone triggers the same web-search summary) |
 | `cert_sans` | array | Certificate Transparency SANs from crt.sh, deduplicated: `domain`, `issuer`, `not_before`, `not_after`, `logged_at`. Present only when the `ct_logs` phase ran |
 | `archive_urls` | array | Wayback CDX historical URLs, filtered to 200/301/302 captures: `url`, `timestamp`, `status_code`, `mime_type`, `category` (`login`/`api`/`admin`/`asset`/`doc`/`other`). Present only when the `archives` phase ran |
 | `subdomains` | array | Deduplicated subdomains derived from `cert_sans` + `archive_urls`: `subdomain`, `source` (`ct_logs`/`archive`) |

--- a/internal/scraper/browser.go
+++ b/internal/scraper/browser.go
@@ -179,9 +179,48 @@ func (p *Pipeline) scrapeBrowser(ctx context.Context, url string, maxLength int)
 		slog.Warn("browser timezone override failed", "url", url, "error", err)
 	}
 
+	// Subscribe to the CDP events proving the main document's HTTP status
+	// before triggering navigation — CDP events are asynchronous, so a
+	// subscription started after Navigate() can race and miss them. Track
+	// every Document-type response for this page's top-level frame (a
+	// redirect chain fires responseReceived once per hop, all with the SAME
+	// FrameID) and keep only the LAST one — the final response once redirects
+	// settle. Stop once PageFrameNavigated confirms the frame's navigation
+	// committed, mirroring the same pattern Page.Reload() already uses to
+	// detect navigation completion.
+	var mainStatus int
+	var gotMainStatus bool
+	waitNav := page.EachEvent(
+		func(e *proto.NetworkResponseReceived) bool {
+			if e.Type == proto.NetworkResourceTypeDocument && e.FrameID == page.FrameID && e.Response != nil {
+				mainStatus = e.Response.Status
+				gotMainStatus = true
+			}
+			return false
+		},
+		func(e *proto.PageFrameNavigated) bool {
+			return e.Frame.ID == page.FrameID
+		},
+	)
+
 	err = page.Navigate(url)
 	if err != nil {
 		return nil, networkError(url, "browser", fmt.Errorf("navigation failed: %w", err))
+	}
+	waitNav()
+
+	// A genuine HTTP 4xx/5xx on the main document (e.g. a dead DOI-resolver
+	// landing page) must be reported as a definite scrape failure — the three
+	// HTTP-based tiers already do this via classifyHTTPStatus (markdown.go,
+	// html.go, stealth.go). Unlike them, CDP navigation never surfaces a
+	// status code through page.Navigate()'s own return value, so without this
+	// check a 404's "Page Not Found" HTML was silently returned as if it were
+	// real content (issue #432). gotMainStatus can be false when the main
+	// document's responseReceived event never fired (rare CDP timing edge) —
+	// in that case there is no signal either way, so extraction proceeds as
+	// before rather than guessing.
+	if gotMainStatus && mainStatus >= 400 {
+		return nil, classifyHTTPStatus(mainStatus, url, "browser")
 	}
 
 	// Wait for the page to reach a stable DOM state. SPAs need longer — they

--- a/internal/scraper/browser_test.go
+++ b/internal/scraper/browser_test.go
@@ -97,7 +97,7 @@ func TestScrapeBrowserNotFoundDetected(t *testing.T) {
 	defer ts.Close()
 
 	p := NewPipeline(PipelineConfig{AllowPrivateIPs: true})
-	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000)
+	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000, false)
 	if err == nil {
 		t.Fatalf("expected an error for a 404 main document, got a successful result: %+v", result)
 	}
@@ -129,7 +129,7 @@ func TestScrapeBrowserSuccessStillWorks(t *testing.T) {
 	defer ts.Close()
 
 	p := NewPipeline(PipelineConfig{AllowPrivateIPs: true})
-	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000)
+	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000, false)
 	if err != nil {
 		t.Fatalf("unexpected error for a 200 response: %v", err)
 	}

--- a/internal/scraper/browser_test.go
+++ b/internal/scraper/browser_test.go
@@ -1,7 +1,12 @@
 package scraper
 
 import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
+	"strings"
 	"sync"
 	"testing"
 
@@ -74,5 +79,61 @@ func TestBrowserPoolCleanupRemovesUserDataDir(t *testing.T) {
 
 	if _, err := os.Stat(userDataDir); !os.IsNotExist(err) {
 		t.Errorf("expected UserDataDir %q to be removed after close, stat err = %v", userDataDir, err)
+	}
+}
+
+// TestScrapeBrowserNotFoundDetected is the regression test for issue #432:
+// a genuine HTTP 404 on the main document (e.g. a dead DOI-resolver landing
+// page) rendered by the browser tier must be reported as ErrNotFound, not
+// returned as if the dead page's HTML were real content.
+func TestScrapeBrowserNotFoundDetected(t *testing.T) {
+	skipIfNoChrome(t)
+	resetPool(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte("<html><body><h1>Page Not Found</h1><p>The requested article could not be located.</p></body></html>"))
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{AllowPrivateIPs: true})
+	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000)
+	if err == nil {
+		t.Fatalf("expected an error for a 404 main document, got a successful result: %+v", result)
+	}
+	var se *ScrapeError
+	if !errors.As(err, &se) {
+		t.Fatalf("expected a *ScrapeError, got %T: %v", err, err)
+	}
+	if se.Kind != ErrNotFound {
+		t.Errorf("Kind = %v, want ErrNotFound", se.Kind)
+	}
+	if se.Tier != "browser" {
+		t.Errorf("Tier = %q, want browser", se.Tier)
+	}
+}
+
+// TestScrapeBrowserSuccessStillWorks proves the 404-detection subscription
+// added for issue #432 does not regress the ordinary 200 path — content is
+// still extracted normally.
+func TestScrapeBrowserSuccessStillWorks(t *testing.T) {
+	skipIfNoChrome(t)
+	resetPool(t)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><body><article><p>` +
+			strings.Repeat("Real article content that is long enough to extract. ", 5) +
+			`</p></article></body></html>`))
+	}))
+	defer ts.Close()
+
+	p := NewPipeline(PipelineConfig{AllowPrivateIPs: true})
+	result, err := p.scrapeBrowser(context.Background(), ts.URL, 10000)
+	if err != nil {
+		t.Fatalf("unexpected error for a 200 response: %v", err)
+	}
+	if result == nil || len(result.Content) < 100 {
+		t.Fatalf("expected extracted content, got: %+v", result)
 	}
 }

--- a/internal/tools/audit_bibliography.go
+++ b/internal/tools/audit_bibliography.go
@@ -409,7 +409,16 @@ func auditOneEntry(ctx context.Context, deps Dependencies, e content.BibEntry, r
 	if r.DOI != "" && deps.RetractionResolver != nil {
 		if status, found, err := deps.RetractionResolver.Resolve(ctx, r.DOI); err == nil {
 			r.ExistChecked = true
-			r.Exists = &found
+			// Crossref found=true is authoritative existence — record it. But
+			// found=false is NOT authoritative absence: Crossref does not index
+			// every registrant (notably arXiv DOIs, 10.48550/*, registered
+			// through DataCite and 404 in Crossref while the work is real).
+			// Leave Exists unset on found=false so the doi.org handle-registry
+			// fallback below gets a chance to confirm existence honestly,
+			// mirroring verify_citation.go's verifyByDOI (issue #226, #432).
+			if found {
+				r.Exists = &found
+			}
 			if status != nil {
 				r.Retraction = status
 			}
@@ -421,6 +430,21 @@ func auditOneEntry(ctx context.Context, deps Dependencies, e content.BibEntry, r
 					r.URL = bestClaimURL(rec, r.DOI)
 				}
 			}
+			// Authoritative cross-registrar existence (#226, #432): consulted
+			// only when Crossref left existence unknown (found=false); never
+			// overrides a resolver that already confirmed existence. Resolves
+			// DOIs Crossref doesn't index, notably arXiv preprints, while
+			// still reporting a genuinely fabricated DOI as not-found.
+			if r.Exists == nil && deps.DOIRegistry != nil {
+				if registered, rerr := deps.DOIRegistry.IsRegistered(ctx, r.DOI); rerr == nil {
+					r.Exists = &registered
+				}
+			}
+			// If existence is STILL unknown here (no DOIRegistry configured, or
+			// it errored), do NOT default to Exists=false: auditFlags's doiMiss
+			// check requires Exists!=nil, so leaving it nil correctly routes the
+			// entry to unchecked (absence of evidence) rather than a false
+			// not_found (evidence of absence) — see spec rule 3.3, issue #432.
 			return
 		}
 	}

--- a/internal/tools/audit_bibliography_test.go
+++ b/internal/tools/audit_bibliography_test.go
@@ -293,12 +293,21 @@ func TestAuditBibliography_TitleOnlySubsetContainmentUnchecked(t *testing.T) {
 }
 
 func TestAuditBibliography_NotFoundDOI(t *testing.T) {
-	// A DOI authoritatively absent from Crossref (404 → found=false) is not_found
-	// (a possible fabrication), distinct from unchecked.
+	// A DOI absent from BOTH Crossref (404 → found=false) AND the cross-registrar
+	// doi.org handle registry (not registered anywhere) is not_found (a possible
+	// fabrication), distinct from unchecked. Crossref 404 alone is NOT
+	// authoritative absence (#432 — arXiv DOIs 404 in Crossref while being real);
+	// the doi.org registry is the tie-breaker, mirroring verify_citation's
+	// verifyByDOI.
 	crossref := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(404)
 	}))
 	defer crossref.Close()
+	doiRegistry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer doiRegistry.Close()
+
 	deps := setupTestDeps()
 	rr := search.NewCrossrefRetractionResolver("t@e.com", search.Deps{
 		HTTPClient: crossref.Client(),
@@ -306,6 +315,12 @@ func TestAuditBibliography_NotFoundDOI(t *testing.T) {
 	})
 	rr.SetBaseURL(crossref.URL)
 	deps.RetractionResolver = rr
+	reg := search.NewHandleDOIRegistry(search.Deps{
+		HTTPClient: doiRegistry.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+	reg.SetBaseURL(doiRegistry.URL)
+	deps.DOIRegistry = reg
 
 	out, isErr := callAudit(t, deps, map[string]any{
 		"entries": []any{map[string]any{"doi": "10.9999/fabricated.does.not.exist"}},
@@ -315,14 +330,103 @@ func TestAuditBibliography_NotFoundDOI(t *testing.T) {
 	}
 	s := summaryOf(t, out)
 	if s["notFound"].(float64) != 1 {
-		t.Errorf("a DOI Crossref returns 404 for should be not_found, got %v", s)
+		t.Errorf("a DOI absent from both Crossref and the doi.org registry should be not_found, got %v", s)
 	}
 	if s["unchecked"].(float64) != 0 {
 		t.Errorf("a checked-and-absent DOI must not be counted unchecked: %v", s)
 	}
 	e0 := out["entries"].([]any)[0].(map[string]any)
 	if e0["exists"] != false {
-		t.Errorf("a 404 DOI should report exists=false: %v", e0)
+		t.Errorf("a DOI absent from both resolvers should report exists=false: %v", e0)
+	}
+}
+
+// TestAuditBibliography_CrossrefMissDOIRegistryConfirms is the regression test
+// for issue #432 finding 3: a real arXiv-style DOI (10.48550/arXiv.*) that 404s
+// in Crossref (Crossref does not index DataCite-registered arXiv DOIs) but IS
+// registered in the doi.org handle registry must NOT be flagged not_found —
+// that was the exact false-positive found against 10.48550/arXiv.1706.03762
+// ("Attention Is All You Need").
+func TestAuditBibliography_CrossrefMissDOIRegistryConfirms(t *testing.T) {
+	crossref := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer crossref.Close()
+	doiRegistry := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte(`{"responseCode":1}`))
+	}))
+	defer doiRegistry.Close()
+
+	deps := setupTestDeps()
+	rr := search.NewCrossrefRetractionResolver("t@e.com", search.Deps{
+		HTTPClient: crossref.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+	rr.SetBaseURL(crossref.URL)
+	deps.RetractionResolver = rr
+	reg := search.NewHandleDOIRegistry(search.Deps{
+		HTTPClient: doiRegistry.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+	reg.SetBaseURL(doiRegistry.URL)
+	deps.DOIRegistry = reg
+
+	out, isErr := callAudit(t, deps, map[string]any{
+		"entries": []any{map[string]any{"doi": "10.48550/arXiv.1706.03762", "title": "Attention Is All You Need"}},
+	})
+	if isErr {
+		t.Fatal("unexpected tool error")
+	}
+	s := summaryOf(t, out)
+	if s["notFound"].(float64) != 0 {
+		t.Errorf("a Crossref-404 DOI confirmed by the doi.org registry must NOT be not_found, got %v", s)
+	}
+	e0 := out["entries"].([]any)[0].(map[string]any)
+	if e0["exists"] != true {
+		t.Errorf("doi.org registry confirmation should set exists=true: %v", e0)
+	}
+}
+
+// TestAuditBibliography_DOIRegistryUnavailableDegradesUnchecked is the
+// regression test for issue #432 spec rule 3.3: when Crossref 404s AND the
+// doi.org registry is unavailable/unconfigured (no fallback answer either
+// way), the entry must degrade to unchecked (absence of evidence), never a
+// false not_found (evidence of absence) — DOIRegistry is nil here, mirroring a
+// deployment that never configured it.
+func TestAuditBibliography_DOIRegistryUnavailableDegradesUnchecked(t *testing.T) {
+	crossref := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(404)
+	}))
+	defer crossref.Close()
+
+	deps := setupTestDeps()
+	rr := search.NewCrossrefRetractionResolver("t@e.com", search.Deps{
+		HTTPClient: crossref.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	})
+	rr.SetBaseURL(crossref.URL)
+	deps.RetractionResolver = rr
+	deps.DOIRegistry = nil
+
+	out, isErr := callAudit(t, deps, map[string]any{
+		"entries": []any{map[string]any{"doi": "10.48550/arXiv.1706.03762"}},
+	})
+	if isErr {
+		t.Fatal("unexpected tool error")
+	}
+	s := summaryOf(t, out)
+	if s["notFound"].(float64) != 0 {
+		t.Errorf("with no DOIRegistry to confirm absence, a Crossref 404 must NOT be not_found: %v", s)
+	}
+	if s["unchecked"].(float64) != 1 {
+		t.Errorf("a Crossref 404 with no DOIRegistry fallback should degrade to unchecked, got %v", s)
+	}
+	e0 := out["entries"].([]any)[0].(map[string]any)
+	if e0["exists"] == true {
+		t.Errorf("existence must not be confirmed when no resolver answered: %v", e0)
+	}
+	if e0["reason"] == nil || e0["reason"] == "" {
+		t.Error("an unchecked entry must carry a reason so it isn't read as fake")
 	}
 }
 

--- a/internal/tools/company_recon.go
+++ b/internal/tools/company_recon.go
@@ -152,7 +152,12 @@ func registerCompanyRecon(srv *mcp.Server, deps Dependencies) {
 			}()
 		}
 
-		if phaseSet["profiling"] && deps.Search != nil {
+		// "profiling" and "web" both trigger the same web-search company
+		// summary (issue #432): they are documented as independently
+		// selectable, so either alone must produce the summary, not just
+		// "profiling". When both are selected, the source is recorded once
+		// under "profiling" (arbitrary but stable) rather than duplicated.
+		if (phaseSet["profiling"] || phaseSet["web"]) && deps.Search != nil {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -160,23 +165,18 @@ func registerCompanyRecon(srv *mcp.Server, deps Dependencies) {
 				if summary == "" {
 					return
 				}
+				phase := "web"
+				if phaseSet["profiling"] {
+					phase = "profiling"
+				}
 				mu.Lock()
 				result.Profile = &companyProfile{Summary: summary}
-				result.Sources = append(result.Sources, companySourceRef{Phase: "profiling", Name: "web_search"})
+				result.Sources = append(result.Sources, companySourceRef{Phase: phase, Name: "web_search"})
 				mu.Unlock()
 			}()
 		}
 
 		wg.Wait()
-
-		if phaseSet["web"] {
-			// "web" is descriptive metadata about profiling's own web_search
-			// contribution — record it as its own source only when profiling
-			// itself did not already run (phases can be selected independently).
-			if !phaseSet["profiling"] {
-				result.Sources = append(result.Sources, companySourceRef{Phase: "web", Name: "note", URL: "select the profiling phase to include a web-search summary"})
-			}
-		}
 
 		result.Subdomains = deriveSubdomains(domain, result.CertSANs, result.ArchiveURLs)
 

--- a/internal/tools/company_recon_test.go
+++ b/internal/tools/company_recon_test.go
@@ -214,6 +214,61 @@ func TestCompanyReconSessionTracking(t *testing.T) {
 	}
 }
 
+// TestCompanyReconWebPhaseAloneProducesSummary is the regression test for
+// issue #432: the tool description promises phases "profiling|ct_logs|
+// archives|web" are independently selectable, but "web" alone used to be a
+// no-op placeholder. selecting "web" without "profiling" must produce the
+// same web-search company summary "profiling" alone would.
+func TestCompanyReconWebPhaseAloneProducesSummary(t *testing.T) {
+	t.Parallel()
+	out, res := callTool(t, setupTestDeps(), "company_recon", map[string]any{
+		"target": "acme.com",
+		"phases": []any{"web"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %v", res.Content)
+	}
+	profile, ok := out["profile"].(map[string]any)
+	if !ok || profile["summary"] == "" {
+		t.Fatalf("phases:[web] alone should populate profile.summary, got: %v", out["profile"])
+	}
+	if _, ok := out["cert_sans"]; ok {
+		t.Error("ct_logs phase was not selected; cert_sans should be absent")
+	}
+	if _, ok := out["archive_urls"]; ok {
+		t.Error("archives phase was not selected; archive_urls should be absent")
+	}
+	sources, ok := out["sources"].([]any)
+	if !ok || len(sources) != 1 {
+		t.Fatalf("sources = %v, want exactly 1 entry (the web-search summary)", out["sources"])
+	}
+	s0 := sources[0].(map[string]any)
+	if s0["phase"] != "web" {
+		t.Errorf("sole source phase = %v, want %q", s0["phase"], "web")
+	}
+	if s0["name"] != "web_search" {
+		t.Errorf("sole source name = %v, want web_search (not a placeholder note)", s0["name"])
+	}
+}
+
+// TestCompanyReconWebAndProfilingNoDuplicateSource proves selecting both
+// "web" and "profiling" together records the source once, not twice — the
+// two phase names share one underlying web-search call.
+func TestCompanyReconWebAndProfilingNoDuplicateSource(t *testing.T) {
+	t.Parallel()
+	out, res := callTool(t, setupTestDeps(), "company_recon", map[string]any{
+		"target": "acme.com",
+		"phases": []any{"web", "profiling"},
+	})
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %v", res.Content)
+	}
+	sources, ok := out["sources"].([]any)
+	if !ok || len(sources) != 1 {
+		t.Fatalf("sources = %v, want exactly 1 entry (no duplicate web-search source)", out["sources"])
+	}
+}
+
 func TestCompanyReconCompanyNameFallsBackToWebSearch(t *testing.T) {
 	t.Parallel()
 	out, res := callTool(t, setupTestDeps(), "company_recon", map[string]any{"target": "Acme Corp"})

--- a/scripts/harness-432.sh
+++ b/scripts/harness-432.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Permanent regression gate for issue #432 (company_recon "web" phase dead
+# code, scraper browser-tier 404 misclassification, audit_bibliography false
+# not_found on arXiv-family DOIs). Runs 6 independent gates in order; fails
+# loud (non-zero exit) on the first gate that fails. Re-run after every change
+# to internal/tools/{company_recon,audit_bibliography,paper_fulltext}.go or
+# internal/scraper/{browser,errors}.go.
+#
+# Usage: bash scripts/harness-432.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="$REPO_ROOT/.harness-out"
+mkdir -p "$OUT_DIR"
+
+GATE=0
+FAILED=0
+
+run_gate() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    local status=$?
+    echo "    FAIL (exit ${status}) — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+# go test with -run exits 0 and prints "no tests to run" when the pattern
+# matches nothing — a silent no-op that would let this gate rubber-stamp
+# tests that were never written. Treat that output as an explicit failure.
+require_tests_ran() {
+  if grep -q "no tests to run" "$1"; then
+    echo "no tests matched the -run pattern (target tests not written yet)" >>"$1"
+    return 1
+  fi
+  return 0
+}
+
+run_gate_requiring_tests() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1 && require_tests_ran "$logfile"; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    echo "    FAIL — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+run_gate "Lint (golangci-lint)" \
+  "$OUT_DIR/432-01-lint.log" \
+  make lint
+
+run_gate "SAST (gosec) + vuln scan + pattern checks (rules 2.1/2.2)" \
+  "$OUT_DIR/432-02-sast.log" \
+  bash -c '
+    set -e
+    make sec
+    make vuln
+    echo "--- grep: browser-tier fix reuses classifyHTTPStatus, no bespoke status check (rule 5.2) ---"
+    grep -q "classifyHTTPStatus" internal/scraper/browser.go || { echo "browser.go must call classifyHTTPStatus"; exit 1; }
+    echo "--- grep: audit_bibliography DOI fallback consults deps.DOIRegistry, not a new resolver (rule 5.3) ---"
+    grep -q "DOIRegistry" internal/tools/audit_bibliography.go || { echo "audit_bibliography.go must consult deps.DOIRegistry"; exit 1; }
+    echo "--- grep: no TODO/FIXME left in the three fixed files ---"
+    ! grep -rn "TODO\|FIXME" internal/tools/company_recon.go internal/tools/audit_bibliography.go internal/scraper/browser.go 2>/dev/null
+  '
+
+# internal/tools holds zero per-instance state (Design Rule 1); none of the
+# three fixes add module-level mutable state (spec rule 1.1, N/A row). No
+# dedicated new isolation test is required — the existing suite's concurrent
+# registration test is reused as proof no regression was introduced.
+run_gate_requiring_tests "Multi-instance isolation (rule 1.1, reuse)" \
+  "$OUT_DIR/432-03-isolation.log" \
+  go test ./internal/tools/... -run 'TestRegisterAllDoesNotPanic' -v -count=1
+
+run_gate "Dead-code scan (go vet)" \
+  "$OUT_DIR/432-04-deadcode.log" \
+  go vet ./...
+
+run_gate_requiring_tests "Unit/integration tests proving rules 3.1/3.2/3.3" \
+  "$OUT_DIR/432-05-unit.log" \
+  go test -race ./internal/tools/... ./internal/scraper/... -run 'TestCompanyRecon.*Web|TestCompanyReconPhaseSelection|TestScrapeBrowser.*NotFound|TestAuditBibliography.*DOIRegistry|TestAuditBibliography.*ArXiv|TestAuditBibliography.*Registry' -v -count=1
+
+run_gate_requiring_tests "E2E (real MCP flow per finding, recorded proof)" \
+  "$OUT_DIR/432-06-e2e.log" \
+  go test -tags=e2e -run 'TestCompanyRecon_E2E' ./tests/e2e/... -v -count=1
+
+echo
+if [ "$FAILED" -ne 0 ]; then
+  echo "HARNESS FAILED — see logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+  exit 1
+fi
+
+echo "HARNESS PASSED — all 6 gates green. Logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+exit 0


### PR DESCRIPTION
## Summary

Closes #432. Three IRL-sweep findings, each with an isolated root-cause fix:

- **company_recon**: `phases:["web"]` alone returned a placeholder instead of the web-search summary — the code required `"profiling"` even though `"web"` is documented as an independently selectable phase. Fixed by triggering the summary on either phase; source attribution stays stable (recorded under `"profiling"` when both are selected).
- **browser scrape tier**: never inspected the main document's HTTP status, so a dead DOI-resolver landing page's 404 HTML was returned as if it were real content. Fixed by subscribing to `NetworkResponseReceived`/`PageFrameNavigated` CDP events before `Navigate()` (avoiding the async-subscription race) and routing `>=400` through the same `classifyHTTPStatus` the other three tiers already use.
- **audit_bibliography**: treated a Crossref 404 as authoritative non-existence, false-flagging `not_found` on valid arXiv DOIs (e.g. `10.48550/arXiv.1706.03762`, "Attention Is All You Need") that Crossref doesn't index but the doi.org handle registry confirms. Fixed by mirroring `verify_citation.go`'s existing `verifyByDOI` fallback: Crossref `found=false` no longer sets `Exists`; `deps.DOIRegistry` is consulted as the tie-breaker; if that's also unavailable, the entry degrades to `unchecked` rather than defaulting to a false `not_found`.

Built and closed out per the harnessed-build methodology: spec + N/A rows in #432, `scripts/harness-432.sh` (6 gates, committed as permanent regression infra), one module at a time with harness re-runs, full `make verify` clean.

### Deviations from the #432 spec (documented in the closing comment)
- All three modules were originally built on `fix/scrape-raw-mode-pipeline-reuse`, which turned out to host a separate already-open PR (#431). Moved the full changeset to this fresh branch cut from `main` to keep the two efforts isolated.
- `browser_test.go`'s new tests were initially written against a `scrapeBrowser` signature that included PR #431's still-unmerged `raw bool` parameter. Adjusted to match `main`'s actual 3-parameter signature since #431 isn't merged yet.

## Test plan
- [x] `scripts/harness-432.sh` — all 6 gates pass (lint, SAST+vuln+pattern checks, multi-instance isolation, go vet/dead-code, unit/integration tests, E2E)
- [x] `make verify` — full CI-equivalent gate passes (fmt-check, vet, lint, sec, vuln, validate-lenses, test-race, test-e2e, check-python-drift, test-python, build)
- [x] `go test -race ./...` clean
- [x] Docs-drift tests (`TestToolsDocMatchesRegistry`, `TestOutputSchemaMatchesResponse`, `TestProvidersDocStructuredDomainTable`) pass after the one-line `docs/TOOLS.md` fix
- [x] No tool JSON schema changed → `make gen-python-client` confirmed not required

🤖 Generated with [Claude Code](https://claude.com/claude-code)