### PR TITLE
test: close Phase 4 audit gaps for milestone #16 (research_panel + monitor E2E)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,27 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 # academic_search results that lack one. Best-effort, no-op when unset.
 # UNPAYWALL_EMAIL=you@example.com    # required contact email (falls back to OPENALEX_EMAIL if unset)
 
+# ── Research Panel (optional, enables research_panel) ───────────────────────
+# research_panel auto-detects its panel members from whichever of these are
+# set; the tool registers only when at least one resolves. Priority: an
+# OpenRouter key covers every model below through one credential and takes
+# priority over direct provider keys when both are set.
+# OPENROUTER_API_KEY=...              # unlocks 400+ models via one key (openrouter.ai)
+# OPENAI_API_KEY=...                  # direct OpenAI
+# ANTHROPIC_API_KEY=...               # direct Anthropic
+# GOOGLE_AI_API_KEY=...               # direct Google Gemini
+# OLLAMA_BASE_URL=http://localhost:11434   # local Ollama; needs ALLOW_PRIVATE_IPS=true unless
+#                                           # pointed at a public host
+# LM_STUDIO_BASE_URL=http://localhost:1234 # local LM Studio; same gating as Ollama
+# RESEARCH_PANEL_DEFAULT_MODELS=openrouter/anthropic/claude-sonnet-4-6,openrouter/openai/gpt-5
+#                                      # comma-separated '<provider>/<model-id>' overrides for the
+#                                      # auto-detected default panel; unresolvable entries are dropped
+# RESEARCH_PANEL_MAX_MODELS=3         # cap on default panel size (a tool call's own max_models
+#                                      # input can only narrow this, never widen it)
+# AWS Bedrock has no dedicated var here — it activates when standard
+# AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY/AWS_REGION are already set (same as
+# any other AWS CLI-configured tool), no new credential surface added.
+
 # ── Patent Search Providers (optional, enables structured patent search) ────
 # These provide direct access to official patent databases with structured results.
 # When configured, patent_search uses these instead of web search fallback.

--- a/internal/tools/research_panel_test.go
+++ b/internal/tools/research_panel_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -43,6 +45,90 @@ func TestResearchPanelTool(t *testing.T) {
 	}
 	if out["trust"] != untrustedContentTrust {
 		t.Errorf("expected trust marker %q, got %v", untrustedContentTrust, out["trust"])
+	}
+}
+
+// TestResearchPanelPartialFailure proves rule 3.2 (issue #441): one panel
+// member erroring must not fail the whole call — the tool returns the
+// surviving responses and records the failure in _meta, never a tool error,
+// as long as at least one model succeeds.
+func TestResearchPanelPartialFailure(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	deps.ResearchPanelProviders = []ModelProvider{
+		&mockModelProvider{name: "mock-a", modelID: "model-a", text: "The sky is blue."},
+		&mockModelProvider{name: "mock-b", modelID: "model-b", err: errors.New("simulated timeout")},
+	}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "research_panel",
+		Arguments: map[string]any{"question": "What color is the sky?", "use_cache": false},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("one failed panel member must not fail the whole call when another succeeds, got error: %v", res.Content)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	meta, _ := out["_meta"].(map[string]any)
+	if meta["models_succeeded"].(float64) != 1 {
+		t.Errorf("expected 1 succeeded model, got %v", meta["models_succeeded"])
+	}
+	if meta["models_failed"].(float64) != 1 {
+		t.Errorf("expected 1 failed model recorded in _meta, got %v", meta["models_failed"])
+	}
+	panel, _ := out["panel"].([]any)
+	if len(panel) != 2 {
+		t.Fatalf("expected both panel entries present (one success, one error), got %d", len(panel))
+	}
+	var sawError bool
+	for _, p := range panel {
+		entry := p.(map[string]any)
+		if entry["provider"] == "mock-b" {
+			if entry["error"] == nil {
+				t.Errorf("failed panel member should carry an error field, got %v", entry)
+			}
+			sawError = true
+		}
+	}
+	if !sawError {
+		t.Fatal("expected the mock-b entry to be present with its error recorded")
+	}
+}
+
+// TestResearchPanelNoSynthesisCall proves rule 4.4 (issue #441): divergence
+// analysis is pure Go (AnalyzeDivergence), so the total number of Ask calls
+// equals exactly the panel size — no additional judge/synthesis model call is
+// made on top of the panel members themselves.
+func TestResearchPanelNoSynthesisCall(t *testing.T) {
+	ctx := context.Background()
+	var calls atomic.Int64
+	deps := setupTestDeps()
+	deps.ResearchPanelProviders = []ModelProvider{
+		&mockModelProvider{name: "mock-a", modelID: "model-a", text: "The sky is blue.", calls: &calls},
+		&mockModelProvider{name: "mock-b", modelID: "model-b", text: "The sky appears blue.", calls: &calls},
+	}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "research_panel",
+		Arguments: map[string]any{"question": "What color is the sky?", "use_cache": false},
+	})
+	if err != nil || res.IsError {
+		t.Fatalf("CallTool failed: err=%v isError=%v content=%v", err, res.IsError, res.Content)
+	}
+	if got := calls.Load(); got != int64(len(deps.ResearchPanelProviders)) {
+		t.Errorf("expected exactly %d Ask calls (one per panel member, no extra synthesis call), got %d", len(deps.ResearchPanelProviders), got)
 	}
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -292,16 +293,26 @@ func (m *mockLocalProvider) Local(_ context.Context, _ search.LocalSearchParams)
 }
 
 // mockModelProvider backs research_panel in tests — a fixed panel member that
-// answers instantly without a real LLM credential.
+// answers instantly without a real LLM credential. A non-nil err makes Ask
+// fail instead, and calls (when set) counts every Ask invocation so a test
+// can assert no extra call beyond the panel members themselves.
 type mockModelProvider struct {
 	name    string
 	modelID string
 	text    string
+	err     error
+	calls   *atomic.Int64
 }
 
 func (m *mockModelProvider) Name() string    { return m.name }
 func (m *mockModelProvider) ModelID() string { return m.modelID }
 func (m *mockModelProvider) Ask(_ context.Context, _ string) (ModelResponse, error) {
+	if m.calls != nil {
+		m.calls.Add(1)
+	}
+	if m.err != nil {
+		return ModelResponse{}, m.err
+	}
 	return ModelResponse{Text: m.text, InputTokens: 10, OutputTokens: 20, LatencyMs: 5}, nil
 }
 

--- a/tests/e2e/monitor_e2e_test.go
+++ b/tests/e2e/monitor_e2e_test.go
@@ -1,0 +1,233 @@
+//go:build e2e
+
+package e2e
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestMonitorQuery_E2E drives monitor_query_save → monitor_query_check over
+// the real MCP transport and proves research monitoring (#273) end-to-end:
+// registered only when MONITORING_ENABLED, consent-gated (denied without a
+// grant), and the save→check diff actually narrows to just-new URLs against a
+// deterministic local SearXNG-shaped httptest server (real DuckDuckGo/Google
+// results aren't stable enough to assert "these exact URLs are new").
+func TestMonitorQuery_E2E(t *testing.T) {
+	// Two fixed responses: monitor_query_save baselines against the first
+	// (both URLs "seen"); monitor_query_check re-runs against the second,
+	// which adds one new URL — that's the only one that should come back new.
+	first := `{"results":[{"title":"A","url":"https://example.com/a","content":"a"},{"title":"B","url":"https://example.com/b","content":"b"}]}`
+	second := `{"results":[{"title":"A","url":"https://example.com/a","content":"a"},{"title":"B","url":"https://example.com/b","content":"b"},{"title":"C","url":"https://example.com/c","content":"c"}]}`
+	call := 0
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		call++
+		w.Header().Set("Content-Type", "application/json")
+		if call == 1 {
+			_, _ = w.Write([]byte(first))
+			return
+		}
+		_, _ = w.Write([]byte(second))
+	}))
+	defer ts.Close()
+
+	h := newMCPTestHarness(t,
+		"ALLOW_PRIVATE_IPS=true",
+		"MONITORING_ENABLED=true",
+		"STDIO_USER_ID=monitor-e2e-tester",
+		"SEARCH_PROVIDER=searxng",
+		"SEARXNG_URL="+ts.URL,
+	)
+
+	h.send(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]interface{}{"name": "e2e-monitor-test", "version": "1.0.0"},
+		},
+	})
+	if resp := h.readResponse(); resp.Error != nil {
+		t.Fatalf("initialize returned error: %s", resp.Error)
+	}
+
+	h.send(jsonRPCRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+
+	parseTool := func(resp jsonRPCResponse) map[string]any {
+		t.Helper()
+		var res struct {
+			Content []struct {
+				Text string `json:"text"`
+			} `json:"content"`
+		}
+		if err := json.Unmarshal(resp.Result, &res); err != nil || len(res.Content) == 0 {
+			t.Fatalf("bad tool result: %v raw=%s", err, resp.Result)
+		}
+		var out map[string]any
+		if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+			t.Fatalf("tool output not JSON: %v raw=%s", err, res.Content[0].Text)
+		}
+		return out
+	}
+
+	t.Run("ListedInTools", func(t *testing.T) {
+		h.send(jsonRPCRequest{JSONRPC: "2.0", ID: 2, Method: "tools/list"})
+		resp := h.readResponse()
+		if resp.Error != nil {
+			t.Fatalf("tools/list returned error: %s", resp.Error)
+		}
+		var result struct {
+			Tools []struct {
+				Name string `json:"name"`
+			} `json:"tools"`
+		}
+		if err := json.Unmarshal(resp.Result, &result); err != nil {
+			t.Fatalf("failed to parse tools result: %v", err)
+		}
+		var haveSave, haveCheck bool
+		for _, tool := range result.Tools {
+			if tool.Name == "monitor_query_save" {
+				haveSave = true
+			}
+			if tool.Name == "monitor_query_check" {
+				haveCheck = true
+			}
+		}
+		if !haveSave || !haveCheck {
+			t.Errorf("monitor_query_save/monitor_query_check should be registered when MONITORING_ENABLED=true, got save=%v check=%v", haveSave, haveCheck)
+		}
+	})
+
+	t.Run("SaveBaselinesThenCheckReturnsOnlyNewURL", func(t *testing.T) {
+		h.send(jsonRPCRequest{
+			JSONRPC: "2.0",
+			ID:      3,
+			Method:  "tools/call",
+			Params: map[string]interface{}{
+				"name":      "monitor_query_save",
+				"arguments": map[string]interface{}{"query": "test monitor query"},
+			},
+		})
+		resp := h.readResponse()
+		if resp.Error != nil {
+			t.Fatalf("monitor_query_save transport error: %s", resp.Error)
+		}
+		save := parseTool(resp)
+		if save["status"] != "ok" {
+			t.Fatalf("monitor_query_save should succeed with STDIO_USER_ID + consent auto-grant, got status=%v reason=%v", save["status"], save["reason"])
+		}
+		if seenCount, _ := save["seenCount"].(float64); seenCount != 2 {
+			t.Fatalf("expected seenCount=2 from the baseline fixture, got %v", save["seenCount"])
+		}
+
+		h.send(jsonRPCRequest{
+			JSONRPC: "2.0",
+			ID:      4,
+			Method:  "tools/call",
+			Params: map[string]interface{}{
+				"name":      "monitor_query_check",
+				"arguments": map[string]interface{}{"query": "test monitor query"},
+			},
+		})
+		resp = h.readResponse()
+		if resp.Error != nil {
+			t.Fatalf("monitor_query_check transport error: %s", resp.Error)
+		}
+		check := parseTool(resp)
+		if check["status"] != "ok" {
+			t.Fatalf("monitor_query_check should succeed, got status=%v reason=%v", check["status"], check["reason"])
+		}
+		if newCount, _ := check["newCount"].(float64); newCount != 1 {
+			t.Fatalf("expected exactly 1 new result (the fixture added one URL), got %v", check["newCount"])
+		}
+		if check["trust"] != "untrusted-external-content" {
+			t.Errorf("monitor_query_check trust = %v, want untrusted-external-content", check["trust"])
+		}
+	})
+
+	t.Run("CheckIsIdempotentOnSecondCallWithNoUpstreamChange", func(t *testing.T) {
+		h.send(jsonRPCRequest{
+			JSONRPC: "2.0",
+			ID:      5,
+			Method:  "tools/call",
+			Params: map[string]interface{}{
+				"name":      "monitor_query_check",
+				"arguments": map[string]interface{}{"query": "test monitor query"},
+			},
+		})
+		resp := h.readResponse()
+		if resp.Error != nil {
+			t.Fatalf("monitor_query_check transport error: %s", resp.Error)
+		}
+		check := parseTool(resp)
+		if newCount, _ := check["newCount"].(float64); newCount != 0 {
+			t.Fatalf("second consecutive check against the same fixture should report zero new results, got %v", check["newCount"])
+		}
+	})
+
+	t.Run("Shutdown", func(t *testing.T) {
+		h.shutdown()
+	})
+}
+
+// TestMonitorQuery_DeniedWithoutConsent proves monitor_query_save fails
+// closed when monitoring is enabled but the caller has no recorded consent
+// for the 'monitoring' purpose — the same STDIO auto-grant path as memory
+// (TestSecurity_STDIO_UserIdentity) but exercising monitor's own gate, since
+// #273 is the first sub-issue to introduce this Purpose end-to-end.
+func TestMonitorQuery_DeniedWithoutConsent(t *testing.T) {
+	h := newMCPTestHarness(t,
+		"MONITORING_ENABLED=true",
+		// no STDIO_USER_ID → anonymous → unauthenticated, not just unconsented
+	)
+
+	h.send(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      1,
+		Method:  "initialize",
+		Params: map[string]interface{}{
+			"protocolVersion": "2025-03-26",
+			"capabilities":    map[string]interface{}{},
+			"clientInfo":      map[string]interface{}{"name": "e2e-monitor-denied-test", "version": "1.0.0"},
+		},
+	})
+	if resp := h.readResponse(); resp.Error != nil {
+		t.Fatalf("initialize returned error: %s", resp.Error)
+	}
+	h.send(jsonRPCRequest{JSONRPC: "2.0", Method: "notifications/initialized"})
+
+	h.send(jsonRPCRequest{
+		JSONRPC: "2.0",
+		ID:      2,
+		Method:  "tools/call",
+		Params: map[string]interface{}{
+			"name":      "monitor_query_save",
+			"arguments": map[string]interface{}{"query": "test monitor query"},
+		},
+	})
+	resp := h.readResponse()
+	if resp.Error != nil {
+		t.Fatalf("monitor_query_save transport error: %s", resp.Error)
+	}
+	var res struct {
+		Content []struct {
+			Text string `json:"text"`
+		} `json:"content"`
+	}
+	if err := json.Unmarshal(resp.Result, &res); err != nil || len(res.Content) == 0 {
+		t.Fatalf("bad tool result: %v raw=%s", err, resp.Result)
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].Text), &out); err != nil {
+		t.Fatalf("tool output not JSON: %v raw=%s", err, res.Content[0].Text)
+	}
+	if out["status"] != "unavailable" {
+		t.Fatalf("monitor_query_save must deny an anonymous caller even with MONITORING_ENABLED=true, got status=%v", out["status"])
+	}
+
+	h.shutdown()
+}


### PR DESCRIPTION
Closes four Phase 4 diff-audit gaps found while auditing milestone #16 (issue #441) against the actual merged diff.

## Gaps found and fixed

1. **`TestMonitorQuery_E2E` cited in `scripts/harness-16.sh` gate 6 but never existed** — `monitor_query_save`/`monitor_query_check` (#273) had zero E2E coverage through the real MCP transport, despite issue #441 rule 6 citing it as proof. Added `tests/e2e/monitor_e2e_test.go`: `TestMonitorQuery_E2E` (save→check diff against a deterministic SearXNG-shaped httptest fixture, plus idempotency on a second no-change check) and `TestMonitorQuery_DeniedWithoutConsent` (anonymous caller denied).
2. **Rule 3.2 (partial panel failure) had no test** — added `TestResearchPanelPartialFailure`: one erroring panel member must not fail the whole `research_panel` call.
3. **Rule 4.4 (no synthesis LLM call) had no test** — added `TestResearchPanelNoSynthesisCall`: asserts total `Ask` calls == panel size, proving divergence analysis never triggers an extra model call.
4. **`.env.example` never documented research_panel's env var surface** — `internal/config.ResearchPanelConfig` reads 8 vars (`OPENROUTER_API_KEY`, `OPENAI_API_KEY`, `ANTHROPIC_API_KEY`, `GOOGLE_AI_API_KEY`, `OLLAMA_BASE_URL`, `LM_STUDIO_BASE_URL`, `RESEARCH_PANEL_DEFAULT_MODELS`, `RESEARCH_PANEL_MAX_MODELS`) with zero mention in the authoritative env var doc. Added a documented section.

All new tests verified passing locally (`-race`, `-v`, `-count=1`) before push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)