### PR TITLE
chore(harness): add local HTTPS+OAuth e2e harness for regulated features

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: build build-fips sync-lenses test test-race test-cover test-e2e test-live test-eval test-geo-eval test-concurrency test-bench test-python test-python-live \
-        lint fmt fmt-check vet vuln sec tools hooks precommit verify clean run dev docker docker-smoke release version-sync rebuild-local help all \
+        lint fmt fmt-check vet vuln sec tools hooks precommit verify clean run dev docker docker-smoke e2e-oauth-docker release version-sync rebuild-local help all \
         gen-python-client check-python-drift
 
 BINARY = web-researcher-mcp
@@ -184,6 +184,12 @@ docker:
 docker-smoke:
 	bash scripts/docker-smoke.sh $(BINARY):smoke
 
+# Full local e2e pass: HTTPS reverse proxy + throwaway OAuth issuer + the real
+# regulated-feature surface (memory/analytics/monitoring) + isolation + GDPR
+# export/erasure. Manual only — needs a Docker daemon; not run in CI.
+e2e-oauth-docker:
+	bash scripts/e2e-oauth-docker.sh
+
 release:
 	goreleaser release --snapshot --clean
 
@@ -199,7 +205,7 @@ rebuild-local:
 	bash scripts/rebuild-local.sh $(ARGS)
 
 help:
-	@grep -E '^[a-zA-Z_-]+:.*' Makefile | grep -v '^\.PHONY' | sort | \
+	@grep -E '^[a-zA-Z0-9_-]+:.*' Makefile | grep -v '^\.PHONY' | sort | \
 		awk -F: '{printf "  %-18s\n", $$1}'
 
 all: verify

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -232,6 +232,8 @@ docker run -p 3000:3000 \
 
 **For headless browser (go-rod):** The bundled images already ship Chromium and set `CHROME_PATH`. Override `CHROME_PATH` only if you mount a different Chromium/Chrome binary.
 
+**Full HTTPS + OAuth + regulated-feature e2e pass:** `scripts/e2e-oauth-docker.sh` builds the image, fronts it with a Caddy HTTPS proxy and a throwaway RS256 JWKS issuer, and drives `memory_save`/`memory_recall`, `get_my_analytics`, `monitor_query_save`/`monitor_query_check`, cross-user isolation, and `/admin/data` export+erasure end-to-end over real MCP-over-HTTPS calls. Manual/local only (needs a Docker daemon) — not part of `make verify` or CI, which is what `make docker-smoke` covers instead (plain HTTP, no OAuth).
+
 ---
 
 ## Kubernetes

--- a/scripts/e2e-oauth-docker.sh
+++ b/scripts/e2e-oauth-docker.sh
@@ -1,0 +1,228 @@
+#!/usr/bin/env bash
+# e2e-oauth-docker.sh — stand up a full local Docker deployment (HTTPS reverse
+# proxy + a minimal static-JWKS OAuth issuer + the real server image) and run
+# an end-to-end pass over the regulated, consent-gated tools (memory_save/
+# memory_recall, get_my_analytics, monitor_query_save/monitor_query_check),
+# plus a tenant/user isolation check and a GDPR export/erasure check.
+#
+# This is a manual/local e2e harness, NOT part of `make verify` or CI: it needs
+# a Docker daemon (Rancher Desktop, Docker Desktop, etc.) and is deliberately
+# heavier than docker-smoke.sh (which only proves the container serves MCP over
+# plain HTTP). Use this when you need to validate the full HTTPS+OAuth+
+# consent-gated-feature story before a release, not on every commit.
+#
+# Why a hand-minted JWKS instead of a real IdP: internal/auth/middleware.go
+# validates RS256 JWTs against a JWKS fetched from
+# ${OAUTH_ISSUER_URL}/.well-known/jwks.json — there is no dev-mode bypass, so
+# the only way to drive that code path locally is a real (self-signed) RSA
+# keypair + a static JWKS server. This script builds one from scratch every
+# run so there is never a stale keypair to debug.
+#
+# Rancher Desktop / Docker Desktop VM note: only paths under $HOME are shared
+# into the container VM by default, so this script does its work under
+# $WORK_DIR (default: ~/.cache/web-researcher-mcp/e2e-oauth), not /tmp.
+#
+# Usage:
+#   scripts/e2e-oauth-docker.sh          # run the full pass
+#   scripts/e2e-oauth-docker.sh --keep   # leave containers running after the run
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+IMAGE="web-researcher-mcp:e2e-oauth"
+WORK_DIR="${WORK_DIR:-$HOME/.cache/web-researcher-mcp/e2e-oauth}"
+NET="wrm-e2e-net"
+APP="wrm-e2e-app"
+PROXY="wrm-e2e-proxy"
+ISSUER_CONTAINER="wrm-e2e-jwks"
+HTTPS_PORT=8543
+JWKS_PORT=9599
+KID="e2e-test-key"
+ISSUER_URL="http://${ISSUER_CONTAINER}:${JWKS_PORT}"
+AUDIENCE="web-researcher-mcp"
+KEEP="${1:-}"
+
+pass=0
+fail=0
+check() {
+  local desc="$1" cond="$2"
+  if [ "$cond" = "0" ]; then
+    echo "  [PASS] $desc"
+    pass=$((pass + 1))
+  else
+    echo "  [FAIL] $desc"
+    fail=$((fail + 1))
+  fi
+}
+
+cleanup() {
+  if [ "$KEEP" != "--keep" ]; then
+    echo "=== cleanup: removing containers + network"
+    docker rm -f "$APP" "$PROXY" "$ISSUER_CONTAINER" >/dev/null 2>&1 || true
+    docker network rm "$NET" >/dev/null 2>&1 || true
+  else
+    echo "=== --keep set: leaving $APP, $PROXY, $ISSUER_CONTAINER running on $NET"
+  fi
+}
+trap cleanup EXIT
+
+echo "=== [1/8] Prep work dir: $WORK_DIR"
+rm -rf "$WORK_DIR"
+mkdir -p "$WORK_DIR/certs" "$WORK_DIR/www/.well-known"
+
+echo "=== [2/8] Generate self-signed TLS cert for the HTTPS proxy"
+openssl req -x509 -nodes -newkey rsa:2048 -days 7 \
+  -keyout "$WORK_DIR/certs/server.key" -out "$WORK_DIR/certs/server.crt" \
+  -subj "/CN=localhost" -addext "subjectAltName=DNS:localhost,IP:127.0.0.1" \
+  >/dev/null 2>&1
+
+echo "=== [3/8] Mint RSA keypair + JWKS + two per-user JWTs"
+python3 "$REPO_ROOT/scripts/e2e-oauth-mint-jwt.py" init "$WORK_DIR" "$KID"
+cp "$WORK_DIR/jwks.json" "$WORK_DIR/www/.well-known/jwks.json"
+USER1=e2e-user-alice
+USER2=e2e-user-bob
+python3 "$REPO_ROOT/scripts/e2e-oauth-mint-jwt.py" mint "$WORK_DIR" "$USER1" "$KID" "$ISSUER_URL" "$AUDIENCE" > "$WORK_DIR/token1.txt"
+python3 "$REPO_ROOT/scripts/e2e-oauth-mint-jwt.py" mint "$WORK_DIR" "$USER2" "$KID" "$ISSUER_URL" "$AUDIENCE" > "$WORK_DIR/token2.txt"
+TOKEN1="$(cat "$WORK_DIR/token1.txt")"
+TOKEN2="$(cat "$WORK_DIR/token2.txt")"
+
+ADMIN_KEY="$(openssl rand -hex 32)"
+
+cat > "$WORK_DIR/Caddyfile" <<EOF
+{
+	auto_https off
+}
+
+https://localhost:${HTTPS_PORT} {
+	tls /certs/server.crt /certs/server.key
+	reverse_proxy ${APP}:8080
+}
+EOF
+
+echo "=== [4/8] Build image ${IMAGE}"
+docker build -t "$IMAGE" "$REPO_ROOT" >/dev/null
+
+echo "=== [5/8] Start network + JWKS issuer + app + HTTPS proxy"
+docker network rm "$NET" >/dev/null 2>&1 || true
+docker network create "$NET" >/dev/null
+
+docker rm -f "$ISSUER_CONTAINER" "$APP" "$PROXY" >/dev/null 2>&1 || true
+
+docker run -d --name "$ISSUER_CONTAINER" --network "$NET" \
+  -v "$WORK_DIR/www:/usr/share/nginx/html:ro" \
+  nginx:alpine sh -c "sed -i 's/listen  *80;/listen ${JWKS_PORT};/' /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'" \
+  >/dev/null
+
+docker run -d --name "$APP" --network "$NET" \
+  -e PORT=8080 \
+  -e ADMIN_API_KEY="$ADMIN_KEY" \
+  -e MEMORY_ENABLED=true \
+  -e USER_ANALYTICS_ENABLED=true \
+  -e MONITORING_ENABLED=true \
+  -e OAUTH_ISSUER_URL="$ISSUER_URL" \
+  -e OAUTH_AUDIENCE="$AUDIENCE" \
+  "$IMAGE" >/dev/null
+
+docker run -d --name "$PROXY" --network "$NET" \
+  -p "${HTTPS_PORT}:${HTTPS_PORT}" \
+  -v "$WORK_DIR/Caddyfile:/etc/caddy/Caddyfile:ro" \
+  -v "$WORK_DIR/certs:/certs:ro" \
+  caddy:2-alpine >/dev/null
+
+BASE="https://localhost:${HTTPS_PORT}"
+CURL_OPTS=(-sk)
+
+echo "=== [6/8] Wait for readiness"
+ready=""
+for _ in $(seq 1 50); do
+  body="$(curl "${CURL_OPTS[@]}" "$BASE/health/ready" 2>/dev/null || true)"
+  [ "$body" = "ready" ] && { ready=yes; break; }
+  sleep 0.3
+done
+if [ -z "$ready" ]; then
+  echo "!!! server never became ready"
+  docker logs "$APP" 2>&1 | tail -40
+  exit 1
+fi
+check "HTTPS proxy + /health/ready" 0
+
+echo "=== [7/8] Grant consent for both users, then drive MCP over HTTPS+OAuth"
+for user in "$USER1" "$USER2"; do
+  for purpose in memory analytics monitoring; do
+    curl "${CURL_OPTS[@]}" -X POST "$BASE/admin/consent" \
+      -H "X-Admin-Key: $ADMIN_KEY" -H "Content-Type: application/json" \
+      -d "{\"tenant_id\":\"default\",\"user_id\":\"$user\",\"purpose\":\"$purpose\",\"granted\":true}" \
+      >/dev/null
+  done
+done
+
+mcp_init() {
+  local token="$1" hdrs
+  hdrs="$(mktemp)"
+  curl "${CURL_OPTS[@]}" -D "$hdrs" -X POST "$BASE/mcp/" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $token" \
+    -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"e2e-oauth","version":"1.0"}}}' \
+    >/dev/null
+  local sid
+  sid="$(grep -i '^Mcp-Session-Id:' "$hdrs" | head -1 | cut -d: -f2- | tr -d '\r' | xargs)"
+  rm -f "$hdrs"
+  curl "${CURL_OPTS[@]}" -X POST "$BASE/mcp/" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $token" -H "Mcp-Session-Id: $sid" \
+    -d '{"jsonrpc":"2.0","method":"notifications/initialized"}' -o /dev/null
+  echo "$sid"
+}
+
+mcp_call() {
+  local token="$1" sid="$2" name="$3" args="$4"
+  curl "${CURL_OPTS[@]}" -X POST "$BASE/mcp/" \
+    -H "Content-Type: application/json" -H "Accept: application/json, text/event-stream" \
+    -H "Authorization: Bearer $token" -H "Mcp-Session-Id: $sid" \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":2,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$args}}"
+}
+
+SID1="$(mcp_init "$TOKEN1")"
+SID2="$(mcp_init "$TOKEN2")"
+[ -n "$SID1" ] && [ -n "$SID2" ]
+check "MCP initialize for two distinct authenticated users" $?
+
+R="$(mcp_call "$TOKEN1" "$SID1" memory_save '{"note":"e2e isolation secret for alice","topic":"e2e"}')"
+echo "$R" | grep -q '"status":"ok"'
+check "memory_save (alice)" $?
+
+R="$(mcp_call "$TOKEN1" "$SID1" memory_recall '{}')"
+echo "$R" | grep -q 'e2e isolation secret for alice'
+check "memory_recall sees own note (alice)" $?
+
+R="$(mcp_call "$TOKEN2" "$SID2" memory_recall '{}')"
+if echo "$R" | grep -q 'e2e isolation secret for alice'; then leak=1; else leak=0; fi
+check "memory_recall does NOT leak alice's note to bob (isolation)" "$leak"
+echo "$R" | grep -q '"count":0'
+check "bob's memory_recall count is 0" $?
+
+R="$(mcp_call "$TOKEN1" "$SID1" get_my_analytics '{}')"
+echo "$R" | grep -q '"userId":"'"$USER1"'"'
+check "get_my_analytics scoped to alice" $?
+
+R="$(mcp_call "$TOKEN1" "$SID1" monitor_query_save '{"query":"e2e oauth harness query","provider":"duckduckgo"}')"
+echo "$R" | grep -q '"status":"ok"'
+check "monitor_query_save (alice)" $?
+
+R="$(mcp_call "$TOKEN2" "$SID2" monitor_query_check '{"query":"e2e oauth harness query","provider":"duckduckgo"}')"
+echo "$R" | grep -q '"status":"not_found"'
+check "monitor_query_check has no baseline for bob (isolation)" $?
+
+echo "=== [8/8] GDPR export + erasure"
+R="$(curl "${CURL_OPTS[@]}" -H "X-Admin-Key: $ADMIN_KEY" "$BASE/admin/data?tenant_id=default&user_id=$USER1")"
+echo "$R" | grep -q 'e2e isolation secret for alice'
+check "/admin/data export includes alice's memory" $?
+
+curl "${CURL_OPTS[@]}" -X DELETE -H "X-Admin-Key: $ADMIN_KEY" "$BASE/admin/data?tenant_id=default&user_id=$USER1" >/dev/null
+
+R="$(curl "${CURL_OPTS[@]}" -H "X-Admin-Key: $ADMIN_KEY" "$BASE/admin/data?tenant_id=default&user_id=$USER1")"
+echo "$R" | grep -qv 'e2e isolation secret for alice'
+check "/admin/data erasure removed alice's memory" $?
+
+echo
+echo "=== RESULTS: $pass passed, $fail failed"
+[ "$fail" -eq 0 ] || exit 1

--- a/scripts/e2e-oauth-mint-jwt.py
+++ b/scripts/e2e-oauth-mint-jwt.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Mint a throwaway RSA keypair/JWKS/JWT for the OAuth e2e harness.
+
+Not a production auth tool: this signs self-issued RS256 tokens against a
+locally-generated key so scripts/e2e-oauth-docker.sh can exercise the real
+OAuth code path (internal/auth/middleware.go) without a hosted IdP.
+
+Usage:
+  e2e-oauth-mint-jwt.py init  <dir> <kid>
+      Generates an RSA keypair + JWKS document into <dir>/priv.pem and
+      <dir>/jwks.json.
+  e2e-oauth-mint-jwt.py mint  <dir> <subject> <kid> <issuer> <audience>
+      Signs a JWT for <subject> using <dir>/priv.pem, printed to stdout.
+"""
+import base64
+import json
+import sys
+import time
+
+import jwt
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+
+def b64url_uint(n):
+    b = n.to_bytes((n.bit_length() + 7) // 8, "big")
+    return base64.urlsafe_b64encode(b).rstrip(b"=").decode()
+
+
+def cmd_init(directory, kid):
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    priv_pem = key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    pub = key.public_key().public_numbers()
+    jwks = {
+        "keys": [
+            {
+                "kty": "RSA",
+                "use": "sig",
+                "alg": "RS256",
+                "kid": kid,
+                "n": b64url_uint(pub.n),
+                "e": b64url_uint(pub.e),
+            }
+        ]
+    }
+    with open(f"{directory}/priv.pem", "wb") as f:
+        f.write(priv_pem)
+    with open(f"{directory}/jwks.json", "w") as f:
+        json.dump(jwks, f, indent=2)
+
+
+def cmd_mint(directory, subject, kid, issuer, audience):
+    with open(f"{directory}/priv.pem", "rb") as f:
+        priv_pem = f.read()
+    now = int(time.time())
+    claims = {
+        "iss": issuer,
+        "aud": audience,
+        "sub": subject,
+        "tenant_id": "default",
+        "iat": now,
+        "exp": now + 3600,
+    }
+    token = jwt.encode(claims, priv_pem, algorithm="RS256", headers={"kid": kid})
+    print(token)
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(__doc__, file=sys.stderr)
+        sys.exit(2)
+    mode, directory = sys.argv[1], sys.argv[2]
+    if mode == "init":
+        cmd_init(directory, sys.argv[3])
+    elif mode == "mint":
+        cmd_mint(directory, sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6])
+    else:
+        print(f"unknown mode: {mode}", file=sys.stderr)
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- Adds `scripts/e2e-oauth-docker.sh` + `scripts/e2e-oauth-mint-jwt.py`: a manual/local Docker harness that fronts the real server image with a Caddy HTTPS proxy and a throwaway RS256 JWKS issuer, then drives real MCP-over-HTTPS+OAuth calls against the regulated-feature surface (memory, analytics, monitoring), tenant isolation, and GDPR export/erasure.
- Adds a `make e2e-oauth-docker` target and documents it in `docs/DEPLOYMENT.md`, alongside the existing `docker-smoke.sh` (plain HTTP, no OAuth).
- Manual-only: needs a Docker daemon, not wired into `make verify` or CI.

## Test plan
- [x] Ran the harness fresh (`bash scripts/e2e-oauth-docker.sh`) — 11/11 checks pass
- [x] Ran it with `--keep` and drove additional real IRL tool calls (29 live tools) against the kept containers over HTTPS+OAuth, including consent withdraw/re-grant edge cases for `memory` and `analytics`
- [x] `make fmt-check`, `go vet ./...`, `golangci-lint run`, `gosec`, `govulncheck` all clean
- [x] `go test -race -count=1 ./...` green
- [x] `go test -tags=e2e ./tests/e2e/...` (real STDIO binary) green
- [x] Doc-drift gates (`TestToolsDocMatchesRegistry`, `TestProvidersDocStructuredDomainTable`, `TestAllToolsHaveAnnotations`, `TestOutputSchemaMatchesResponse`, `TestToolDescriptionQuality`) green
- [x] `make check-python-drift` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)