### PR TITLE
fix: goreleaser changelog regex misses comma-scoped/scoped-chore commits

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -322,23 +322,23 @@ changelog:
   use: github
   groups:
     - title: "New Features"
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?feat(\([-[:word:], ]+\))??!?:.+$'
       order: 0
     - title: "Bug Fixes"
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?fix(\([-[:word:], ]+\))??!?:.+$'
       order: 1
     - title: "Performance"
-      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+      regexp: '^.*?perf(\([-[:word:], ]+\))??!?:.+$'
       order: 2
     - title: "Other"
       order: 999
   filters:
     exclude:
-      - "^docs:"
-      - "^test:"
-      - "^ci:"
-      - "^chore:"
-      - "^style:"
+      - "^docs(\\(.+\\))?:"
+      - "^test(\\(.+\\))?:"
+      - "^ci(\\(.+\\))?:"
+      - "^chore(\\(.+\\))?:"
+      - "^style(\\(.+\\))?:"
 
 release:
   github:


### PR DESCRIPTION
## Summary
- v1.46.0's auto-generated release notes miscategorized #444/#445 into "Other" (their scopes contain a comma: `feat(search,tools):`, `fix(search,tools):`) and leaked #442 into "Other" instead of excluding it (`chore(harness):` — the exclude filter only matched bare `chore:`).
- Widens the feat/fix/perf group regexes to allow commas/hyphens/spaces inside the scope, and the docs/test/ci/chore/style exclude filters to match an optional `(scope)` suffix.
- Manually corrected v1.46.0's published release notes via `gh release edit` to reflect the fixed categorization; this PR prevents the same miscategorization on future releases.

## Test plan
- [x] Verified the new regexes against the actual v1.46.0 commit messages (`feat(search,tools):`, `fix(search,tools):`, `chore(harness):`, plain `feat(search):`) — all categorize/exclude correctly now.
- [ ] CI green on this PR.