### PR TITLE
feat(scrape_page,search_and_scrape): surface size hint on resource_link hand-off

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -25,6 +25,7 @@ The heaviest tools — `scrape_page` (`mode: raw`), `search_and_scrape`, and `re
 - The linked body is stored in the shared `cache.Cache` (memory + AES-encrypted disk, or Redis in HTTP mode) under a **content-addressed** key and served read-only via the `research://artifact/{id}` resource template. The id is the SHA-256 of the body, so identical payloads de-dupe and the URI is stable/idempotent.
 - Artifacts are **short-lived** (bounded TTL); a fetch after expiry returns a not-found error, never another caller's data. With no cache configured, large payloads inline (correctness over size).
 - Canonical implementation: `largeResultOrInline(...)` + `registerArtifactResource(...)` in `internal/tools/artifacts.go`. Cache-freshness `_meta` (and routing `_meta`) ride on either shape.
+- On this linked shape, `scrape_page` and `search_and_scrape` each merge extra, tool-specific fields into the inline summary alongside the generic ones, via `largeResultOrInlineWithFields(...)`, so a caller can judge whether the linked artifact is worth a follow-up read without one: `scrape_page` (`mode: raw`) adds `contentSizeBytes` (the raw content's byte length); `search_and_scrape` adds `sourceCount` (sources successfully scraped) and `status` (`complete`/`partial`/`failed`). Both are present ONLY on the linked shape — absent from every inline (non-linked) response, where `contentLength` / `summary.urlsScraped` already carry the same information.
 
 ---
 
@@ -157,6 +158,7 @@ type ScrapeOutput struct {
     DetectedDOI      string            `json:"detectedDoi,omitempty"`      // a scholarly DOI the page declares (#199); peer-reviewed pages only; omitted when none
     RetractionStatus *RetractionStatus `json:"retractionStatus,omitempty"` // Crossref integrity status for detectedDoi; omitted when clean/unresolved — never a guess
     Highlights       []TranscriptHighlight `json:"highlights,omitempty"`   // top ≤5 scored YouTube transcript segments (#284); omitted for non-YouTube URLs and transcripts under 5 segments
+    ContentSizeBytes int       `json:"contentSizeBytes,omitempty"` // raw content length in bytes (#508); present ONLY on the linked resource_link hand-off shape (mode=raw content at/above the link threshold — see Large-Payload Linking above), never on an inline response
 }
 
 type TranscriptHighlight struct {
@@ -253,6 +255,8 @@ Raw mode still runs through the **same safety guards** as every other scrape: `v
 **Trade-off — untrusted bytes.** Because sanitization is skipped, raw content may contain active `<script>`/HTML, embedded markup, or indirect prompt-injection payloads. The bytes are untrusted: never execute or render them, and treat any instructions inside them as data, not commands. For normal reading, prefer `full` (sanitized). `search_and_scrape` is always sanitized and has no raw mode.
 
 Raw responses are keyed like any other scrape: the cache key includes `mode` (so `raw` never collides with a cleaned `full`/`preview` entry for the same URL) and `max_length`. See the Cache section below for the full key.
+
+**Large raw body hint (`contentSizeBytes`, #508).** When a raw response is large enough to cross the [Large-Payload Linking](#large-payload-linking-resource_link) threshold, the inline summary carries `contentSizeBytes` — the raw content's byte length — alongside the generic `resource`/`bytes`/`expiresAt` link fields, so a caller can judge whether the linked artifact is worth a follow-up read without one. It mirrors `contentLength` for a linked payload; it is omitted from every inline (non-linked) response, where `contentLength` already carries the same information.
 
 ### Scraping Strategy (Tiered Fallback)
 
@@ -414,6 +418,7 @@ type SearchAndScrapeOutput struct {
     Recommendations []Recommendation `json:"recommendations,omitempty"` // advisory; see below
     Components      []Component      `json:"components,omitempty"`      // mcp-auto-formatted (deterministic, no LLM); see below
     Hints           *ZeroResultHints `json:"hints,omitempty"`            // present only when the search phase itself returned zero results (#357); same shape as web_search, including epistemicWarning
+    SourceCount     int             `json:"sourceCount,omitempty"`      // sources successfully scraped, mirrors Summary.URLsScraped (#508); present ONLY on the linked resource_link hand-off shape (see Large-Payload Linking above), never on an inline response
 }
 
 // Recommendation is an advisory pointer to a higher-quality source already in
@@ -500,6 +505,10 @@ type PipelineSummary struct {
 
 - **`recommendations`** surface the highest-quality related sources from the *current* result set using the transparent quality signals (authority, relevance, freshness, content). They are **advisory only** — `sources` ordering is never changed and the caller can ignore them. Strictly content-based: no user-behavior inputs, no profiling. Toggle with `SOURCE_RECOMMENDATIONS` (default `true`). Behavior-based/personalized ranking is explicitly out of scope.
 - **`components`** are optional renderable structures (source cards, a quality-comparison table) assembled **deterministically** from data already extracted — there is no server-side LLM call and no model of any kind. Every component is labelled `autoFormatted: true` / `"mcp-auto-formatted"` (stating the MCP server shaped it, not an LLM) and references the raw source URLs, so nothing is hidden or unverifiable. Off by default (`GENERATIVE_UI_ENABLED=false`); when off, output is byte-for-byte unchanged. The raw `content`/`sources` are always present regardless.
+
+### Large bundle hint (`sourceCount`, #508)
+
+When a result is large enough to cross the [Large-Payload Linking](#large-payload-linking-resource_link) threshold, the inline summary carries `sourceCount` (sources successfully scraped) and `status` alongside the generic `resource`/`bytes`/`expiresAt` link fields, so a caller can judge whether the linked artifact is worth a follow-up read without one. `sourceCount` mirrors `summary.urlsScraped`; both fields are omitted from every inline (non-linked) response, where `summary.urlsScraped` and `status` already carry the same information.
 
 ### Cache
 - NOT cached as a whole (composed of cached sub-operations)

--- a/internal/tools/artifacts.go
+++ b/internal/tools/artifacts.go
@@ -93,6 +93,20 @@ type linkSummary struct {
 // summary is a short human-facing description of the linked contents (e.g.
 // "raw page content for https://… (142 KB)"); it MUST NOT embed the full body.
 func largeResultOrInline(ctx context.Context, deps Dependencies, payload []byte, summary string) *mcp.CallToolResult {
+	return largeResultOrInlineWithFields(ctx, deps, payload, summary, nil)
+}
+
+// largeResultOrInlineWithFields behaves exactly like largeResultOrInline, but
+// additionally merges `extra` key/value pairs into the inline summary JSON (and
+// StructuredContent) when the payload links out. This lets a caller surface a
+// tool-specific hint — e.g. `contentSizeBytes` for a raw scrape, or
+// `sourceCount`/`status` for search_and_scrape — alongside the generic
+// resource/bytes/expiresAt fields, so a caller can judge whether the linked
+// artifact is worth a follow-up read WITHOUT one (#508). extra is ignored (and
+// must be nil/empty) on the inline path — a small payload already carries its
+// own fields undisturbed. Keys in extra must not collide with linkSummary's own
+// field names (resource, bytes, mimeType, summary, expiresAt, linked).
+func largeResultOrInlineWithFields(ctx context.Context, deps Dependencies, payload []byte, summary string, extra map[string]any) *mcp.CallToolResult {
 	if len(payload) < linkThresholdBytes {
 		return structuredResult(payload)
 	}
@@ -103,14 +117,14 @@ func largeResultOrInline(ctx context.Context, deps Dependencies, payload []byte,
 	}
 	size := len(payload)
 	expires := time.Now().UTC().Add(artifactTTL).Format(time.RFC3339)
-	sumBytes, _ := json.Marshal(linkSummary{
+	sumBytes := marshalLinkSummary(linkSummary{
 		Resource:  uri,
 		Bytes:     size,
 		MIMEType:  artifactMIMEType,
 		Summary:   summary,
 		ExpiresAt: expires,
 		Linked:    true,
-	})
+	}, extra)
 	sizeInt := int64(size)
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -128,6 +142,32 @@ func largeResultOrInline(ctx context.Context, deps Dependencies, payload []byte,
 		},
 		StructuredContent: json.RawMessage(sumBytes),
 	}
+}
+
+// marshalLinkSummary marshals sum, then — when extra is non-empty — merges its
+// keys into the resulting JSON object. Merging happens on the decoded map
+// rather than via struct embedding so each linkSummary caller can contribute a
+// different, tool-specific set of extra fields without a shared struct growing
+// unbounded optional fields. extra keys are trusted call-site data (int/string
+// counts and statuses already computed for the tool's own output), never
+// user-controlled HTML/page content, so no further sanitization is needed here.
+func marshalLinkSummary(sum linkSummary, extra map[string]any) []byte {
+	base, err := json.Marshal(sum)
+	if err != nil || len(extra) == 0 {
+		return base
+	}
+	var m map[string]any
+	if err := json.Unmarshal(base, &m); err != nil {
+		return base
+	}
+	for k, v := range extra {
+		m[k] = v
+	}
+	merged, err := json.Marshal(m)
+	if err != nil {
+		return base
+	}
+	return merged
 }
 
 // registerArtifactResource wires the read side of the artifact link: a resource

--- a/internal/tools/artifacts_test.go
+++ b/internal/tools/artifacts_test.go
@@ -143,3 +143,100 @@ func TestLargeResultOrInline_NoCacheInlines(t *testing.T) {
 		t.Fatalf("no-cache large payload should inline (1 item), got %d", len(res.Content))
 	}
 }
+
+// TestLargeResultOrInlineWithFields_MergesExtra: extra key/value pairs land in
+// both the inline TextContent summary and StructuredContent when the payload
+// links out (#508) — this is the mechanism scrape_page/search_and_scrape use to
+// surface contentSizeBytes/sourceCount/status alongside the generic
+// resource/bytes/expiresAt fields.
+func TestLargeResultOrInlineWithFields_MergesExtra(t *testing.T) {
+	deps := artifactTestDeps()
+	big := []byte(`{"content":"` + strings.Repeat("x", linkThresholdBytes) + `"}`)
+	extra := map[string]any{"contentSizeBytes": 12345, "sourceCount": 3, "status": "complete"}
+	res := largeResultOrInlineWithFields(context.Background(), deps, big, "with extra fields", extra)
+
+	if len(res.Content) != 2 {
+		t.Fatalf("large payload should be summary + link (2 items), got %d", len(res.Content))
+	}
+	txt, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("first content should be the summary TextContent, got %T", res.Content[0])
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal([]byte(txt.Text), &m); err != nil {
+		t.Fatalf("summary should be valid JSON: %v", err)
+	}
+	if got, want := m["contentSizeBytes"], float64(12345); got != want {
+		t.Errorf("contentSizeBytes = %v, want %v", got, want)
+	}
+	if got, want := m["sourceCount"], float64(3); got != want {
+		t.Errorf("sourceCount = %v, want %v", got, want)
+	}
+	if got, want := m["status"], "complete"; got != want {
+		t.Errorf("status = %v, want %v", got, want)
+	}
+	// The generic linkSummary fields must still be present alongside the extras.
+	if m["linked"] != true || m["resource"] == "" || m["bytes"] == nil {
+		t.Errorf("generic linkSummary fields missing from merged summary: %+v", m)
+	}
+
+	// StructuredContent carries the same merged shape.
+	scBytes, ok := res.StructuredContent.(json.RawMessage)
+	if !ok {
+		t.Fatalf("StructuredContent should be json.RawMessage, got %T", res.StructuredContent)
+	}
+	var sm map[string]any
+	if err := json.Unmarshal(scBytes, &sm); err != nil {
+		t.Fatalf("StructuredContent should be valid JSON: %v", err)
+	}
+	if got, want := sm["contentSizeBytes"], float64(12345); got != want {
+		t.Errorf("StructuredContent contentSizeBytes = %v, want %v", got, want)
+	}
+}
+
+// TestLargeResultOrInlineWithFields_SmallPayloadIgnoresExtra: below the link
+// threshold, largeResultOrInlineWithFields must behave exactly like
+// largeResultOrInline/structuredResult — extra fields are never injected into a
+// small, already-complete inline response.
+func TestLargeResultOrInlineWithFields_SmallPayloadIgnoresExtra(t *testing.T) {
+	deps := artifactTestDeps()
+	small := []byte(`{"hello":"world"}`)
+	extra := map[string]any{"contentSizeBytes": 999}
+	res := largeResultOrInlineWithFields(context.Background(), deps, small, "small", extra)
+
+	if len(res.Content) != 1 {
+		t.Fatalf("small payload should be a single inline content, got %d items", len(res.Content))
+	}
+	txt, ok := res.Content[0].(*mcp.TextContent)
+	if !ok {
+		t.Fatalf("small payload content should be TextContent, got %T", res.Content[0])
+	}
+	if txt.Text != string(small) {
+		t.Errorf("small payload should inline unchanged, got %q", txt.Text)
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(txt.Text), &m); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, present := m["contentSizeBytes"]; present {
+		t.Errorf("extra fields must not leak into the small/inline path, got %+v", m)
+	}
+}
+
+// TestMarshalLinkSummary_NoExtraLeavesSummaryUnchanged: marshalLinkSummary with
+// a nil/empty extra map must be byte-identical to a plain json.Marshal(sum),
+// so largeResultOrInline's existing behavior (and every caller that has not
+// been migrated to largeResultOrInlineWithFields, e.g. research_export) is
+// preserved exactly.
+func TestMarshalLinkSummary_NoExtraLeavesSummaryUnchanged(t *testing.T) {
+	sum := linkSummary{Resource: "research://artifact/abc", Bytes: 42, MIMEType: artifactMIMEType, Summary: "s", ExpiresAt: "2026-01-01T00:00:00Z", Linked: true}
+	want, _ := json.Marshal(sum)
+
+	if got := marshalLinkSummary(sum, nil); string(got) != string(want) {
+		t.Errorf("marshalLinkSummary(nil extra) = %s, want %s", got, want)
+	}
+	if got := marshalLinkSummary(sum, map[string]any{}); string(got) != string(want) {
+		t.Errorf("marshalLinkSummary(empty extra) = %s, want %s", got, want)
+	}
+}

--- a/internal/tools/schemas.go
+++ b/internal/tools/schemas.go
@@ -291,6 +291,17 @@ var scrapePageOutputSchema = map[string]any{
 				},
 			},
 		},
+		// contentSizeBytes (#508) is present ONLY on the linked resource_link
+		// hand-off shape (mode=raw content at/above the size threshold — see
+		// internal/tools/artifacts.go's largeResultOrInlineWithFields): it rides
+		// alongside the generic resource/bytes/expiresAt link-summary fields so a
+		// caller can judge whether the linked artifact is worth a follow-up read
+		// without one. Absent on every inline (non-linked) response, where
+		// contentLength already carries the same information.
+		"contentSizeBytes": map[string]any{
+			"type":        "integer",
+			"description": "Raw content length in bytes. Present only when the response links out to a resource_link artifact (mode=raw content at/above the size threshold); mirrors contentLength for a linked payload without requiring a follow-up read.",
+		},
 	},
 }
 
@@ -401,6 +412,18 @@ var searchAndScrapeOutputSchema = map[string]any{
 					"table":         map[string]any{"type": "object"},
 				},
 			},
+		},
+		// sourceCount (#508) is present ONLY on the linked resource_link hand-off
+		// shape (result at/above the size threshold — see internal/tools/
+		// artifacts.go's largeResultOrInlineWithFields): it rides alongside the
+		// generic resource/bytes/expiresAt link-summary fields, mirroring the
+		// already-present status field, so a caller can judge whether the linked
+		// artifact is worth a follow-up read without one. Absent on every inline
+		// (non-linked) response, where summary.urlsScraped already carries the
+		// same count.
+		"sourceCount": map[string]any{
+			"type":        "integer",
+			"description": "Number of sources successfully scraped (mirrors summary.urlsScraped). Present only when the response links out to a resource_link artifact, surfacing the count without a follow-up read.",
 		},
 	},
 }

--- a/internal/tools/scrape.go
+++ b/internal/tools/scrape.go
@@ -235,6 +235,21 @@ func registerScrapePage(srv *mcp.Server, deps Dependencies) {
 	})
 }
 
+// rawContentSizeFromCache recovers the raw content's byte length from a
+// previously cached scrapeRaw response body, for the contentSizeBytes hint
+// (#508). The cached body already carries "contentLength" (the pre-marshal
+// len(result.Content)); on any parse failure this falls back to the full
+// cached payload's size so the hint is always present, just less precise.
+func rawContentSizeFromCache(cached []byte) int {
+	var probe struct {
+		ContentLength int `json:"contentLength"`
+	}
+	if err := json.Unmarshal(cached, &probe); err == nil && probe.ContentLength > 0 {
+		return probe.ContentLength
+	}
+	return len(cached)
+}
+
 // scrapeRaw handles mode=="raw": it reuses the exact same tiered fetch
 // pipeline as full mode (markdown -> stealth -> html -> browser, with the same
 // anti-bot header spoofing, bot-wall detection, and tier escalation), through
@@ -252,7 +267,11 @@ func scrapeRaw(ctx context.Context, deps Dependencies, input scrapePageInput, ma
 		auditToolCall(ctx, deps, "scrape_page", time.Since(start), nil, "")
 		// A cached raw body can be large; link it past the threshold (#181) while
 		// keeping the cache-freshness _meta. Small bodies inline as before.
-		return withCacheMeta(largeResultOrInline(ctx, deps, cached, "raw page content for "+input.URL), meta), nil, nil
+		// contentSizeBytes (#508) surfaces the raw content's byte length on the
+		// inline summary itself, so a caller can judge whether the linked
+		// artifact is worth a follow-up read without one.
+		extra := map[string]any{"contentSizeBytes": rawContentSizeFromCache(cached)}
+		return withCacheMeta(largeResultOrInlineWithFields(ctx, deps, cached, "raw page content for "+input.URL, extra), meta), nil, nil
 	}
 
 	// Negative-cache short-circuit. URL-level failures (SSRF/blocked/auth/browser/
@@ -317,7 +336,9 @@ func scrapeRaw(ctx context.Context, deps Dependencies, input scrapePageInput, ma
 
 	// Raw page bodies are the heaviest single-tool payload; link past the
 	// threshold (#181) so the full text stays out of context until fetched.
-	return largeResultOrInline(ctx, deps, jsonBytes, "raw page content for "+input.URL), nil, nil
+	// contentSizeBytes (#508) surfaces contentLen on the inline summary itself.
+	extraFields := map[string]any{"contentSizeBytes": contentLen}
+	return largeResultOrInlineWithFields(ctx, deps, jsonBytes, "raw page content for "+input.URL, extraFields), nil, nil
 }
 
 // detectScholarlyDOITopBytes bounds the body fallback to the front matter of the

--- a/internal/tools/scrape_artifact_hint_test.go
+++ b/internal/tools/scrape_artifact_hint_test.go
@@ -1,0 +1,271 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/audit"
+	"github.com/zoharbabin/web-researcher-mcp/internal/cache"
+	"github.com/zoharbabin/web-researcher-mcp/internal/content"
+	"github.com/zoharbabin/web-researcher-mcp/internal/metrics"
+	"github.com/zoharbabin/web-researcher-mcp/internal/scraper"
+	"github.com/zoharbabin/web-researcher-mcp/internal/session"
+)
+
+// TestScrapePageRaw_LargeBody_SurfacesContentSizeBytes is the #508 end-to-end
+// guard for scrape_page: a raw-mode body large enough to cross
+// linkThresholdBytes must link out via resource_link AND carry a
+// contentSizeBytes field on the inline summary, so a caller can judge whether
+// the linked artifact is worth a follow-up read without one.
+func TestScrapePageRaw_LargeBody_SurfacesContentSizeBytes(t *testing.T) {
+	bigBody := strings.Repeat("raw page byte filler content. ", linkThresholdBytes/20)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(bigBody))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	deps := Dependencies{
+		Cache:    cache.NewMemory(cache.MemoryConfig{MaxSizeMB: 8}),
+		Search:   &mockProvider{},
+		Scraper:  scraper.NewPipeline(scraper.PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true}),
+		Content:  content.NewProcessor(),
+		Sessions: func() session.Manager { m, _ := session.NewManager(session.Config{MaxSessions: 100}); return m }(),
+		Metrics:  metrics.NewCollector(),
+		Auditor:  audit.NewNoop(),
+		Logger:   slog.Default(),
+	}
+	srv := createTestServer(deps)
+	client := connectTestClient(ctx, t, srv)
+	defer client.Close()
+
+	res, err := client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "scrape_page",
+		Arguments: map[string]any{"url": ts.URL, "mode": "raw"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool-level error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+
+	// The large raw body must link out (summary + resource_link, not the full body).
+	if len(res.Content) != 2 {
+		t.Fatalf("expected summary + resource_link (2 content items) for a large raw body, got %d", len(res.Content))
+	}
+	if _, ok := res.Content[1].(*mcp.ResourceLink); !ok {
+		t.Fatalf("second content should be a ResourceLink, got %T", res.Content[1])
+	}
+
+	var summary map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &summary); err != nil {
+		t.Fatalf("parse inline summary: %v", err)
+	}
+	if summary["linked"] != true {
+		t.Fatalf("expected linked:true in summary, got %+v", summary)
+	}
+	csb, ok := summary["contentSizeBytes"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric contentSizeBytes in inline summary, got %+v", summary)
+	}
+	if int(csb) != len(bigBody) {
+		t.Errorf("contentSizeBytes = %v, want %d (raw content length)", csb, len(bigBody))
+	}
+}
+
+// TestScrapePageRaw_SmallBody_NoContentSizeBytes confirms the new field is
+// scoped to the link hand-off only: a small (non-linked) raw response must NOT
+// gain a contentSizeBytes field — contentLength already covers it inline.
+func TestScrapePageRaw_SmallBody_NoContentSizeBytes(t *testing.T) {
+	const smallBody = "tiny raw body"
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		_, _ = w.Write([]byte(smallBody))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	deps := scrapeTestDeps()
+	srv := createTestServer(deps)
+	client := connectTestClient(ctx, t, srv)
+	defer client.Close()
+
+	res, err := client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "scrape_page",
+		Arguments: map[string]any{"url": ts.URL, "mode": "raw"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool-level error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("small raw body should inline (1 content item), got %d", len(res.Content))
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, present := out["contentSizeBytes"]; present {
+		t.Errorf("small inline raw response must not carry contentSizeBytes, got %+v", out)
+	}
+	if out["contentLength"] == nil {
+		t.Error("small inline raw response should still carry contentLength")
+	}
+}
+
+// TestSearchAndScrape_LargeBundle_SurfacesSourceCountAndStatus is the #508
+// end-to-end guard for search_and_scrape: a multi-page bundle large enough to
+// cross linkThresholdBytes must link out AND carry sourceCount + status on the
+// inline summary.
+func TestSearchAndScrape_LargeBundle_SurfacesSourceCountAndStatus(t *testing.T) {
+	bigArticle := strings.Repeat("Sufficiently long article body filler content for the pipeline. ", linkThresholdBytes/50)
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body><article>" + bigArticle + "</article></body></html>"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	deps := Dependencies{
+		Cache:    cache.NewMemory(cache.MemoryConfig{MaxSizeMB: 8}),
+		Search:   &mockProviderWithURL{url: ts.URL},
+		Scraper:  scraper.NewPipeline(scraper.PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true}),
+		Content:  content.NewProcessor(),
+		Sessions: func() session.Manager { m, _ := session.NewManager(session.Config{MaxSessions: 100}); return m }(),
+		Metrics:  metrics.NewCollector(),
+		Auditor:  audit.NewNoop(),
+		Logger:   slog.Default(),
+	}
+	srv := createTestServer(deps)
+	client := connectTestClient(ctx, t, srv)
+	defer client.Close()
+
+	res, err := client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_and_scrape",
+		Arguments: map[string]any{"query": "test query", "num_results": float64(1), "total_max_length": float64(1_000_000)},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool-level error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+
+	if len(res.Content) != 2 {
+		t.Fatalf("expected summary + resource_link (2 content items) for a large bundle, got %d", len(res.Content))
+	}
+	if _, ok := res.Content[1].(*mcp.ResourceLink); !ok {
+		t.Fatalf("second content should be a ResourceLink, got %T", res.Content[1])
+	}
+
+	var summary map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &summary); err != nil {
+		t.Fatalf("parse inline summary: %v", err)
+	}
+	if summary["linked"] != true {
+		t.Fatalf("expected linked:true in summary, got %+v", summary)
+	}
+	sc, ok := summary["sourceCount"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric sourceCount in inline summary, got %+v", summary)
+	}
+	if int(sc) != 1 {
+		t.Errorf("sourceCount = %v, want 1", sc)
+	}
+	if summary["status"] != "complete" {
+		t.Errorf("status = %v, want %q", summary["status"], "complete")
+	}
+}
+
+// TestSearchAndScrape_SmallResult_NoSourceCountHint confirms the new fields are
+// scoped to the link hand-off only: a small (non-linked) search_and_scrape
+// response must NOT gain sourceCount — summary.urlsScraped already covers it.
+func TestSearchAndScrape_SmallResult_NoSourceCountHint(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte("<html><body><article>" + strings.Repeat("Short article content. ", 20) + "</article></body></html>"))
+	}))
+	defer ts.Close()
+
+	ctx := context.Background()
+	deps := Dependencies{
+		Cache:    cache.NewNoop(),
+		Search:   &mockProviderWithURL{url: ts.URL},
+		Scraper:  scraper.NewPipeline(scraper.PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true}),
+		Content:  content.NewProcessor(),
+		Sessions: func() session.Manager { m, _ := session.NewManager(session.Config{MaxSessions: 100}); return m }(),
+		Metrics:  metrics.NewCollector(),
+		Auditor:  audit.NewNoop(),
+		Logger:   slog.Default(),
+	}
+	srv := createTestServer(deps)
+	client := connectTestClient(ctx, t, srv)
+	defer client.Close()
+
+	res, err := client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "search_and_scrape",
+		Arguments: map[string]any{"query": "test", "num_results": float64(1)},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool-level error: %s", res.Content[0].(*mcp.TextContent).Text)
+	}
+	if len(res.Content) != 1 {
+		t.Fatalf("small result should inline (1 content item), got %d", len(res.Content))
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &out); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if _, present := out["sourceCount"]; present {
+		t.Errorf("small inline search_and_scrape response must not carry sourceCount, got %+v", out)
+	}
+	summaryObj, _ := out["summary"].(map[string]any)
+	if summaryObj["urlsScraped"] == nil {
+		t.Error("small inline response should still carry summary.urlsScraped")
+	}
+}
+
+// TestScrapePageSchemaDeclaresContentSizeBytes and
+// TestSearchAndScrapeSchemaDeclaresSourceCount are manual schema-declaration
+// guards (#508). scrape_page and search_and_scrape are excluded from the
+// generic TestOutputSchemaMatchesResponse gate in metadata_test.go (their
+// resource_link hand-off path returns a hand-built *mcp.CallToolResult with a
+// nil typed `out`, which the SDK never runs through OutputSchema validation —
+// see largeResultOrInlineWithFields in artifacts.go), so these fields would
+// otherwise be undocumented with no CI failure. Mirrors the existing
+// TestScrapePageSchemaDeclaresDOIFields pattern in scrape_doi_test.go.
+func TestScrapePageSchemaDeclaresContentSizeBytes(t *testing.T) {
+	props, _ := scrapePageOutputSchema["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("scrapePageOutputSchema has no properties")
+	}
+	if _, declared := props["contentSizeBytes"]; !declared {
+		t.Error("scrapePageOutputSchema must declare \"contentSizeBytes\"")
+	}
+}
+
+func TestSearchAndScrapeSchemaDeclaresSourceCount(t *testing.T) {
+	props, _ := searchAndScrapeOutputSchema["properties"].(map[string]any)
+	if props == nil {
+		t.Fatal("searchAndScrapeOutputSchema has no properties")
+	}
+	if _, declared := props["sourceCount"]; !declared {
+		t.Error("searchAndScrapeOutputSchema must declare \"sourceCount\"")
+	}
+}

--- a/internal/tools/searchandscrape.go
+++ b/internal/tools/searchandscrape.go
@@ -133,7 +133,11 @@ func registerSearchAndScrape(srv *mcp.Server, deps Dependencies) {
 
 				summary := fmt.Sprintf("search_and_scrape (LLM context) results for %q — %d snippets, %s combined content",
 					input.Query, len(ctxResult.Snippets), humanBytes(len(combined)))
-				return largeResultOrInline(ctx, deps, jsonBytes, summary), nil, nil
+				// sourceCount/status (#508): surfaced on the inline summary itself so a
+				// caller can judge whether the linked artifact is worth a follow-up read
+				// without one. Mirrors the always-"complete" status already set above.
+				extra := map[string]any{"sourceCount": len(sources), "status": "complete"}
+				return largeResultOrInlineWithFields(ctx, deps, jsonBytes, summary, extra), nil, nil
 			}
 			// ctxErr != nil or empty result: fall through to normal search + scrape.
 		}
@@ -261,7 +265,12 @@ func registerSearchAndScrape(srv *mcp.Server, deps Dependencies) {
 		// Large multi-page bundles link instead of inlining (#181) to keep context
 		// lean; small results inline unchanged. Routing _meta rides on either shape.
 		summary := fmt.Sprintf("search_and_scrape results for %q — %d pages scraped, %s combined content", input.Query, scraped, humanBytes(len(combined)))
-		return withRoutingMeta(largeResultOrInline(ctx, deps, jsonBytes, summary), rt), nil, nil
+		// sourceCount/status (#508): surfaced on the inline summary itself so a
+		// caller can judge whether the linked artifact is worth a follow-up read
+		// without one. status mirrors the already-computed complete/partial/failed
+		// value; sourceCount mirrors scraped (len(sources)).
+		extra := map[string]any{"sourceCount": scraped, "status": status}
+		return withRoutingMeta(largeResultOrInlineWithFields(ctx, deps, jsonBytes, summary, extra), rt), nil, nil
 	})
 }
 

--- a/python/web_researcher_mcp/models.py
+++ b/python/web_researcher_mcp/models.py
@@ -1847,6 +1847,7 @@ class ScrapePageResponse:
     citation: Optional[Citation] = None
     content: Optional[str] = None
     contentLength: Optional[int] = None
+    contentSizeBytes: Optional[int] = None
     contentType: Optional[str] = None
     detectedDoi: Optional[str] = None
     domainCategory: Optional[str] = None
@@ -1876,6 +1877,7 @@ class ScrapePageResponse:
             citation=Citation.from_dict(d.get('citation')) if d.get('citation') else None,
             content=d.get('content'),
             contentLength=d.get('contentLength'),
+            contentSizeBytes=d.get('contentSizeBytes'),
             contentType=d.get('contentType'),
             detectedDoi=d.get('detectedDoi'),
             domainCategory=d.get('domainCategory'),
@@ -1969,6 +1971,7 @@ class SearchAndScrapeResponse:
     recommendations: list[SearchAndScrapeRecommendation] = field(default_factory=list)
     scrapeFailures: list[SearchAndScrapeScrapefailure] = field(default_factory=list)
     sizeMetadata: Optional[SizeMetadata] = None
+    sourceCount: Optional[int] = None
     sources: list[SearchAndScrapeSource] = field(default_factory=list)
     status: Optional[str] = None
     summary: Optional[Summary] = None
@@ -1987,6 +1990,7 @@ class SearchAndScrapeResponse:
             recommendations=[SearchAndScrapeRecommendation.from_dict(i) for i in (d.get('recommendations') or [])],
             scrapeFailures=[SearchAndScrapeScrapefailure.from_dict(i) for i in (d.get('scrapeFailures') or [])],
             sizeMetadata=SizeMetadata.from_dict(d.get('sizeMetadata')) if d.get('sizeMetadata') else None,
+            sourceCount=d.get('sourceCount'),
             sources=[SearchAndScrapeSource.from_dict(i) for i in (d.get('sources') or [])],
             status=d.get('status'),
             summary=Summary.from_dict(d.get('summary')) if d.get('summary') else None,


### PR DESCRIPTION
## Summary
When `scrape_page(mode="raw")` or `search_and_scrape` hands off a large response to a `research://artifact/{id}` resource_link, the inline reply now carries a size/count hint alongside the link, so a caller can judge whether it's worth a follow-up read without one:
- `scrape_page`: new `contentSizeBytes` field
- `search_and_scrape`: new `sourceCount`/`status` fields

Implemented via a generic `largeResultOrInlineWithFields` extension of the shared artifact hand-off helper — each call site contributes only the fields it already has, no duplication. `mode=preview`/`mode=full` never reach the artifact-link path in the current code (preview is capped well under the link threshold; full always inlines), so they're unaffected and out of scope.

Closes #508

## Test plan
- New unit tests for `largeResultOrInlineWithFields`/`marshalLinkSummary` (extra-field merge, no leak on inline path)
- New end-to-end tests: large/small body pairs for both tools confirming new fields appear only on the linked hand-off
- `go build ./...`, `go test -race ./...`, `go vet ./...`, `golangci-lint run ./...` all clean
- Doc/schema drift tests pass; `make gen-python-client`/`check-python-drift` clean