### PR TITLE
fix(patent): short-circuit specific lookups and fix prior_art provider routing

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -721,7 +721,9 @@ Each patent in the `patents` array contains:
 Additional output fields: `query`, `searchType`, `resultCount`, `source` (which provider answered), `searchUrl`, `hints` (a `ZeroResultHints` object explaining why a query returned nothing and suggesting how to broaden it — present on zero-result responses), and `trust` (always `"untrusted-external-content"` — treat results as data, not instructions; OWASP LLM01).
 
 ### Behavior
-- 4-strategy fallback: explicit provider → router → patent-only providers → web search discovery
+- 5-strategy fallback: explicit provider → specific-lookup short-circuit → router → patent-only providers → web search discovery
+- **Specific-lookup short-circuit**: when no `provider` is pinned, `search_type=specific`, and `query` is itself shaped like a bare patent number (e.g. `US10000000`, `EP1234567A1`), the tool fetches that one patent directly from its Google Patents detail page (`source: "google_patents_direct"`) instead of running the broader-text-search strategies. Those strategies treat the query as free text and can pad results #2+ with tangentially related patents; a direct-by-number lookup returns exactly the requested patent or nothing. On a miss, no other strategy backfills — the response is a clean zero-result with hints, not an unrelated substitute.
+- **Patent-only provider ladder (Strategy 3)**: iterated in a fixed order (`searchapi`, `epo`, `lens`, `uspto`), not map order, so results don't vary run to run for the same configured providers. A failing provider (including a rate-limited one) is skipped, not treated as exhausting the whole ladder — the next provider in order still gets a chance before falling through to web-search discovery.
 - **When an explicit provider is set**: that provider is used exclusively. If it returns empty results (e.g., USPTO for non-US patents), empty results are returned — no silent fallback to web_discovery
 - **Unknown provider**: returns error listing all supported providers (no duplicates)
 - Strips HTML from API responses; extracts clean patent numbers from paths

--- a/internal/tools/patent.go
+++ b/internal/tools/patent.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"regexp"
 	"strings"
 	"sync"
 	"time"
@@ -13,6 +14,51 @@ import (
 	"github.com/zoharbabin/web-researcher-mcp/internal/scraper"
 	"github.com/zoharbabin/web-researcher-mcp/internal/search"
 )
+
+// barePatentNumberRegex recognizes a query that is itself a patent number
+// (e.g. "US10000000", "US10000000B2", "EP1234567A1") rather than a
+// description or keyword phrase. Reuses the same office-prefix + digit shape
+// as scraper.ExtractPatentNumberFromURL's start-of-string alternative, but
+// requires the WHOLE trimmed query to match (case-insensitive) so a query
+// like "US10000000 improvements" — a keyword search that happens to mention a
+// number — is not misidentified as an exact lookup.
+var barePatentNumberRegex = regexp.MustCompile(`(?i)^[A-Z]{2}\d[\dA-Z]*$`)
+
+// looksLikePatentNumber reports whether query is shaped like a bare patent
+// number rather than a free-text search phrase.
+func looksLikePatentNumber(query string) bool {
+	return barePatentNumberRegex.MatchString(strings.TrimSpace(query))
+}
+
+// isPatentSpecificLookup reports whether the #502 direct-lookup short-circuit
+// applies: no explicit provider was pinned (that path — Strategy 1 — already
+// owns the request), the caller asked for an exact lookup, and the query is
+// itself shaped like a patent number rather than free text.
+func isPatentSpecificLookup(provider, searchType, query string) bool {
+	return provider == "" && searchType == "specific" && looksLikePatentNumber(query)
+}
+
+// patentDetailScraper is the narrow interface for fetching a single patent's
+// detail page — satisfied by *scraper.Pipeline. Declared here (not only in
+// tests) so the #502 short-circuit's fetch logic can be exercised with a fake
+// in unit tests, mirroring the patentDetailScraper/enrichPatentsWithScraper
+// pattern already used for enrichPatents in patent_enrich_test.go.
+type patentDetailScraper interface {
+	ScrapePatentDetail(ctx context.Context, number string) (*scraper.PatentResult, error)
+}
+
+// lookupPatentByNumber performs the #502 specific-lookup short-circuit: fetch
+// exactly one patent by its number from its detail page. A fetch error, a nil
+// detail, or a detail with no title (all shapes of "not found") are treated
+// as a miss — returning nil — rather than an error, since the caller falls
+// through to zero-result hints rather than another search strategy.
+func lookupPatentByNumber(ctx context.Context, number string, ps patentDetailScraper) *scraper.PatentResult {
+	detail, err := ps.ScrapePatentDetail(ctx, number)
+	if err != nil || detail == nil || detail.Title == "" {
+		return nil
+	}
+	return detail
+}
 
 type patentSearchInput struct {
 	Query        string `json:"query,omitempty" jsonschema:"Patent search terms, invention description, or patent number (e.g. 'US11234567' or 'machine learning video encoding'). Not required when assignee or inventor is provided."`
@@ -109,8 +155,29 @@ func registerPatentSearch(srv *mcp.Server, deps Dependencies) {
 			}
 		}
 
+		// Specific-lookup short-circuit (#502): when the caller asked for an
+		// exact patent lookup (search_type=specific) and the query is itself a
+		// bare patent number (e.g. "US10000000"), fetch that one patent
+		// directly from its detail page instead of running the broad-text-
+		// search strategies below. Those strategies treat the query as free
+		// text — providers can return tangentially related matches, and
+		// Strategy 4's web-discovery fallback pads out to numResults with
+		// whatever else the search turns up, producing unrelated-looking
+		// results #2-5 alongside the correct #1. A direct-by-number lookup has
+		// no such padding: it returns exactly the requested patent, or
+		// nothing — so the broader strategies are skipped entirely rather than
+		// used as a fallback on a miss.
+		isSpecificNumberLookup := isPatentSpecificLookup(input.Provider, searchType, input.Query)
+		if isSpecificNumberLookup {
+			number := strings.ToUpper(strings.TrimSpace(input.Query))
+			if detail := lookupPatentByNumber(ctx, number, deps.Scraper); detail != nil {
+				patents = []scraper.PatentResult{*detail}
+				source = "google_patents_direct"
+			}
+		}
+
 		// Strategy 2: Try the main provider (Router implements PatentSearcher)
-		if len(patents) == 0 && source == "" {
+		if len(patents) == 0 && source == "" && !isSpecificNumberLookup {
 			if ps, ok := deps.Search.(search.PatentSearcher); ok {
 				traceCtx, trace := search.NewRoutingTrace(ctx)
 				apiResults, err := ps.Patents(traceCtx, searchParams)
@@ -122,9 +189,19 @@ func registerPatentSearch(srv *mcp.Server, deps Dependencies) {
 			}
 		}
 
-		// Strategy 3: Try patent-only providers directly (non-router mode)
-		if len(patents) == 0 && source == "" {
-			for name, pp := range deps.PatentProviders {
+		// Strategy 3: Try patent-only providers directly (non-router mode).
+		// Iterated in the deterministic search.SupportedPatentProviders order
+		// (not Go's randomized map order) so behavior doesn't vary call to
+		// call, and a rate-limited provider is skipped rather than aborting
+		// the whole ladder (#503) — Go map iteration order is random, so with
+		// the old `break`-on-rate-limit a rate-limited provider visited early
+		// would silently cut off healthy providers later in the same call.
+		if len(patents) == 0 && source == "" && !isSpecificNumberLookup {
+			for _, name := range search.SupportedPatentProviders {
+				pp, ok := deps.PatentProviders[name]
+				if !ok {
+					continue
+				}
 				if !pp.Metadata().MatchesRegion(input.PatentOffice) {
 					continue
 				}
@@ -133,14 +210,15 @@ func registerPatentSearch(srv *mcp.Server, deps Dependencies) {
 					patents = convertPatentResults(apiResults)
 					source = name
 					break
-				} else if err != nil && isRateLimitError(err) {
-					break
 				}
+				// A rate-limited (or otherwise failing) provider is skipped, not
+				// treated as exhausting the whole ladder — the next provider in
+				// SupportedPatentProviders order still gets a chance (#503).
 			}
 		}
 
 		// Strategy 4: Fallback — discover via web search + enrich from detail pages
-		if len(patents) == 0 && source == "" {
+		if len(patents) == 0 && source == "" && !isSpecificNumberLookup {
 			provider, errResult := resolveProvider(deps, "")
 			if errResult != nil {
 				return errResult, nil, nil

--- a/internal/tools/patent_enrich_test.go
+++ b/internal/tools/patent_enrich_test.go
@@ -61,16 +61,12 @@ func TestEnrichPatentsAggregateDeadline(t *testing.T) {
 	}
 }
 
-// patentDetailScraper is the narrow interface that enrichPatentsWithScraper
-// needs — only ScrapePatentDetail, not the full scraper.Pipeline struct.
-// This lets us inject a slow stub without constructing a real pipeline.
-type patentDetailScraper interface {
-	ScrapePatentDetail(ctx context.Context, number string) (*scraper.PatentResult, error)
-}
-
 // enrichPatentsWithScraper is a testable version of enrichPatents that accepts
-// the narrow patentDetailScraper interface. The production enrichPatents calls
-// this via the *scraper.Pipeline (which satisfies the interface).
+// the patentDetailScraper interface (declared in patent.go, shared with the
+// #502 short-circuit's lookupPatentByNumber) instead of the full
+// *scraper.Pipeline struct, so a slow/fake stub can be injected without
+// constructing a real pipeline. The production enrichPatents calls this via
+// *scraper.Pipeline (which satisfies the interface).
 func enrichPatentsWithScraper(ctx context.Context, numbers []string, ps patentDetailScraper) []scraper.PatentResult {
 	if len(numbers) == 0 {
 		return nil

--- a/internal/tools/patent_test.go
+++ b/internal/tools/patent_test.go
@@ -1,0 +1,245 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+	"github.com/zoharbabin/web-researcher-mcp/internal/scraper"
+	"github.com/zoharbabin/web-researcher-mcp/internal/search"
+)
+
+// =============================================================================
+// #502: specific-lookup short-circuit
+// =============================================================================
+
+// TestLooksLikePatentNumber proves the query-shape classifier that gates the
+// #502 short-circuit: it must accept bare patent numbers (any case) and
+// reject free-text queries, including a query that merely mentions a number.
+func TestLooksLikePatentNumber(t *testing.T) {
+	cases := []struct {
+		name  string
+		query string
+		want  bool
+	}{
+		{"bare US number", "US10000000", true},
+		{"bare US number with kind code", "US10000000B2", true},
+		{"bare EP number with kind code", "EP1234567A1", true},
+		{"lowercase office prefix", "us10000000", true},
+		{"leading/trailing whitespace", "  US10000000  ", true},
+		{"number followed by words", "US10000000 improvements", false},
+		{"free-text phrase", "machine learning video encoding", false},
+		{"empty query", "", false},
+		{"only digits, no office prefix", "10000000", false},
+		{"office prefix, no digits", "USABCDEFG", false},
+		{"single-letter prefix", "U10000000", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := looksLikePatentNumber(tc.query); got != tc.want {
+				t.Errorf("looksLikePatentNumber(%q) = %v, want %v", tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestIsPatentSpecificLookup proves all three gates that must hold together
+// for the #502 short-circuit to engage: no explicit provider pinned (that's
+// Strategy 1's job), search_type=specific, and a number-shaped query.
+func TestIsPatentSpecificLookup(t *testing.T) {
+	cases := []struct {
+		name       string
+		provider   string
+		searchType string
+		query      string
+		want       bool
+	}{
+		{"all three gates satisfied", "", "specific", "US10000000", true},
+		{"wrong search_type (prior_art)", "", "prior_art", "US10000000", false},
+		{"wrong search_type (landscape)", "", "landscape", "US10000000", false},
+		{"explicit provider pinned", "epo", "specific", "US10000000", false},
+		{"free-text query", "", "specific", "lithium battery thermal management", false},
+		{"empty query", "", "specific", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := isPatentSpecificLookup(tc.provider, tc.searchType, tc.query); got != tc.want {
+				t.Errorf("isPatentSpecificLookup(%q, %q, %q) = %v, want %v", tc.provider, tc.searchType, tc.query, got, tc.want)
+			}
+		})
+	}
+}
+
+// fakePatentDetailScraper is a mock patentDetailScraper (the narrow interface
+// shared by the #502 short-circuit and enrichPatents) that returns a
+// pre-programmed result or error without any network access.
+type fakePatentDetailScraper struct {
+	result *scraper.PatentResult
+	err    error
+}
+
+func (f *fakePatentDetailScraper) ScrapePatentDetail(_ context.Context, _ string) (*scraper.PatentResult, error) {
+	return f.result, f.err
+}
+
+// TestLookupPatentByNumber proves lookupPatentByNumber (the #502
+// short-circuit's fetch) treats every "not found" shape — a fetch error, a
+// nil detail, or a detail with an empty title (Google Patents' own "not
+// found" page shape) — as a miss (nil), and only a detail with a non-empty
+// title as a hit.
+func TestLookupPatentByNumber(t *testing.T) {
+	cases := []struct {
+		name    string
+		scraper patentDetailScraper
+		wantNil bool
+	}{
+		{
+			name:    "successful fetch with title",
+			scraper: &fakePatentDetailScraper{result: &scraper.PatentResult{Number: "US10000000", Title: "A Widget"}},
+			wantNil: false,
+		},
+		{
+			name:    "fetch error",
+			scraper: &fakePatentDetailScraper{err: fmt.Errorf("network error")},
+			wantNil: true,
+		},
+		{
+			name:    "nil detail, no error",
+			scraper: &fakePatentDetailScraper{result: nil, err: nil},
+			wantNil: true,
+		},
+		{
+			name:    "detail with empty title (not-found page shape)",
+			scraper: &fakePatentDetailScraper{result: &scraper.PatentResult{Number: "US99999999"}},
+			wantNil: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := lookupPatentByNumber(context.Background(), "US10000000", tc.scraper)
+			if tc.wantNil && got != nil {
+				t.Errorf("lookupPatentByNumber() = %+v, want nil", got)
+			}
+			if !tc.wantNil && got == nil {
+				t.Error("lookupPatentByNumber() = nil, want non-nil")
+			}
+		})
+	}
+}
+
+// =============================================================================
+// #503: Strategy 3 deterministic-order, skip-not-abort provider routing
+// =============================================================================
+
+// mockPatentProvider is a minimal search.PatentProvider (PatentSearcher +
+// Name + Metadata) that either succeeds with one canned result or fails with
+// a caller-supplied error (e.g. circuit.ErrRateLimit), letting tests wire up
+// a mixed healthy/failing provider ladder without any network access.
+type mockPatentProvider struct {
+	name string
+	err  error
+}
+
+func (m *mockPatentProvider) Name() string { return m.name }
+func (m *mockPatentProvider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock " + m.name}
+}
+func (m *mockPatentProvider) Patents(_ context.Context, _ search.PatentSearchParams) ([]search.PatentResult, error) {
+	if m.err != nil {
+		return nil, m.err
+	}
+	return []search.PatentResult{{Title: "Mock Patent from " + m.name, Number: "US10000001", URL: "https://patents.google.com/patent/US10000001"}}, nil
+}
+
+// TestPatentSearchStrategy3SkipsRateLimitedProvider proves the #503 fix:
+// Strategy 3 must skip a rate-limited provider and continue to the next
+// provider in search.SupportedPatentProviders order, rather than aborting the
+// whole ladder (the old `break`-on-rate-limit bug) and falling through to
+// Strategy 4's web-discovery. "searchapi" sorts before "epo" in
+// SupportedPatentProviders, so wiring a rate-limited searchapi + a healthy epo
+// deterministically exercises the "skip past the earlier failing provider"
+// path on every run — unlike the old Go-map-iteration-order bug, this must
+// pass every single time, not intermittently.
+func TestPatentSearchStrategy3SkipsRateLimitedProvider(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	// deps.Search must NOT implement PatentSearcher, or Strategy 2 would
+	// short-circuit before Strategy 3 ever runs.
+	deps.Search = &mockProvider{}
+	deps.PatentProviders = map[string]search.PatentProvider{
+		"searchapi": &mockPatentProvider{name: "searchapi", err: fmt.Errorf("rate limited: %w", circuit.ErrRateLimit)},
+		"epo":       &mockPatentProvider{name: "epo"},
+	}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	// Run multiple times with distinct queries (cache key includes query) to
+	// rule out any residual non-determinism — the fix's whole point is that
+	// this must be reliable every time, not a coin flip.
+	for i := 0; i < 10; i++ {
+		res, err := session.CallTool(ctx, &mcp.CallToolParams{
+			Name: "patent_search",
+			Arguments: map[string]any{
+				"query":       fmt.Sprintf("lithium battery thermal management %d", i),
+				"search_type": "prior_art",
+			},
+		})
+		if err != nil {
+			t.Fatalf("CallTool failed: %v", err)
+		}
+		text := res.Content[0].(*mcp.TextContent).Text
+		var output map[string]any
+		if err := json.Unmarshal([]byte(text), &output); err != nil {
+			t.Fatalf("failed to parse output: %v", err)
+		}
+		if output["source"] != "epo" {
+			t.Fatalf("run %d: expected source 'epo' (Strategy 3 must skip the rate-limited searchapi and continue to epo), got %v", i, output["source"])
+		}
+		if output["resultCount"].(float64) != 1 {
+			t.Fatalf("run %d: expected 1 result from epo, got %v", i, output["resultCount"])
+		}
+	}
+}
+
+// TestPatentSearchStrategy3AllProvidersFail proves that when every
+// patent-only provider fails (not just one), Strategy 3 still falls through
+// cleanly to Strategy 4's web-discovery fallback rather than erroring out —
+// the #503 fix removes the abort-on-rate-limit `break`, but a provider that
+// returns a non-rate-limit error must still be skipped the same way.
+func TestPatentSearchStrategy3AllProvidersFail(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	deps.Search = &mockProviderWithURL{url: "https://patents.google.com/patent/US20200012345A1/en"}
+	deps.PatentProviders = map[string]search.PatentProvider{
+		"searchapi": &mockPatentProvider{name: "searchapi", err: fmt.Errorf("rate limited: %w", circuit.ErrRateLimit)},
+		"epo":       &mockPatentProvider{name: "epo", err: fmt.Errorf("upstream error")},
+		"uspto":     &mockPatentProvider{name: "uspto", err: fmt.Errorf("upstream error")},
+	}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "patent_search",
+		Arguments: map[string]any{
+			"query":       "graphene oxide filtration membrane",
+			"search_type": "prior_art",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	var output map[string]any
+	if err := json.Unmarshal([]byte(text), &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output["source"] != "web_discovery" {
+		t.Fatalf("expected fallback to 'web_discovery' when all patent providers fail, got %v", output["source"])
+	}
+}


### PR DESCRIPTION
## Summary
- **#502**: `patent_search(search_type="specific")` on a bare patent number now short-circuits to a direct Google Patents detail-page lookup instead of running the broad-text-search strategies, which padded results #2-5 with unrelated patents even after the exact match was found in result #1. On a miss, no other strategy backfills — a clean zero-result with hints instead.
- **#503** (root cause): Strategy 3 (patent-only providers) iterated `deps.PatentProviders`, a Go map with randomized iteration order, and `break`d the entire loop on any rate-limited provider's error — not just skipping that provider. Whether a rate-limited provider was visited before or after healthy ones was a coin flip, causing intermittent fallback to `web_discovery` despite USPTO/EPO/Lens all being configured. Fixed by iterating in the fixed `search.SupportedPatentProviders` order and skipping (not aborting on) a failing provider.

Closes #502, closes #503

## Test plan
- New tests: `looksLikePatentNumber`/`isPatentSpecificLookup` classifiers (17 cases), `lookupPatentByNumber` hit/miss/error cases, and — critically — `TestPatentSearchStrategy3SkipsRateLimitedProvider` running 10 times with distinct queries asserting deterministic `source="epo"` every run (proving the fix, not luck), plus an all-providers-fail fallback test
- `go build ./...`, `go test -race ./internal/tools/... ./internal/search/...`, `go vet ./...`, `golangci-lint run ./...` all clean
- Doc drift tests pass; no output schema change (source is an unconstrained string field, `google_patents_direct` is a new value not a new field) so no Python regen needed