### PR TITLE
docs(security): switch FIPS build flag to GOFIPS140, document mTLS/compliance decisions

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -4,8 +4,4 @@ This project follows the [Contributor Covenant v2.1](https://www.contributor-cov
 
 ## Reporting concerns
 
-Please report Code of Conduct concerns privately to the maintainer. For
-sensitive reports, open a [private security advisory](https://github.com/zoharbabin/web-researcher-mcp/security/advisories/new)
-(GitHub keeps it confidential between you and the maintainer) or contact the
-maintainer through their [GitHub profile](https://github.com/zoharbabin). All
-reports are handled confidentially.
+Please report Code of Conduct concerns privately to the maintainer. For sensitive reports, open a [private security advisory](https://github.com/zoharbabin/web-researcher-mcp/security/advisories/new) (GitHub keeps it confidential between you and the maintainer) or contact the maintainer through their [GitHub profile](https://github.com/zoharbabin). All reports are handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,18 +18,13 @@ Whether you're fixing a typo, adding a search provider, improving docs, or propo
 
 ### Prerequisites
 
-- **Go** — version requirement is specified in `go.mod` (the `toolchain` directive
-  pins the exact patched release; Go auto-downloads it, so you never build with
-  an unpatched compiler)
+- **Go** — version requirement is specified in `go.mod` (the `toolchain` directive pins the exact patched release; Go auto-downloads it, so you never build with an unpatched compiler)
 - **API keys** (for integration/E2E testing):
   - Google Custom Search: `GOOGLE_CUSTOM_SEARCH_API_KEY` and `GOOGLE_CUSTOM_SEARCH_ID`
   - Brave Search (optional): `BRAVE_API_KEY`
 - **Chrome/Chromium** — optional, only needed for headless scraping features
 
-Linters and the vulnerability scanner are **not** separate installs — they are
-pinned in `go.mod` as `tool` directives and invoked via `go tool`, so every
-contributor and CI run uses byte-identical versions (no drift, no "works on my
-machine").
+Linters and the vulnerability scanner are **not** separate installs — they are pinned in `go.mod` as `tool` directives and invoked via `go tool`, so every contributor and CI run uses byte-identical versions (no drift, no "works on my machine").
 
 ### One-time setup
 
@@ -38,9 +33,7 @@ make tools   # warms the pinned golangci-lint + govulncheck + gosec (go tool fet
 make hooks   # installs the git pre-commit hook (fmt + vet + lint on staged files)
 ```
 
-The pre-commit hook keeps commits fast by checking only staged Go files with the
-quick gates; the full suite (race, vuln, e2e) runs in CI. Bypass a hook in an
-emergency with `git commit --no-verify` — CI still enforces everything.
+The pre-commit hook keeps commits fast by checking only staged Go files with the quick gates; the full suite (race, vuln, e2e) runs in CI. Bypass a hook in an emergency with `git commit --no-verify` — CI still enforces everything.
 
 ### Getting Started
 
@@ -75,24 +68,12 @@ Unit and integration tests do not require API keys. Only E2E tests that hit live
 
 ### Testing both transports locally
 
-If your change touches transport-specific behavior (auth, rate limiting,
-sessions, HTTP handlers), test it over both STDIO and HTTP before opening a
-PR — tool logic is identical across transports, but the surrounding plumbing
-isn't.
+If your change touches transport-specific behavior (auth, rate limiting, sessions, HTTP handlers), test it over both STDIO and HTTP before opening a PR — tool logic is identical across transports, but the surrounding plumbing isn't.
 
-- **STDIO** — the default `.mcp.json` entry in this repo already covers this;
-  just run your MCP client against the built binary.
-- **HTTP, zero setup** — run `PORT=3000 ./web-researcher-mcp` and point any
-  MCP client at `http://localhost:3000/mcp/` (no auth, no TLS). See
-  [DEPLOYMENT.md → HTTP](docs/DEPLOYMENT.md#http-multi-client-web-apps).
-- **HTTP, container parity** — `make docker-smoke` builds the real Docker
-  image and drives a full `initialize`/`tools/call` sequence over plain HTTP
-  in a container (no `-i`/`-t`, matching production). `make e2e-oauth-docker`
-  adds HTTPS + OAuth 2.1 + multi-tenant isolation + GDPR export/erasure on top,
-  entirely via Docker — no cluster needed.
-- **Full k8s parity** — for changes that need real multi-pod behavior (HPA
-  scaling, `REDIS_URL` cross-pod state, the stateless MCP transport under a
-  rolling deployment), see [docs/K8S_LOCAL_DEV.md](docs/K8S_LOCAL_DEV.md).
+- **STDIO** — the default `.mcp.json` entry in this repo already covers this; just run your MCP client against the built binary.
+- **HTTP, zero setup** — run `PORT=3000 ./web-researcher-mcp` and point any MCP client at `http://localhost:3000/mcp/` (no auth, no TLS). See [DEPLOYMENT.md → HTTP](docs/DEPLOYMENT.md#http-multi-client-web-apps).
+- **HTTP, container parity** — `make docker-smoke` builds the real Docker image and drives a full `initialize`/`tools/call` sequence over plain HTTP in a container (no `-i`/`-t`, matching production). `make e2e-oauth-docker` adds HTTPS + OAuth 2.1 + multi-tenant isolation + GDPR export/erasure on top, entirely via Docker — no cluster needed.
+- **Full k8s parity** — for changes that need real multi-pod behavior (HPA scaling, `REDIS_URL` cross-pod state, the stateless MCP transport under a rolling deployment), see [docs/K8S_LOCAL_DEV.md](docs/K8S_LOCAL_DEV.md).
 
 ## Running Tests
 
@@ -264,12 +245,7 @@ STDIO transport is unaffected.
    - (individual targets exist too: `make test-race`, `make lint`, `make sec`, `make vuln`)
    - New code has tests; documentation updated if behavior changes
 
-   `main` is branch-protected: the **Lint**, **Test**, **Security** (govulncheck +
-   gosec), and **E2E** CI checks must all pass before a PR can merge, the branch
-   must be up to date with `main`, linear history is required, and all PR
-   conversations must be resolved. Running `make verify` locally reproduces the
-   CI checks exactly (same pinned tool versions via `go tool`). Human approval is
-   **not** required (the repo is maintainer-driven — see the merge policy below).
+   `main` is branch-protected: the **Lint**, **Test**, **Security** (govulncheck + gosec), and **E2E** CI checks must all pass before a PR can merge, the branch must be up to date with `main`, linear history is required, and all PR conversations must be resolved. Running `make verify` locally reproduces the CI checks exactly (same pinned tool versions via `go tool`). Human approval is **not** required (the repo is maintainer-driven — see the merge policy below).
 
 4. **Write a clear PR description** — explain what changed and why. Include:
    - Summary of changes
@@ -290,27 +266,15 @@ STDIO transport is unaffected.
 
 ### Maintainer Merge Policy
 
-`main` requires **zero human approvals** (this is a maintainer-driven repo, so a
-required-reviewer rule would just block the maintainer's own PRs). Quality is
-held by two gates instead: the CI checks above, and a mandatory **Copilot review
-as a second set of eyes**. Every PR is reviewed by Copilot and every finding is
-either fixed or rebutted before merge.
+`main` requires **zero human approvals** (this is a maintainer-driven repo, so a required-reviewer rule would just block the maintainer's own PRs). Quality is held by two gates instead: the CI checks above, and a mandatory **Copilot review as a second set of eyes**. Every PR is reviewed by Copilot and every finding is either fixed or rebutted before merge.
 
-**How Copilot review is triggered:** by the repo setting *Settings → Rules →
-Rulesets → "Request pull request review from Copilot"* (a one-time UI toggle).
-Copilot **cannot** be requested per-PR via the API or `gh` — it is not a
-collaborator, so `gh pr edit --add-reviewer` and the `requested_reviewers`
-REST/GraphQL endpoints all reject it. The automatic setting is the only
-mechanism; if a fast PR merges before Copilot posts, address its findings in a
-follow-up PR.
+**How Copilot review is triggered:** by the repo setting *Settings → Rules → Rulesets → "Request pull request review from Copilot"* (a one-time UI toggle). Copilot **cannot** be requested per-PR via the API or `gh` — it is not a collaborator, so `gh pr edit --add-reviewer` and the `requested_reviewers` REST/GraphQL endpoints all reject it. The automatic setting is the only mechanism; if a fast PR merges before Copilot posts, address its findings in a follow-up PR.
 
 Per-PR cycle the maintainer follows:
 
 1. Open the PR; CI runs and Copilot review is auto-requested.
 2. Wait for Copilot's review to post (`copilot-pull-request-reviewer[bot]`).
-3. For **each** Copilot finding: fix it, or reply in-thread explaining why it's
-   incorrect — then resolve the conversation. (Copilot only ever `COMMENTED`,
-   never `APPROVED`, so its review can't satisfy an approval gate by design.)
+3. For **each** Copilot finding: fix it, or reply in-thread explaining why it's incorrect — then resolve the conversation. (Copilot only ever `COMMENTED`, never `APPROVED`, so its review can't satisfy an approval gate by design.)
 4. Confirm all CI checks are green and every Copilot thread is resolved.
 5. Merge: `gh pr merge <N> --squash --admin`.
 
@@ -327,9 +291,7 @@ gh api repos/zoharbabin/web-researcher-mcp/pulls/<N>/comments \
 gh pr merge <N> --squash --admin
 ```
 
-`--admin` clears the conversation-resolution/up-to-date formalities at merge
-time; it is **not** a substitute for steps 2–3 — never run it before Copilot's
-findings are genuinely addressed.
+`--admin` clears the conversation-resolution/up-to-date formalities at merge time; it is **not** a substitute for steps 2–3 — never run it before Copilot's findings are genuinely addressed.
 
 ## Issue Guidelines
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ build:
 	CGO_ENABLED=0 go build $(LDFLAGS) -o $(BINARY) ./cmd/web-researcher-mcp
 
 build-fips:
-	GOEXPERIMENT=boringcrypto CGO_ENABLED=0 go build $(LDFLAGS) -o $(BINARY) ./cmd/web-researcher-mcp
+	GOFIPS140=latest CGO_ENABLED=0 go build $(LDFLAGS) -o $(BINARY) ./cmd/web-researcher-mcp
 
 # --- Tests ------------------------------------------------------------------
 

--- a/README.md
+++ b/README.md
@@ -7,10 +7,7 @@
   <strong>Your AI research assistant that cites real sources and stays honest.</strong>
 </p>
 <p align="center">
-  Search the entire web or narrow it down to just the sites you trust;<br/>
-  medical journals, court databases, news outlets, academic papers.<br/>
-  Analyze the full source, not just snippets. Links that work, citations you can trust,<br/>
-  no made up closed garden pre-synthesized results.
+  Search the entire web or narrow it down to just the sites you trust;<br/> medical journals, court databases, news outlets, academic papers.<br/> Analyze the full source, not just snippets. Links that work, citations you can trust,<br/> no made up closed garden pre-synthesized results.
 </p>
 
 ⭐ If you're tired of AI making things up, and [web-researcher-mcp](https://github.com/zoharbabin/web-researcher-mcp/) helps you, give us a star ⭐ — it helps more teams discover the project.  

--- a/decks/README.md
+++ b/decks/README.md
@@ -1,7 +1,6 @@
 # decks/
 
-Presentation decks about this project — source + rendered outputs, one folder
-per deck. Published to the docs site under `/decks/<name>/` via `.github/workflows/docs.yml`.
+Presentation decks about this project — source + rendered outputs, one folder per deck. Published to the docs site under `/decks/<name>/` via `.github/workflows/docs.yml`.
 
 | Deck | What it covers |
 |------|----------------|
@@ -18,15 +17,9 @@ decks/<name>/
 └── <name>-deck.pdf     # rendered, self-contained
 ```
 
-- **Source is [Marp](https://marp.app/)** (`marp: true` frontmatter). Slides are
-  Markdown; styling is a single inline `<style>` block matched to
-  `assets/social-preview.svg`.
-- **Rendered outputs are self-contained** — the logo is embedded as a
-  `data:image/svg+xml;base64` URI, so the HTML works on GitHub Pages with no
-  external fetch and the PDF needs no local files.
-- **Accuracy rule (same as docs):** every factual claim must match the current
-  code, and slides making a technical claim cite the file that backs it (in a
-  `_footer`). Re-verify against the codebase before re-rendering.
+- **Source is [Marp](https://marp.app/)** (`marp: true` frontmatter). Slides are Markdown; styling is a single inline `<style>` block matched to `assets/social-preview.svg`.
+- **Rendered outputs are self-contained** — the logo is embedded as a `data:image/svg+xml;base64` URI, so the HTML works on GitHub Pages with no external fetch and the PDF needs no local files.
+- **Accuracy rule (same as docs):** every factual claim must match the current code, and slides making a technical claim cite the file that backs it (in a `_footer`). Re-verify against the codebase before re-rendering.
 
 ## Re-rendering
 
@@ -39,7 +32,4 @@ npx @marp-team/marp-cli@latest <name>-deck.md --pdf --allow-local-files -o <name
 
 ## Publishing
 
-`docs.yml` copies each deck's rendered `*.html` (as `index.html`) and `*.pdf`
-into `site_src/decks/<name>/`, so they serve at
-`https://zoharbabin.com/web-researcher-mcp/decks/<name>/`. Add a new deck's
-copy lines to that workflow's assemble step.
+`docs.yml` copies each deck's rendered `*.html` (as `index.html`) and `*.pdf` into `site_src/decks/<name>/`, so they serve at `https://zoharbabin.com/web-researcher-mcp/decks/<name>/`. Add a new deck's copy lines to that workflow's assemble step.

--- a/decks/compliance/compliance-deck.md
+++ b/decks/compliance/compliance-deck.md
@@ -238,11 +238,9 @@ Strip the labels, and they demand **the same handful of things**:
 
 <br>
 
-Compliance teams call this *control mapping* — and it's usually a 1,400-row
-spreadsheet and a consultant. **We built the 8 properties into the code instead.**
+Compliance teams call this *control mapping* — and it's usually a 1,400-row spreadsheet and a consultant. **We built the 8 properties into the code instead.**
 
-> **The payoff:** add the 23rd standard and you write **zero** new code — you
-> already satisfy it. Compliance cost stops scaling with the number of regimes.
+> **The payoff:** add the 23rd standard and you write **zero** new code — you already satisfy it. Compliance cost stops scaling with the number of regimes.
 
 <!-- _footer: '↳ proof: docs/SECURITY_AND_COMPLIANCE.md "Compliance Posture" · docs/SECURITY.md crosswalks' -->
 
@@ -252,8 +250,7 @@ spreadsheet and a consultant. **We built the 8 properties into the code instead.
 
 # The architecture that satisfies them
 
-The 8 properties are baked into *how the code is built* — so they hold everywhere,
-not just where someone remembered to add them:
+The 8 properties are baked into *how the code is built* — so they hold everywhere, not just where someone remembered to add them:
 
 - **One way in for every dependency** — nothing reaches in through a back door, so there's one place to audit
 - **Swappable parts behind clean seams** — the cache, search, and audit layers can change without rewriting callers
@@ -271,17 +268,11 @@ not just where someone remembered to add them:
 
 # The safest config is the *default* config
 
-Run it the normal way — locally, inside your AI app — and there's **no network
-port open, no login to misconfigure, nothing exposed to the internet.** The app
-that launched it is the only thing that can reach it. The typical user *can't*
-hold it wrong, because there's nothing to set.
+Run it the normal way — locally, inside your AI app — and there's **no network port open, no login to misconfigure, nothing exposed to the internet.** The app that launched it is the only thing that can reach it. The typical user *can't* hold it wrong, because there's nothing to set.
 
-The heavyweight controls for shared, multi-user deployments — sign-in, per-customer
-isolation, rate limits, encryption, audit logs — only switch on when an operator
-deliberately runs it as a network server.
+The heavyweight controls for shared, multi-user deployments — sign-in, per-customer isolation, rate limits, encryption, audit logs — only switch on when an operator deliberately runs it as a network server.
 
-> **Secure by default, permissive by configuration.** Power is unlocked by an
-> *explicit* choice, never the reverse.
+> **Secure by default, permissive by configuration.** Power is unlocked by an *explicit* choice, never the reverse.
 
 <!-- _footer: '↳ proof: docs/SECURITY_AND_COMPLIANCE.md Principles 1 & 4, "Deployment Security"' -->
 
@@ -291,8 +282,7 @@ deliberately runs it as a network server.
 
 # Controls, not certificates: the honest line
 
-"Compliance as architecture" ships the *controls*. It can't ship the *operating
-organization* a certificate requires — so here's the split:
+"Compliance as architecture" ships the *controls*. It can't ship the *operating organization* a certificate requires — so here's the split:
 
 | Layer | Who owns it |
 |-------|-------------|
@@ -300,9 +290,7 @@ organization* a certificate requires — so here's the split:
 | **The operator owns the process** | They're the **data controller** — sign BAAs/DPAs, set the retention *schedule* (code gives TTL knobs, not policy), run access reviews + incident response, choose lawful basis, run DPIAs |
 | **A hosted SaaS adds the program** | Trained staff, controls *audited over time*, 24/7 IR, signed customer DPAs, and the actual **SOC 2 / HITRUST / ISO 27001 audit** — none of which a repo can contain |
 
-> So "aligned with 23 standards" means *we provide the technical controls each one
-> requires* — not that an organization has been audited against them. A binary
-> can't clear a hospital's HIPAA bar; it hands that review its evidence.
+> So "aligned with 23 standards" means *we provide the technical controls each one requires* — not that an organization has been audited against them. A binary can't clear a hospital's HIPAA bar; it hands that review its evidence.
 
 <!-- _footer: '↳ proof: docs/SECURITY_AND_COMPLIANCE.md "Operator & Hosted-Service Responsibilities"' -->
 
@@ -312,24 +300,13 @@ organization* a certificate requires — so here's the split:
 
 # Agency sharpens one old threat — and adds a new one
 
-Give an AI a tool that fetches any page, and it now *chooses the URLs*. That
-**amplifies an old vuln** and **surfaces a new one**:
+Give an AI a tool that fetches any page, and it now *chooses the URLs*. That **amplifies an old vuln** and **surfaces a new one**:
 
-**Old vuln, now automated — SSRF (OWASP Web A10).** A hijacked link can steer an
-*autonomous* fetch at your internal network. So before any fetch the server
-rejects private/reserved IPs and cloud-metadata hosts, connects only to the
-exact resolved address (DNS-rebind defense), and re-checks on every redirect.
+**Old vuln, now automated — SSRF (OWASP Web A10).** A hijacked link can steer an *autonomous* fetch at your internal network. So before any fetch the server rejects private/reserved IPs and cloud-metadata hosts, connects only to the exact resolved address (DNS-rebind defense), and re-checks on every redirect.
 
-**A genuinely new class — indirect prompt injection.** A booby-trapped page can
-try to hijack the AI reading it. The server strips active markup, caps size, and
-stamps every result that carries external text with an `untrusted-external-content`
-marker — in the JSON *envelope*, never inside the content where a page could forge
-it, and **enforced by a cross-tool drift test** so a new tool can't ship unmarked.
-It does **not** enforce the prompt boundary — that's the *host's* job, where the
-model and agent loop live.
+**A genuinely new class — indirect prompt injection.** A booby-trapped page can try to hijack the AI reading it. The server strips active markup, caps size, and stamps every result that carries external text with an `untrusted-external-content` marker — in the JSON *envelope*, never inside the content where a page could forge it, and **enforced by a cross-tool drift test** so a new tool can't ship unmarked. It does **not** enforce the prompt boundary — that's the *host's* job, where the model and agent loop live.
 
-> Prompt injection is **#1** on OWASP's LLM list, and the agentic rules are still
-> being drafted. This tool sits squarely in that gap.
+> Prompt injection is **#1** on OWASP's LLM list, and the agentic rules are still being drafted. This tool sits squarely in that gap.
 
 <!-- _footer: '↳ proof: internal/scraper/ssrf.go · internal/tools/scrape.go (envelope "trust" marker) · internal/tools/metadata_test.go (cross-tool gate) · internal/content/sanitize.go · OWASP Web A10 · LLM01' -->
 
@@ -339,17 +316,11 @@ model and agent loop live.
 
 # An erasure registry you can't outrun
 
-Privacy starts with collecting little: the cache is content-addressed (not keyed
-to a user), and the operator — not us — is the data controller. But the moment a
-feature *does* store personal data, "right to be forgotten" has to actually work.
+Privacy starts with collecting little: the cache is content-addressed (not keyed to a user), and the operator — not us — is the data controller. But the moment a feature *does* store personal data, "right to be forgotten" has to actually work.
 
-So it's enforced structurally: **every store that holds personal data must
-register an Exporter + Eraser.** One `(tenant, user)` request fans out to all of
-them — and each store ships a round-trip **release-gate test**.
+So it's enforced structurally: **every store that holds personal data must register an Exporter + Eraser.** One `(tenant, user)` request fans out to all of them — and each store ships a round-trip **release-gate test**.
 
-> Add a new feature and forget to wire its eraser? **CI fails — not an auditor.**
-> GDPR access / portability / erasure (Art. 15 / 17 / 20) becomes a property of
-> the build, not a promise in a policy PDF.
+> Add a new feature and forget to wire its eraser? **CI fails — not an auditor.** GDPR access / portability / erasure (Art. 15 / 17 / 20) becomes a property of the build, not a promise in a policy PDF.
 
 <!-- _footer: '↳ proof: internal/datasubject/registry.go · internal/session/datasubject_test.go ("the #85 release gate")' -->
 
@@ -359,10 +330,7 @@ them — and each store ships a round-trip **release-gate test**.
 
 # Consent as a primitive: record → verify → honor
 
-The AI-tool standard (MCP) says *asking* the user for consent is the **client
-app's** job — so most servers do nothing. But whoever *stores* the data is, in
-law, the **data controller**, and GDPR / Quebec Law 25 make *them* prove consent
-was given and honor a withdrawal — a duty a login token can't discharge.
+The AI-tool standard (MCP) says *asking* the user for consent is the **client app's** job — so most servers do nothing. But whoever *stores* the data is, in law, the **data controller**, and GDPR / Quebec Law 25 make *them* prove consent was given and honor a withdrawal — a duty a login token can't discharge.
 
 So the server treats consent as three things it actually does:
 
@@ -378,8 +346,7 @@ So the server treats consent as three things it actually does:
 
 # The docs are tested, not trusted
 
-"Keep the docs accurate" isn't a good intention here — a stack of small
-mechanisms makes drift hard to write and impossible to merge quietly:
+"Keep the docs accurate" isn't a good intention here — a stack of small mechanisms makes drift hard to write and impossible to merge quietly:
 
 | Layer | What keeps it honest |
 |-------|----------------------|
@@ -388,8 +355,7 @@ mechanisms makes drift hard to write and impossible to merge quietly:
 | **A test reads the docs** | At build time it parses `docs/TOOLS.md`, starts a real server, and fails if the documented tools or shapes don't match reality |
 | **Gates that can't be skipped** | The doc-drift check runs in CI on **every** PR — even docs-only ones |
 
-> The *judgment* — threat models, standards crosswalks — lives in prose and gets
-> human review. Where a claim is enumerable, the build enforces it.
+> The *judgment* — threat models, standards crosswalks — lives in prose and gets human review. Where a claim is enumerable, the build enforces it.
 
 <!-- _footer: '↳ proof: CLAUDE.md "Documentation Guidelines" · internal/tools/metadata_test.go · .github/workflows/ci.yml (docs-drift)' -->
 
@@ -426,9 +392,7 @@ The same architecture pays off differently for everyone who touches it:
 
 <br>
 
-*Honest boundaries: "aligned with," not "certified." The local and server threat
-models differ. By default it stores little; the features that do store personal
-data are opt-in, consent-gated, and erasable — not absent.*
+*Honest boundaries: "aligned with," not "certified." The local and server threat models differ. By default it stores little; the features that do store personal data are opt-in, consent-gated, and erasable — not absent.*
 
 <!-- _footer: '↳ five portable principles · no compliance framework required' -->
 
@@ -439,13 +403,10 @@ data are opt-in, consent-gated, and erasable — not absent.*
 
 # Read the code, not the marketing.
 
-Each technical claim here names the file that backs it — open any one and check.
-And a CI drift gate keeps the tool docs honest against the code.
+Each technical claim here names the file that backs it — open any one and check. And a CI drift gate keeps the tool docs honest against the code.
 
 <br>
 
 <br>
 
-*Solo maintainer · MIT licensed · **contributors welcome.** Spot a claim that
-doesn't match the code? Open an issue or a PR — that's the whole point. Come help
-build it: `github.com/zoharbabin/web-researcher-mcp`*
+*Solo maintainer · MIT licensed · **contributors welcome.** Spot a claim that doesn't match the code? Open an issue or a PR — that's the whole point. Come help build it: `github.com/zoharbabin/web-researcher-mcp`*

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -72,7 +72,7 @@ go build -o web-researcher-mcp ./cmd/web-researcher-mcp
 CGO_ENABLED=0 go build -ldflags="-s -w" -o web-researcher-mcp ./cmd/web-researcher-mcp
 
 # FIPS-compliant build (government/enterprise)
-GOEXPERIMENT=boringcrypto CGO_ENABLED=0 go build -ldflags="-s -w" -o web-researcher-mcp ./cmd/web-researcher-mcp
+GOFIPS140=latest CGO_ENABLED=0 go build -ldflags="-s -w" -o web-researcher-mcp ./cmd/web-researcher-mcp
 
 # Cross-compile
 GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o web-researcher-mcp-linux-amd64 ./cmd/web-researcher-mcp

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -663,6 +663,34 @@ The "sessions" below are the `sequential_search` tool's own research-continuity 
 2. Without Redis: use sticky sessions at your L7 load balancer and divide rate limits by expected instance count.
 3. `go-rod` browser rendering remains per-pod regardless (stateless, no shared pool needed).
 
+### Recovery objectives (RTO/RPO)
+
+Framed in NIST SP 800-34 contingency-planning terms, for an operator building a
+Business Impact Analysis or an Information System Contingency Plan around this
+server:
+
+- **Compute (RTO ≈ 0).** Pods are stateless (`Stateless` transport mode above)
+  and require no session affinity, so a crashed or evicted pod is replaced by
+  the orchestrator with zero coordination — the [HPA example](#kubernetes)
+  restores capacity automatically. There is no leader election, no warm-up
+  handshake, and no data to reattach.
+- **Cache (RPO = 0 by design, not by backup).** Memory and disk cache are
+  disposable: losing a pod's cache costs a re-fetch on the next query, not data
+  loss, because search results are deterministic and the cache is not a system
+  of record. No backup policy is needed for this tier.
+- **Sessions and rate-quota state, without `REDIS_URL` (RPO ≈ per-pod TTL
+  window).** Encrypted-disk sessions survive that one pod's restart but not its
+  loss; a pod replacement loses that pod's in-flight sessions and daily-quota
+  counters. Acceptable for single-instance or best-effort multi-instance
+  deployments; unacceptable if session continuity across a pod loss is a
+  requirement.
+- **Sessions and rate-quota state, with `REDIS_URL` (RPO = Redis's own).**
+  This project encrypts everything before writing it to Redis, but durability
+  beyond that is entirely a function of the operator's Redis deployment — its
+  own persistence mode (RDB/AOF), replication, and backup schedule. Size that
+  Redis RPO to match what the BIA actually requires; this project has no
+  opinion on it beyond "encrypt at rest," which it already enforces.
+
 ### Production Readiness Checklist
 
 Before running multiple instances behind a load balancer, work through this checklist. Items marked **(per-pod without Redis)** behave differently across pods unless `REDIS_URL` is set.

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -121,22 +121,12 @@ OAUTH_AUDIENCE=https://api.example.com \
 ./web-researcher-mcp
 ```
 
-When `PORT` is set, the server runs the HTTP (Streamable) transport exclusively
-and does not read STDIO; when `PORT` is unset it runs STDIO exclusively. The two
-transports are mutually exclusive, so a container started with `PORT` set but no
-stdin attached (`docker run -p ... -e PORT=...`) stays up serving HTTP.
+When `PORT` is set, the server runs the HTTP (Streamable) transport exclusively and does not read STDIO; when `PORT` is unset it runs STDIO exclusively. The two transports are mutually exclusive, so a container started with `PORT` set but no stdin attached (`docker run -p ... -e PORT=...`) stays up serving HTTP.
 
 **Endpoints:**
 - `/mcp/` — Streamable HTTP MCP endpoint (handles POST and streaming)
-- `GET /health/live` — Liveness probe (always 200, `ok`; a degraded-but-alive
-  process must not be killed)
-- `GET /health/ready` — Readiness probe. When multi-provider routing is
-  configured, returns `503` (with the health snapshot JSON) **only when every
-  provider's circuit breaker is open** — the pod cannot serve any query and
-  should be pulled from the load balancer; `200` otherwise (`healthy` or
-  `degraded`, since fallback providers still serve). With no routing
-  (single-provider / zero-config), it is a static `200 ready` — there is no
-  breaker ladder to gate on and the process is ready by construction.
+- `GET /health/live` — Liveness probe (always 200, `ok`; a degraded-but-alive process must not be killed)
+- `GET /health/ready` — Readiness probe. When multi-provider routing is configured, returns `503` (with the health snapshot JSON) **only when every provider's circuit breaker is open** — the pod cannot serve any query and should be pulled from the load balancer; `200` otherwise (`healthy` or `degraded`, since fallback providers still serve). With no routing (single-provider / zero-config), it is a static `200 ready` — there is no breaker ladder to gate on and the process is ready by construction.
 - `GET /metrics` — Prometheus metrics
 - `GET /dashboard` — read-only operator dashboard (HTML); its data endpoint `GET /dashboard/data` is admin-gated. Both are registered only when `ADMIN_API_KEY` is set. See [Operator Dashboard](#operator-dashboard-http-mode)
 - `GET /.well-known/oauth-authorization-server` — OAuth metadata
@@ -665,31 +655,12 @@ The "sessions" below are the `sequential_search` tool's own research-continuity 
 
 ### Recovery objectives (RTO/RPO)
 
-Framed in NIST SP 800-34 contingency-planning terms, for an operator building a
-Business Impact Analysis or an Information System Contingency Plan around this
-server:
+Framed in NIST SP 800-34 contingency-planning terms, for an operator building a Business Impact Analysis or an Information System Contingency Plan around this server:
 
-- **Compute (RTO ≈ 0).** Pods are stateless (`Stateless` transport mode above)
-  and require no session affinity, so a crashed or evicted pod is replaced by
-  the orchestrator with zero coordination — the [HPA example](#kubernetes)
-  restores capacity automatically. There is no leader election, no warm-up
-  handshake, and no data to reattach.
-- **Cache (RPO = 0 by design, not by backup).** Memory and disk cache are
-  disposable: losing a pod's cache costs a re-fetch on the next query, not data
-  loss, because search results are deterministic and the cache is not a system
-  of record. No backup policy is needed for this tier.
-- **Sessions and rate-quota state, without `REDIS_URL` (RPO ≈ per-pod TTL
-  window).** Encrypted-disk sessions survive that one pod's restart but not its
-  loss; a pod replacement loses that pod's in-flight sessions and daily-quota
-  counters. Acceptable for single-instance or best-effort multi-instance
-  deployments; unacceptable if session continuity across a pod loss is a
-  requirement.
-- **Sessions and rate-quota state, with `REDIS_URL` (RPO = Redis's own).**
-  This project encrypts everything before writing it to Redis, but durability
-  beyond that is entirely a function of the operator's Redis deployment — its
-  own persistence mode (RDB/AOF), replication, and backup schedule. Size that
-  Redis RPO to match what the BIA actually requires; this project has no
-  opinion on it beyond "encrypt at rest," which it already enforces.
+- **Compute (RTO ≈ 0).** Pods are stateless (`Stateless` transport mode above) and require no session affinity, so a crashed or evicted pod is replaced by the orchestrator with zero coordination — the [HPA example](#kubernetes) restores capacity automatically. There is no leader election, no warm-up handshake, and no data to reattach.
+- **Cache (RPO = 0 by design, not by backup).** Memory and disk cache are disposable: losing a pod's cache costs a re-fetch on the next query, not data loss, because search results are deterministic and the cache is not a system of record. No backup policy is needed for this tier.
+- **Sessions and rate-quota state, without `REDIS_URL` (RPO ≈ per-pod TTL window).** Encrypted-disk sessions survive that one pod's restart but not its loss; a pod replacement loses that pod's in-flight sessions and daily-quota counters. Acceptable for single-instance or best-effort multi-instance deployments; unacceptable if session continuity across a pod loss is a requirement.
+- **Sessions and rate-quota state, with `REDIS_URL` (RPO = Redis's own).** This project encrypts everything before writing it to Redis, but durability beyond that is entirely a function of the operator's Redis deployment — its own persistence mode (RDB/AOF), replication, and backup schedule. Size that Redis RPO to match what the BIA actually requires; this project has no opinion on it beyond "encrypt at rest," which it already enforces.
 
 ### Production Readiness Checklist
 
@@ -911,20 +882,9 @@ This server is distributed via:
 | `/health/live` | GET | `200 OK` always (`ok`) | K8s liveness probe |
 | `/health/ready` | GET | `200 OK` (`ready`/snapshot); `503` when all provider breakers are open | K8s readiness probe |
 
-`/health/live` is a static process-up check: a `200` means the process is running
-and the HTTP listener is bound (the server completes all initialization —
-providers, cache, sessions, audit — before binding the port, so a successful
-connection already implies a fully-constructed server). A degraded-but-alive
-process must not be killed, so liveness never flips on dependency state.
+`/health/live` is a static process-up check: a `200` means the process is running and the HTTP listener is bound (the server completes all initialization — providers, cache, sessions, audit — before binding the port, so a successful connection already implies a fully-constructed server). A degraded-but-alive process must not be killed, so liveness never flips on dependency state.
 
-`/health/ready` reflects whether the pod can serve a query. With multi-provider
-routing configured, it returns `503` (body `{"status":"unhealthy"}`) **only when
-every provider's circuit breaker is open** — the pod can serve nothing and should
-be pulled from the load balancer — and `200` otherwise (`healthy`/`degraded`,
-since fallback providers still serve). With no routing (single-provider /
-zero-config) there is no breaker ladder, so it stays a static `200`. The body is
-the aggregate status only; the per-provider breaker list is operator data behind
-the admin-gated dashboard and `diagnostics://health`, not this unauthenticated probe.
+`/health/ready` reflects whether the pod can serve a query. With multi-provider routing configured, it returns `503` (body `{"status":"unhealthy"}`) **only when every provider's circuit breaker is open** — the pod can serve nothing and should be pulled from the load balancer — and `200` otherwise (`healthy`/`degraded`, since fallback providers still serve). With no routing (single-provider / zero-config) there is no breaker ladder, so it stays a static `200`. The body is the aggregate status only; the per-provider breaker list is operator data behind the admin-gated dashboard and `diagnostics://health`, not this unauthenticated probe.
 
 ---
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -297,8 +297,7 @@ The `status` field tells you immediately: `"complete"`, `"partial"`, or `"failed
 
 ### 1. Errors are actionable, not diagnostic
 
-Bad: `"error: HTTP 403"`
-Good:
+Bad: `"error: HTTP 403"` Good:
 ```
 Blocked: x.com uses bot detection. Try an alternative source — its content can't be read directly.
 

--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -297,7 +297,9 @@ The `status` field tells you immediately: `"complete"`, `"partial"`, or `"failed
 
 ### 1. Errors are actionable, not diagnostic
 
-Bad: `"error: HTTP 403"` Good:
+Bad: `"error: HTTP 403"`
+
+Good:
 ```
 Blocked: x.com uses bot detection. Try an alternative source — its content can't be read directly.
 

--- a/docs/K8S_LOCAL_DEV.md
+++ b/docs/K8S_LOCAL_DEV.md
@@ -1,25 +1,12 @@
 # Local Kubernetes Parity Testing
 
-Manifests under [`deploy/k8s-local/`](../deploy/k8s-local/) reproduce the
-production topology (`docs/DEPLOYMENT.md`'s [Kubernetes](DEPLOYMENT.md#kubernetes)
-section) on a local single-node cluster: multi-pod HPA scaling, OAuth 2.1 auth,
-`REDIS_URL` cross-pod session/cache/rate-limit state, and namespace-scoped
-`NetworkPolicy` isolation. Use this when a change needs to be exercised across
-real pods (the stateless MCP transport, Redis-backed sessions, HPA behavior,
-multi-tenant isolation) — for everything else, the zero-setup
-[local HTTP](DEPLOYMENT.md#http-multi-client-web-apps) or
-[`make docker-smoke`](DEPLOYMENT.md#docker) paths are faster and need no cluster.
+Manifests under [`deploy/k8s-local/`](../deploy/k8s-local/) reproduce the production topology (`docs/DEPLOYMENT.md`'s [Kubernetes](DEPLOYMENT.md#kubernetes) section) on a local single-node cluster: multi-pod HPA scaling, OAuth 2.1 auth, `REDIS_URL` cross-pod session/cache/rate-limit state, and namespace-scoped `NetworkPolicy` isolation. Use this when a change needs to be exercised across real pods (the stateless MCP transport, Redis-backed sessions, HPA behavior, multi-tenant isolation) — for everything else, the zero-setup [local HTTP](DEPLOYMENT.md#http-multi-client-web-apps) or [`make docker-smoke`](DEPLOYMENT.md#docker) paths are faster and need no cluster.
 
-Everything under `deploy/k8s-local/` is generic — no personal hostnames,
-tokens, or machine-specific paths. The one thing you generate yourself is the
-JWKS/JWT keypair, so no private key is ever committed to the repo.
+Everything under `deploy/k8s-local/` is generic — no personal hostnames, tokens, or machine-specific paths. The one thing you generate yourself is the JWKS/JWT keypair, so no private key is ever committed to the repo.
 
 ## Prerequisites
 
-Any local single-node Kubernetes distribution with an Ingress controller works
-— Rancher Desktop, `kind`, `minikube`, k3d. The steps below assume Rancher
-Desktop's bundled Traefik; substitute `ingressClassName`/annotations in
-`04-ingress.yaml` for a different controller.
+Any local single-node Kubernetes distribution with an Ingress controller works — Rancher Desktop, `kind`, `minikube`, k3d. The steps below assume Rancher Desktop's bundled Traefik; substitute `ingressClassName`/annotations in `04-ingress.yaml` for a different controller.
 
 ## Setup
 
@@ -78,19 +65,11 @@ python3 scripts/e2e-oauth-mint-jwt.py mint "$WORK_DIR" my-local-user wrm-k8s-key
   http://oauth-issuer.web-researcher.svc.cluster.local web-researcher-mcp
 ```
 
-The printed JWT is an RS256 token signed with the keypair from step 3,
-matching what `internal/auth/middleware.go` validates against the in-cluster
-JWKS endpoint — it is only valid inside this cluster, never a real IdP token.
+The printed JWT is an RS256 token signed with the keypair from step 3, matching what `internal/auth/middleware.go` validates against the in-cluster JWKS endpoint — it is only valid inside this cluster, never a real IdP token.
 
 ## Connecting a client
 
-Port-forward the ingress (or use your cluster's LoadBalancer/NodePort), then
-point an MCP client's `http` transport entry at
-`https://web-researcher-mcp.local:<port>/mcp/` with
-`Authorization: Bearer <minted-jwt>`. `.mcp.json` in this repo intentionally
-stays STDIO-only and portable (see [Development Setup](../CONTRIBUTING.md#development-setup))
-— add a client entry for this cluster in your own untracked MCP client config,
-not in the tracked `.mcp.json`.
+Port-forward the ingress (or use your cluster's LoadBalancer/NodePort), then point an MCP client's `http` transport entry at `https://web-researcher-mcp.local:<port>/mcp/` with `Authorization: Bearer <minted-jwt>`. `.mcp.json` in this repo intentionally stays STDIO-only and portable (see [Development Setup](../CONTRIBUTING.md#development-setup)) — add a client entry for this cluster in your own untracked MCP client config, not in the tracked `.mcp.json`.
 
 ## Teardown
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -297,8 +297,7 @@ Raw HTML/Content
 - Reject with informative error when exceeded
 - Counters are in-memory by default; set `RATE_LIMIT_PERSIST=true` to write them through to the encrypted persist store so quotas survive a restart
 
-**Burst handling (parallel tool calls):**
-When a single agent spawns many parallel tool calls, limits are enforced by token buckets, not a queue:
+**Burst handling (parallel tool calls):** When a single agent spawns many parallel tool calls, limits are enforced by token buckets, not a queue:
 - Per-tenant and global token buckets (`internal/ratelimit/limiter.go`) — excess calls are rejected immediately, never buffered
 - Rejected HTTP requests return `429` with a `Retry-After` header (`60` for the per-minute bucket, `3600` for the daily quota)
 - Concurrent scraping is separately bounded by two fixed-size semaphores in the scrape pipeline (`internal/scraper/pipeline.go`) — one for fast tiers, one for the browser tier — so a burst of scrapes runs at a capped concurrency rather than all at once
@@ -324,18 +323,9 @@ Protects against cascading failures when upstream APIs are down.
 
 ### Layer 7: Audit Logging
 
-**Tool calls that do real work are audited** — on cache-hit, terminal success,
-upstream error, AND regulated-tool refusal (no_consent / not_member /
-unauthenticated). Authentication and authorization failures (missing/invalid
-token, insufficient scope, bad admin key) emit a separate `auth.failure` event.
-**Not audited:** cheap input-validation rejections handled at the top of the
-handler before any work (e.g. empty query, missing URL, oversized note) — they
-return a `toolError` immediately and emit no event.
+**Tool calls that do real work are audited** — on cache-hit, terminal success, upstream error, AND regulated-tool refusal (no_consent / not_member / unauthenticated). Authentication and authorization failures (missing/invalid token, insufficient scope, bad admin key) emit a separate `auth.failure` event. **Not audited:** cheap input-validation rejections handled at the top of the handler before any work (e.g. empty query, missing URL, oversized note) — they return a `toolError` immediately and emit no event.
 
-See `internal/audit/logger.go` for the canonical `AuditEvent` struct. Key fields:
-timestamp, tenant/user/session IDs, tool name, request ID, source IP (HTTP only;
-proxy-aware, empty under STDIO), duration, success/error status, and extensible
-metadata.
+See `internal/audit/logger.go` for the canonical `AuditEvent` struct. Key fields: timestamp, tenant/user/session IDs, tool name, request ID, source IP (HTTP only; proxy-aware, empty under STDIO), duration, success/error status, and extensible metadata.
 
 **Storage:**
 - Default: structured log to stderr (slog JSON)
@@ -380,13 +370,7 @@ None of these is a personal-data store. Field contracts live in `docs/TOOLS.md` 
 - No sensitive data in URL query parameters
 
 ### FIPS Compliance (Optional)
-- Build with `GOFIPS140=latest` (Go's native FIPS 140-3 module, `crypto/fips140`) —
-  active CMVP certificate [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247).
-  `GOEXPERIMENT=boringcrypto` is no longer the compliant path: BoringCrypto's own
-  certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
-  (NIST's [FIPS 140-3 Transition](https://csrc.nist.gov/projects/fips-140-3-transition-effort)
-  moved remaining FIPS 140-2 modules off the Active list), and Go's own docs mark
-  `GOEXPERIMENT=boringcrypto` [unsupported and slated for removal](https://go.dev/doc/security/fips140).
+- Build with `GOFIPS140=latest` (Go's native FIPS 140-3 module, `crypto/fips140`) — active CMVP certificate [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247). `GOEXPERIMENT=boringcrypto` is no longer the compliant path: BoringCrypto's own certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678) (NIST's [FIPS 140-3 Transition](https://csrc.nist.gov/projects/fips-140-3-transition-effort) moved remaining FIPS 140-2 modules off the Active list), and Go's own docs mark `GOEXPERIMENT=boringcrypto` [unsupported and slated for removal](https://go.dev/doc/security/fips140).
 - Affects: TLS, AES, SHA, RSA operations
 
 ---

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -380,7 +380,13 @@ None of these is a personal-data store. Field contracts live in `docs/TOOLS.md` 
 - No sensitive data in URL query parameters
 
 ### FIPS Compliance (Optional)
-- Build with `GOEXPERIMENT=boringcrypto` for FIPS 140-2 validated crypto
+- Build with `GOFIPS140=latest` (Go's native FIPS 140-3 module, `crypto/fips140`) —
+  active CMVP certificate [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247).
+  `GOEXPERIMENT=boringcrypto` is no longer the compliant path: BoringCrypto's own
+  certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678)
+  (NIST's [FIPS 140-3 Transition](https://csrc.nist.gov/projects/fips-140-3-transition-effort)
+  moved remaining FIPS 140-2 modules off the Active list), and Go's own docs mark
+  `GOEXPERIMENT=boringcrypto` [unsupported and slated for removal](https://go.dev/doc/security/fips140).
 - Affects: TLS, AES, SHA, RSA operations
 
 ---
@@ -515,7 +521,7 @@ Data minimization (implemented): by default audit logs store only the query leng
 | Control | Implementation |
 |---------|----------------|
 | **SC-8** Transmission Confidentiality | TLS 1.2+ on all connections |
-| **SC-13** Cryptographic Protection | FIPS 140-2 via `GOEXPERIMENT=boringcrypto` |
+| **SC-13** Cryptographic Protection | FIPS 140-3 via `GOFIPS140=latest` (Go's native `crypto/fips140` module, CMVP cert [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)) |
 | **SC-28** Protection at Rest | AES-256-GCM for disk cache |
 | **AC-3** Access Enforcement | OAuth middleware on all HTTP endpoints |
 | **AU-2** Audit Events | All tool calls, auth failures, config changes |
@@ -523,7 +529,7 @@ Data minimization (implemented): by default audit logs store only the query leng
 
 ```bash
 # FIPS-compliant build
-GOEXPERIMENT=boringcrypto CGO_ENABLED=0 \
+GOFIPS140=latest CGO_ENABLED=0 \
   go build -ldflags="-s -w -X main.version=${VERSION}" \
   -o web-researcher-mcp ./cmd/web-researcher-mcp
 ```

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -2,9 +2,7 @@
 
 How this project protects your data, your infrastructure, and your users.
 
-This document covers security architecture, privacy principles, compliance
-posture, contributor guidelines, and deployment guidance — everything in one
-place, for everyone who needs it.
+This document covers security architecture, privacy principles, compliance posture, contributor guidelines, and deployment guidance — everything in one place, for everyone who needs it.
 
 ---
 
@@ -24,32 +22,22 @@ place, for everyone who needs it.
 Six rules that govern every design decision:
 
 1. **Secure by default, permissive by configuration.**  
-   The tool ships safe out of the box. Advanced users unlock capabilities
-   through explicit configuration — never the other way around.
+   The tool ships safe out of the box. Advanced users unlock capabilities through explicit configuration — never the other way around.
 
 2. **Never limit research capabilities for security theater.**  
-   Security controls must protect without reducing the quality, speed, or
-   breadth of results. If a control blocks legitimate research, it becomes
-   configurable — not mandatory.
+   Security controls must protect without reducing the quality, speed, or breadth of results. If a control blocks legitimate research, it becomes configurable — not mandatory.
 
 3. **Compliance through architecture, not bolt-on checklists.**  
-   Data minimization, purpose limitation, and tenant isolation are structural
-   properties of the codebase, not afterthoughts added for an audit.
+   Data minimization, purpose limitation, and tenant isolation are structural properties of the codebase, not afterthoughts added for an audit.
 
 4. **STDIO is zero-trust-by-default.**  
-   The most common deployment (local CLI via Claude Code, Cursor, etc.) has
-   no network listener, no auth to misconfigure, and no attack surface.
-   Multi-tenant security features only activate in HTTP mode.
+   The most common deployment (local CLI via Claude Code, Cursor, etc.) has no network listener, no auth to misconfigure, and no attack surface. Multi-tenant security features only activate in HTTP mode.
 
 5. **Simple things should be simple; complex things should be possible.**  
-   A developer running `go build && ./web-researcher-mcp` should not need
-   to configure OAuth, encryption keys, or compliance profiles. An enterprise
-   deploying for 10,000 users should have everything they need.
+   A developer running `go build && ./web-researcher-mcp` should not need to configure OAuth, encryption keys, or compliance profiles. An enterprise deploying for 10,000 users should have everything they need.
 
 6. **Elegant code is secure code.**  
-   Short, readable, well-tested functions are easier to audit and harder to
-   exploit than clever abstractions. Prefer Go's standard library over third-
-   party dependencies. One clear implementation over pluggable frameworks.
+   Short, readable, well-tested functions are easier to audit and harder to exploit than clever abstractions. Prefer Go's standard library over third- party dependencies. One clear implementation over pluggable frameworks.
 
 ---
 
@@ -98,8 +86,7 @@ User/LLM → [STDIO or HTTP+TLS] → MCP Server
                     (AES-256-GCM, TTL)
 ```
 
-All components are wired through the `tools.Dependencies` struct — zero global
-state, fully testable, every dependency swappable via interfaces.
+All components are wired through the `tools.Dependencies` struct — zero global state, fully testable, every dependency swappable via interfaces.
 
 ---
 
@@ -115,50 +102,20 @@ The highest-severity risk for a scraping server. Our defense:
 4. Connect directly to the resolved IP (prevents DNS rebinding)
 5. Re-validate on each redirect hop (max 5 redirects)
 
-Blocked ranges: RFC 1918, link-local (169.254.0.0/16), loopback, multicast,
-carrier-grade NAT, documentation ranges, IPv6 equivalents. See
-`internal/scraper/ssrf.go` for the canonical list.
+Blocked ranges: RFC 1918, link-local (169.254.0.0/16), loopback, multicast, carrier-grade NAT, documentation ranges, IPv6 equivalents. See `internal/scraper/ssrf.go` for the canonical list.
 
-Escape hatch: `ALLOW_PRIVATE_IPS=true` for development/intranet scraping.
-Domain allowlist: `ALLOWED_DOMAINS=a.com,b.com` for enterprise lock-down.
+Escape hatch: `ALLOW_PRIVATE_IPS=true` for development/intranet scraping. Domain allowlist: `ALLOWED_DOMAINS=a.com,b.com` for enterprise lock-down.
 
 ### Content Security
 
 Scraped content passes through a configurable sanitization pipeline:
 
-1. **Default mode**: HTML sanitization (bluemonday allowlist — strips scripts,
-   iframes, event handlers), hidden content removal (display:none, zero-width
-   chars), size enforcement (50KB per source, 300KB total)
-2. **Raw mode** (`mode: "raw"`, `scrape_page` only): Returns the fetched bytes
-   verbatim — scripts, styles, and markup intact — for inspecting source such as
-   JSON, HTML, or JavaScript (code analysis, security research, web development).
-   Only `content.Process` is skipped; the request still passes through
-   `validateScrapeURL`, the SSRF-safe client, the `ALLOWED_DOMAINS` allowlist,
-   and an `io.LimitReader` bounded by `max_length`. The returned content is
-   UNTRUSTED (it may carry indirect prompt-injection payloads), so callers must
-   never execute or render it. `search_and_scrape` has no raw mode and is always
-   sanitized.
-3. **Size limits**: Configurable per-request via `maxLength` parameter. The LLM
-   decides how much content it needs based on context window and task.
-   Defaults protect against context flooding; explicit overrides serve
-   legitimate research needs (analyzing large codebases, full-page audits).
-4. **Trust boundary marker**: every scrape response carries
-   `"trust": "untrusted-external-content"` in the JSON envelope (not inside the
-   `content` string, where a page could forge it) — an explicit signal to treat
-   `content` as data, never as instructions. Alongside it, `contentType` reports
-   the form: in sanitized modes the extracted type (e.g. `text/markdown`); in raw
-   mode the server's real `Content-Type` header (which may be empty) with
-   `"raw": true`. So downstream consumers always know both *what* they are
-   handling and *that it is untrusted*.
+1. **Default mode**: HTML sanitization (bluemonday allowlist — strips scripts, iframes, event handlers), hidden content removal (display:none, zero-width chars), size enforcement (50KB per source, 300KB total)
+2. **Raw mode** (`mode: "raw"`, `scrape_page` only): Returns the fetched bytes verbatim — scripts, styles, and markup intact — for inspecting source such as JSON, HTML, or JavaScript (code analysis, security research, web development). Only `content.Process` is skipped; the request still passes through `validateScrapeURL`, the SSRF-safe client, the `ALLOWED_DOMAINS` allowlist, and an `io.LimitReader` bounded by `max_length`. The returned content is UNTRUSTED (it may carry indirect prompt-injection payloads), so callers must never execute or render it. `search_and_scrape` has no raw mode and is always sanitized.
+3. **Size limits**: Configurable per-request via `maxLength` parameter. The LLM decides how much content it needs based on context window and task. Defaults protect against context flooding; explicit overrides serve legitimate research needs (analyzing large codebases, full-page audits).
+4. **Trust boundary marker**: every scrape response carries `"trust": "untrusted-external-content"` in the JSON envelope (not inside the `content` string, where a page could forge it) — an explicit signal to treat `content` as data, never as instructions. Alongside it, `contentType` reports the form: in sanitized modes the extracted type (e.g. `text/markdown`); in raw mode the server's real `Content-Type` header (which may be empty) with `"raw": true`. So downstream consumers always know both *what* they are handling and *that it is untrusted*.
 
-The pipeline reduces prompt-injection exposure and context flooding by default,
-while allowing full access to page source when the research task requires it.
-One honest limit: the server **cannot** enforce the prompt boundary itself — the
-model and agent loop live in the host application, so neutralizing plain-text
-injection payloads is the host's job; the server's role is to sanitize, cap, and
-mark provenance so the host can. SSRF protection applies regardless of mode —
-the security boundary is what URLs you can reach, not what content you can read
-from them.
+The pipeline reduces prompt-injection exposure and context flooding by default, while allowing full access to page source when the research task requires it. One honest limit: the server **cannot** enforce the prompt boundary itself — the model and agent loop live in the host application, so neutralizing plain-text injection payloads is the host's job; the server's role is to sanitize, cap, and mark provenance so the host can. SSRF protection applies regardless of mode — the security boundary is what URLs you can reach, not what content you can read from them.
 
 ### Authentication (HTTP mode)
 
@@ -167,30 +124,14 @@ OAuth 2.1 Resource Server pattern:
 - RS256 JWT signature verification via JWKS endpoint
 - Auto-refreshing key cache (configurable interval, default 1 hour)
 - Audience and issuer validation
-- Token revocation via JTI — in-memory by default, optionally backed by the
-  encrypted `persist.Store` so revocations survive restarts (fail-closed: a JTI
-  is revoked if present in either layer)
+- Token revocation via JTI — in-memory by default, optionally backed by the encrypted `persist.Store` so revocations survive restarts (fail-closed: a JTI is revoked if present in either layer)
 - Scope-based per-tool authorization (opt-in via `ENFORCE_SCOPES`; see below)
 - Constant-time comparison for admin key authentication
 - Rejects HS256 from external issuers (algorithm confusion prevention)
 
-**Scope-based authorization (RBAC).** When `ENFORCE_SCOPES=true`, a token that
-carries a `scope`/`scp` claim must hold one of `tool:*`, `tool:<name>`, or the
-coarse `research` scope to invoke a tool (plus any `REQUIRED_SCOPES`). It is
-permissive by design: `ENFORCE_SCOPES=false` (default) ignores scopes, and a
-token with no scope claim is always allowed (backward-compatible). It fails
-closed only on a present-but-insufficient scope. See `Middleware.EnforceScopes`
-in `internal/auth/middleware.go` and the crosswalk in `docs/SECURITY.md`.
+**Scope-based authorization (RBAC).** When `ENFORCE_SCOPES=true`, a token that carries a `scope`/`scp` claim must hold one of `tool:*`, `tool:<name>`, or the coarse `research` scope to invoke a tool (plus any `REQUIRED_SCOPES`). It is permissive by design: `ENFORCE_SCOPES=false` (default) ignores scopes, and a token with no scope claim is always allowed (backward-compatible). It fails closed only on a present-but-insufficient scope. See `Middleware.EnforceScopes` in `internal/auth/middleware.go` and the crosswalk in `docs/SECURITY.md`.
 
-**Session identifiers (accepted risk).** Sequential-search session IDs are
-static UUIDv4 values that do not rotate over the life of a session. This is an
-accepted, documented risk: a session ID is a research-continuity handle, not an
-authentication credential. Authorization is always derived from the validated
-JWT (tenant/user/scope), and sessions are keyed by the compound
-`{tenantID}:{userID}:{sessionID}` so a guessed or leaked session ID cannot cross a tenant
-or user boundary or grant access without a valid token. Rotation was deliberately not
-added to avoid breaking the recovery-after-context-loss workflow the IDs exist
-to support.
+**Session identifiers (accepted risk).** Sequential-search session IDs are static UUIDv4 values that do not rotate over the life of a session. This is an accepted, documented risk: a session ID is a research-continuity handle, not an authentication credential. Authorization is always derived from the validated JWT (tenant/user/scope), and sessions are keyed by the compound `{tenantID}:{userID}:{sessionID}` so a guessed or leaked session ID cannot cross a tenant or user boundary or grant access without a valid token. Rotation was deliberately not added to avoid breaking the recovery-after-context-loss workflow the IDs exist to support.
 
 STDIO mode: no authentication (the calling process is the trust boundary).
 
@@ -243,16 +184,9 @@ All configurable. Returns 429 with `Retry-After` header.
 
 ### Encryption
 
-- **At rest:** AES-256-GCM with random nonces for cache and sessions (when
-  `CACHE_ENCRYPTION_KEY` is set). File permissions 0600.
-- **In transit:** TLS 1.2+ for all outbound connections (Go stdlib default).
-  HSTS header for inbound HTTP.
-- **FIPS option:** Build with `GOFIPS140=latest` for Go's native FIPS 140-3
-  cryptographic module (`crypto/fips140`), backed by active CMVP certificate
-  [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247).
-  `GOEXPERIMENT=boringcrypto` is not the compliant path — BoringCrypto's own
-  certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678),
-  and Go's docs mark that build flag unsupported and slated for removal.
+- **At rest:** AES-256-GCM with random nonces for cache and sessions (when `CACHE_ENCRYPTION_KEY` is set). File permissions 0600.
+- **In transit:** TLS 1.2+ for all outbound connections (Go stdlib default). HSTS header for inbound HTTP.
+- **FIPS option:** Build with `GOFIPS140=latest` for Go's native FIPS 140-3 cryptographic module (`crypto/fips140`), backed by active CMVP certificate [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247). `GOEXPERIMENT=boringcrypto` is not the compliant path — BoringCrypto's own certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678), and Go's docs mark that build flag unsupported and slated for removal.
 
 ### Audit Logging
 
@@ -271,29 +205,11 @@ Every tool invocation produces a structured JSON event:
 }
 ```
 
-Design: async channel-based (never blocks tool calls), swap-to-disk overflow
-(never drops events under normal load), configurable output (stderr or file).
+Design: async channel-based (never blocks tool calls), swap-to-disk overflow (never drops events under normal load), configurable output (stderr or file).
 
-What is NOT logged, ever: raw query text. The query length (an integer) is
-always recorded; when `AUDIT_INCLUDE_REQUEST_BODY=true`, a SHA-256 hash of the
-query is additionally recorded so an operator can correlate repeated queries
-without the literal text ever reaching the audit sink — the literal query is
-never persisted regardless of this flag, so it carries no GDPR erasure gap
-(#486). Scraped content and full request parameters are also never logged
-(PII risk). Audit metadata and upstream error messages pass
-through `audit.MaskSecrets` so any credential echoed back by a provider is
-redacted before it reaches a sink. Audit files rotate at `AUDIT_MAX_BYTES` and
-are pruned after `AUDIT_RETENTION_DAYS` (default 180, clamped to `[180, 3650]`).
+What is NOT logged, ever: raw query text. The query length (an integer) is always recorded; when `AUDIT_INCLUDE_REQUEST_BODY=true`, a SHA-256 hash of the query is additionally recorded so an operator can correlate repeated queries without the literal text ever reaching the audit sink — the literal query is never persisted regardless of this flag, so it carries no GDPR erasure gap (#486). Scraped content and full request parameters are also never logged (PII risk). Audit metadata and upstream error messages pass through `audit.MaskSecrets` so any credential echoed back by a provider is redacted before it reaches a sink. Audit files rotate at `AUDIT_MAX_BYTES` and are pruned after `AUDIT_RETENTION_DAYS` (default 180, clamped to `[180, 3650]`).
 
-**Forwarding to a SIEM or alerting pipeline.** `internal/audit/logger.go` writes
-structured JSON events to disk or stdout only — there is no built-in webhook or
-SIEM sink (see [issue #492](https://github.com/zoharbabin/web-researcher-mcp/issues/492)
-for why: breach-notification pipelines are an enterprise-tier feature gated
-behind paid support in comparable tools, not core OSS). Forward these events
-with a standard log agent instead: point Fluentd, Vector, or a syslog forwarder
-at the configured audit output path (or stdout, if running in a container
-platform that already collects it), and alert on `event_type` and `success`
-fields in your SIEM. No code change is required on this project's side.
+**Forwarding to a SIEM or alerting pipeline.** `internal/audit/logger.go` writes structured JSON events to disk or stdout only — there is no built-in webhook or SIEM sink (see [issue #492](https://github.com/zoharbabin/web-researcher-mcp/issues/492) for why: breach-notification pipelines are an enterprise-tier feature gated behind paid support in comparable tools, not core OSS). Forward these events with a standard log agent instead: point Fluentd, Vector, or a syslog forwarder at the configured audit output path (or stdout, if running in a container platform that already collects it), and alert on `event_type` and `success` fields in your SIEM. No code change is required on this project's side.
 
 ---
 
@@ -320,32 +236,18 @@ The **operator-observability** surfaces added in the routing-observability work 
 Each feature declares its data processing purpose explicitly. Core principles:
 
 - **Primary purpose**: always the user-facing function (search, scrape, analyze)
-- **Legitimate secondary purposes** (when enabled): usage analytics for the
-  user's own benefit, research session memory, trend insights — each opt-in
-  and clearly disclosed
-- **Never allowed**: selling data to third parties, training external models,
-  undisclosed advertising, sharing across tenants without consent
+- **Legitimate secondary purposes** (when enabled): usage analytics for the user's own benefit, research session memory, trend insights — each opt-in and clearly disclosed
+- **Never allowed**: selling data to third parties, training external models, undisclosed advertising, sharing across tenants without consent
 
-When features use data for purposes beyond the immediate request (e.g., a
-search analytics dashboard showing trends over time), they are built with:
-informed activation, transparent data flows, configurable retention, and
-user-controlled deletion.
+When features use data for purposes beyond the immediate request (e.g., a search analytics dashboard showing trends over time), they are built with: informed activation, transparent data flows, configurable retention, and user-controlled deletion.
 
 ### Right to Erasure
 
-For HTTP multi-tenant deployments: the `DELETE /admin/data` endpoint erases
-all personal data for a `(tenant_id, user_id)` subject across every registered
-store (sessions, analytics, memory, workspace) and simultaneously withdraws
-consent so processing cannot silently resume. `GET /admin/data` exports the
-same scope for portability. For STDIO: data is local to your machine — delete
-the cache directory. Any feature that stores data beyond the request lifecycle
-provides a deletion mechanism.
+For HTTP multi-tenant deployments: the `DELETE /admin/data` endpoint erases all personal data for a `(tenant_id, user_id)` subject across every registered store (sessions, analytics, memory, workspace) and simultaneously withdraws consent so processing cannot silently resume. `GET /admin/data` exports the same scope for portability. For STDIO: data is local to your machine — delete the cache directory. Any feature that stores data beyond the request lifecycle provides a deletion mechanism.
 
 ### User Insights Without Surveillance
 
-The project offers features that help you understand your own research
-patterns — which tools you used, how often, and when (opt-in, consent-gated).
-These are designed as **user-owned insights, not profiling**:
+The project offers features that help you understand your own research patterns — which tools you used, how often, and when (opt-in, consent-gated). These are designed as **user-owned insights, not profiling**:
 
 - Data belongs to the user/tenant and is never shared across boundaries
 - The user can view, export, and delete their own data at any time
@@ -354,9 +256,7 @@ These are designed as **user-owned insights, not profiling**:
 - STDIO mode stores everything locally — the user controls their own disk
 - HTTP mode scopes all analytics to the authenticated tenant
 
-The distinction: showing a user "here's what you searched for last month" is
-a productivity feature. Building a hidden model of user behavior to influence
-results without disclosure is profiling. We do the former, never the latter.
+The distinction: showing a user "here's what you searched for last month" is a productivity feature. Building a hidden model of user behavior to influence results without disclosure is profiling. We do the former, never the latter.
 
 ---
 
@@ -364,41 +264,21 @@ results without disclosure is profiling. We do the former, never the latter.
 
 ### STDIO Mode (default, zero-config)
 
-No network listener. No attack surface. The binary communicates via stdin/stdout
-with the calling process. Security is provided by your OS (file permissions,
-process isolation).
+No network listener. No attack surface. The binary communicates via stdin/stdout with the calling process. Security is provided by your OS (file permissions, process isolation).
 
 Suitable for: individual developers, local AI assistants, testing.
 
 ### HTTP Mode (multi-tenant)
 
-Activated by setting `PORT`. Enables OAuth, rate limiting, CORS, and all
-multi-tenant security features.
+Activated by setting `PORT`. Enables OAuth, rate limiting, CORS, and all multi-tenant security features.
 
-**Minimum secure configuration** requires: a port, OAuth issuer and audience for JWKS
-validation, an allowed origins list, an encryption key for the cache and sessions,
-an admin API key, and audit logging enabled with an output path. See
-[`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for exact variable names and defaults.
+**Minimum secure configuration** requires: a port, OAuth issuer and audience for JWKS validation, an allowed origins list, an encryption key for the cache and sessions, an admin API key, and audit logging enabled with an output path. See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for exact variable names and defaults.
 
-**Production hardening** additionally enables per-tenant cache isolation, sets
-rate limits and daily quota, configures a domain allowlist if needed, and adjusts
-scrape concurrency. See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for all variables.
+**Production hardening** additionally enables per-tenant cache isolation, sets rate limits and daily quota, configures a domain allowlist if needed, and adjusts scrape concurrency. See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for all variables.
 
-**Healthcare deployments (HIPAA):** if the server processes or caches content
-containing Protected Health Information (PHI), enable encryption at rest, strict
-per-tenant cache isolation, and audit logging with a retention path sufficient for
-the 6-year HIPAA requirement (45 CFR 164.312(b) requires audit controls; AES-256-GCM
-encryption renders a breach non-reportable under Safe Harbor). See
-[`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for exact variable names and defaults.
+**Healthcare deployments (HIPAA):** if the server processes or caches content containing Protected Health Information (PHI), enable encryption at rest, strict per-tenant cache isolation, and audit logging with a retention path sufficient for the 6-year HIPAA requirement (45 CFR 164.312(b) requires audit controls; AES-256-GCM encryption renders a breach non-reportable under Safe Harbor). See [`docs/DEPLOYMENT.md`](DEPLOYMENT.md) for exact variable names and defaults.
 
-A Business Associate Agreement (BAA) is required between the entity deploying
-this server and any covered entity whose data it processes. The server's
-encryption at rest (AES-256-GCM), encryption in transit (TLS 1.2+), access
-controls (OAuth + tenant isolation), and audit logging satisfy HIPAA Technical
-Safeguards (45 CFR 164.312). The FIPS build option (`GOFIPS140=latest`, Go's
-native FIPS 140-3 module, CMVP certificate
-[#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247))
-satisfies NIST SP 800-111 requirements referenced by HIPAA.
+A Business Associate Agreement (BAA) is required between the entity deploying this server and any covered entity whose data it processes. The server's encryption at rest (AES-256-GCM), encryption in transit (TLS 1.2+), access controls (OAuth + tenant isolation), and audit logging satisfy HIPAA Technical Safeguards (45 CFR 164.312). The FIPS build option (`GOFIPS140=latest`, Go's native FIPS 140-3 module, CMVP certificate [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247)) satisfies NIST SP 800-111 requirements referenced by HIPAA.
 
 ### Container Security
 
@@ -410,25 +290,14 @@ The Docker image ships with full rendering capabilities:
 - Multi-stage build (no build tools in runtime image)
 - All images signed with cosign (verify with `cosign verify`)
 
-The image includes Chromium because accurate research requires rendering
-JavaScript-heavy pages. Chromium is launched with `--no-sandbox`; container-level
-isolation (non-root UID 65534, network policies) provides the sandboxing boundary.
-Chromium's attack surface is mitigated by: non-root execution, bounded concurrency
-(single browser instance shared across goroutines; page concurrency capped by
-MaxBrowserConcurrency, a pool independent of the fast-tier MaxConcurrency, #472),
-SSRF protection on all URLs before they reach the browser, and container-level
-network restrictions.
+The image includes Chromium because accurate research requires rendering JavaScript-heavy pages. Chromium is launched with `--no-sandbox`; container-level isolation (non-root UID 65534, network policies) provides the sandboxing boundary. Chromium's attack surface is mitigated by: non-root execution, bounded concurrency (single browser instance shared across goroutines; page concurrency capped by MaxBrowserConcurrency, a pool independent of the fast-tier MaxConcurrency, #472), SSRF protection on all URLs before they reach the browser, and container-level network restrictions.
 
 Deployment recommendations:
 
 - Mount cache directory as tmpfs or encrypted volume
-- Apply network policies limiting egress to search API endpoints + Chromium
-  download endpoints (for auto-update if enabled)
-- Apply a `seccomp` profile — `RuntimeDefault` is already set in the example
-  manifests (`deploy/k8s-local/03-app.yaml`, `docs/DEPLOYMENT.md`), matching
-  the Kubernetes Pod Security Standards "Restricted" baseline
-- For environments where Chromium is not desired: set `CHROME_PATH=disabled`
-  to skip browser-tier scraping entirely
+- Apply network policies limiting egress to search API endpoints + Chromium download endpoints (for auto-update if enabled)
+- Apply a `seccomp` profile — `RuntimeDefault` is already set in the example manifests (`deploy/k8s-local/03-app.yaml`, `docs/DEPLOYMENT.md`), matching the Kubernetes Pod Security Standards "Restricted" baseline
+- For environments where Chromium is not desired: set `CHROME_PATH=disabled` to skip browser-tier scraping entirely
 
 ---
 
@@ -451,19 +320,11 @@ See `docs/DEPLOYMENT.md` for the table of every variable, its default, and its e
 
 ## Compliance Posture
 
-> **Prefer slides?** The same story — how architecture, not paperwork, keeps
-> this project aligned with 23 standards — is captured in a short visual deck:
-> **[Compliance as Architecture](https://zoharbabin.com/web-researcher-mcp/decks/compliance/)**
-> ([PDF](https://zoharbabin.com/web-researcher-mcp/decks/compliance/compliance-deck.pdf) ·
-> [source](https://github.com/zoharbabin/web-researcher-mcp/blob/main/decks/compliance/compliance-deck.md)).
-> Each technical claim names the file that backs it — open any one and check.
+> **Prefer slides?** The same story — how architecture, not paperwork, keeps this project aligned with 23 standards — is captured in a short visual deck: **[Compliance as Architecture](https://zoharbabin.com/web-researcher-mcp/decks/compliance/)** ([PDF](https://zoharbabin.com/web-researcher-mcp/decks/compliance/compliance-deck.pdf) · [source](https://github.com/zoharbabin/web-researcher-mcp/blob/main/decks/compliance/compliance-deck.md)). Each technical claim names the file that backs it — open any one and check.
 
 ### What We Target
 
-This project is designed to satisfy security and privacy requirements across
-multiple international frameworks simultaneously. We achieve this through
-architectural choices that inherently satisfy shared requirements across
-standards — not through per-framework checkbox exercises.
+This project is designed to satisfy security and privacy requirements across multiple international frameworks simultaneously. We achieve this through architectural choices that inherently satisfy shared requirements across standards — not through per-framework checkbox exercises.
 
 ### Standards Alignment
 
@@ -500,43 +361,21 @@ standards — not through per-framework checkbox exercises.
 
 ### What Compliance Means for This Project
 
-We build compliance into the architecture, not as an afterthought. Our approach
-uses a **tiered compliance model** that scales with capability:
+We build compliance into the architecture, not as an afterthought. Our approach uses a **tiered compliance model** that scales with capability:
 
 **Tier 1 — Core retrieval (always active):**  
-Search, scrape, extract, and return web content. Security controls (SSRF,
-encryption, audit, rate limiting) protect infrastructure. Privacy controls
-(data minimization, TTL caches, no cross-tenant leakage) protect users. This
-tier satisfies the majority of regulatory requirements automatically.
+Search, scrape, extract, and return web content. Security controls (SSRF, encryption, audit, rate limiting) protect infrastructure. Privacy controls (data minimization, TTL caches, no cross-tenant leakage) protect users. This tier satisfies the majority of regulatory requirements automatically.
 
 **Tier 2 — User-facing analytics and insights (when activated):**  
-Search history, topic trends, usage dashboards, session memory. These features
-give users visibility into their own research patterns. Built with: opt-in
-activation, user-owned data, tenant-scoped isolation, configurable retention,
-full deletion capability. Satisfies GDPR legitimate interest (user's own
-benefit) with transparency and control.
+Search history, topic trends, usage dashboards, session memory. These features give users visibility into their own research patterns. Built with: opt-in activation, user-owned data, tenant-scoped isolation, configurable retention, full deletion capability. Satisfies GDPR legitimate interest (user's own benefit) with transparency and control.
 
 **Tier 3 — Machine-formatted output (when activated):**  
-The server does **not** run any LLM or generate prose — synthesis is the client
-model's job (server-side summarization was deliberately not built; see #94).
-The only machine-shaped output is deterministic generative-UI components
-(`GENERATIVE_UI_ENABLED`): source cards and a quality-comparison table built by
-a deterministic transform of already-extracted data, plus consolidated
-bibliographies. Built with: a non-bypassable machine-readable marker
-(`"autoFormatted": true`, label `"mcp-auto-formatted"` — explicitly NOT
-"AI-generated", because no model is involved), source attribution back to the
-raw data, and raw content always present alongside. This transparency posture
-aligns with EU AI Act Art. 50 labeling expectations even though no AI content
-is produced.
+The server does **not** run any LLM or generate prose — synthesis is the client model's job (server-side summarization was deliberately not built; see #94). The only machine-shaped output is deterministic generative-UI components (`GENERATIVE_UI_ENABLED`): source cards and a quality-comparison table built by a deterministic transform of already-extracted data, plus consolidated bibliographies. Built with: a non-bypassable machine-readable marker (`"autoFormatted": true`, label `"mcp-auto-formatted"` — explicitly NOT "AI-generated", because no model is involved), source attribution back to the raw data, and raw content always present alongside. This transparency posture aligns with EU AI Act Art. 50 labeling expectations even though no AI content is produced.
 
 **Tier 4 — Personalization and recommendations (when activated):**  
-Cross-session intelligence, personalized ranking, smart suggestions. Built
-with: explicit consent, explanation capability, opt-out mechanism, bias
-auditing. Satisfies GDPR Art. 22, Quebec Law 25 s.12.1, PIPL Art. 24.
+Cross-session intelligence, personalized ranking, smart suggestions. Built with: explicit consent, explanation capability, opt-out mechanism, bias auditing. Satisfies GDPR Art. 22, Quebec Law 25 s.12.1, PIPL Art. 24.
 
-Each tier adds compliance infrastructure proportional to its regulatory
-exposure. Lower tiers never require higher-tier infrastructure. Features
-always ship with their compliance requirements met — not after.
+Each tier adds compliance infrastructure proportional to its regulatory exposure. Lower tiers never require higher-tier infrastructure. Features always ship with their compliance requirements met — not after.
 
 ### Our Compliance Principles (Evergreen)
 
@@ -544,26 +383,16 @@ These apply regardless of which features are active:
 
 1. **Data belongs to the user/tenant.** Always viewable, exportable, deletable.
 2. **No hidden data flows.** Every processing purpose is disclosed and justified.
-3. **Opt-in for anything beyond the immediate request.** Storing data, analyzing
-   patterns, generating content — each requires explicit activation.
-4. **Proportional controls.** Simple features get simple compliance. Complex
-   features get comprehensive governance. Nothing is over-engineered.
-5. **Compliance infrastructure ships WITH the feature.** Never bolt-on, never
-   "we'll add consent management later."
-6. **Read the code, not the marketing.** Our compliance claims are verifiable
-   in source code. Interfaces, tests, and architecture enforce what docs promise.
+3. **Opt-in for anything beyond the immediate request.** Storing data, analyzing patterns, generating content — each requires explicit activation.
+4. **Proportional controls.** Simple features get simple compliance. Complex features get comprehensive governance. Nothing is over-engineered.
+5. **Compliance infrastructure ships WITH the feature.** Never bolt-on, never "we'll add consent management later."
+6. **Read the code, not the marketing.** Our compliance claims are verifiable in source code. Interfaces, tests, and architecture enforce what docs promise.
 
 ---
 
 ## Operator & Hosted-Service Responsibilities
 
-The tiered model and Compliance Principles above describe the technical controls
-this project **ships**. They are necessary but not sufficient: every framework on
-the Standards Alignment table also has an organizational, process half that a
-source repository cannot contain. **"Aligned with" means this project provides
-the technical controls a standard requires — never that an organization has been
-audited and certified against it.** A binary can't clear a hospital's HIPAA bar;
-it gives that review its technical-controls evidence.
+The tiered model and Compliance Principles above describe the technical controls this project **ships**. They are necessary but not sufficient: every framework on the Standards Alignment table also has an organizational, process half that a source repository cannot contain. **"Aligned with" means this project provides the technical controls a standard requires — never that an organization has been audited and certified against it.** A binary can't clear a hospital's HIPAA bar; it gives that review its technical-controls evidence.
 
 Responsibility splits three ways.
 
@@ -580,35 +409,13 @@ Responsibility splits three ways.
 
 ### To actually reach a given standard, the deploying entity must…
 
-- **SOC 2 Type II** — engage an auditor to observe the shipped controls operating
-  over a 3–12 month period, plus a management assertion. The code supplies the
-  control evidence (OAuth, audit logs, change history); it is not the audited program.
-- **HIPAA** — sign a **Business Associate Agreement** with each covered entity,
-  train its workforce, run a risk analysis, and operate a breach-notification
-  process. The project ships the Technical Safeguards (encryption, audit controls,
-  access controls); the Administrative Safeguards are the operator's.
-- **GDPR / UK GDPR** — name the **data controller**, choose and document a lawful
-  basis, run DPIAs where required, maintain a Record of Processing Activities
-  (Art. 30), and execute 72-hour breach reporting (Art. 33). The project ships the
-  data-subject-rights primitives (access/portability/erasure via `/admin/data`,
-  consent record-verify-honor) — the operator owns the controller obligations.
-- **ISO 27001** — operate an Information Security Management System: documented
-  scope, risk-treatment methodology, Statement of Applicability, internal-audit
-  program, and management review (Clauses 4–10). The project satisfies the
-  relevant Annex A technical controls only.
-- **NYDFS 23 NYCRR 500.11 / NAIC Insurance Data Security Model Law** — a bank or
-  insurer deploying this server must run its own Third-Party Service Provider
-  due-diligence and hold the vendor (this project) to its written information
-  security policy, same shape as a HIPAA BAA or GDPR DPA above. NAIC's Model Law
-  text itself treats NYDFS 500 compliance as satisfying the Model Law, so a
-  covered entity meeting one has effectively met both. The project supplies the
-  technical evidence (encryption, access control, audit logging, vulnerability
-  scanning); the covered entity owns the vendor-oversight program and regulatory
-  filing.
+- **SOC 2 Type II** — engage an auditor to observe the shipped controls operating over a 3–12 month period, plus a management assertion. The code supplies the control evidence (OAuth, audit logs, change history); it is not the audited program.
+- **HIPAA** — sign a **Business Associate Agreement** with each covered entity, train its workforce, run a risk analysis, and operate a breach-notification process. The project ships the Technical Safeguards (encryption, audit controls, access controls); the Administrative Safeguards are the operator's.
+- **GDPR / UK GDPR** — name the **data controller**, choose and document a lawful basis, run DPIAs where required, maintain a Record of Processing Activities (Art. 30), and execute 72-hour breach reporting (Art. 33). The project ships the data-subject-rights primitives (access/portability/erasure via `/admin/data`, consent record-verify-honor) — the operator owns the controller obligations.
+- **ISO 27001** — operate an Information Security Management System: documented scope, risk-treatment methodology, Statement of Applicability, internal-audit program, and management review (Clauses 4–10). The project satisfies the relevant Annex A technical controls only.
+- **NYDFS 23 NYCRR 500.11 / NAIC Insurance Data Security Model Law** — a bank or insurer deploying this server must run its own Third-Party Service Provider due-diligence and hold the vendor (this project) to its written information security policy, same shape as a HIPAA BAA or GDPR DPA above. NAIC's Model Law text itself treats NYDFS 500 compliance as satisfying the Model Law, so a covered entity meeting one has effectively met both. The project supplies the technical evidence (encryption, access control, audit logging, vulnerability scanning); the covered entity owns the vendor-oversight program and regulatory filing.
 
-This split is not a disclaimer — it is the honest shape of "compliance as
-architecture." The repository can make the technical half **provably** true; the
-operating organization owns the process half. Both are required.
+This split is not a disclaimer — it is the honest shape of "compliance as architecture." The repository can make the technical half **provably** true; the operating organization owns the process half. Both are required.
 
 ---
 
@@ -659,9 +466,7 @@ cosign verify ghcr.io/zoharbabin/web-researcher-mcp:latest \
 | cosign | Release artifact signatures | Every release |
 | Syft | SBOM generation | Every release |
 
-`govulncheck`, `gosec`, and `golangci-lint` are pinned as `tool` directives in
-`go.mod`, so CI and local runs (`make verify`) use identical versions. The Go
-toolchain version is pinned in `go.mod`.
+`govulncheck`, `gosec`, and `golangci-lint` are pinned as `tool` directives in `go.mod`, so CI and local runs (`make verify`) use identical versions. The Go toolchain version is pinned in `go.mod`.
 
 ### Dependency Policy
 
@@ -675,53 +480,39 @@ toolchain version is pinned in `go.mod`.
 
 ## Contributor Security Rules
 
-Every contributor (human or AI agent) must follow these rules. They are
-non-negotiable and enforced in code review.
+Every contributor (human or AI agent) must follow these rules. They are non-negotiable and enforced in code review.
 
 ### The Rules
 
 1. **Never introduce OWASP Top 10 vulnerabilities.**  
-   No command injection, XSS, SQL injection, SSRF, path traversal, or
-   insecure deserialization. If unsure whether code is safe, ask.
+   No command injection, XSS, SQL injection, SSRF, path traversal, or insecure deserialization. If unsure whether code is safe, ask.
 
 2. **Validate all external input at system boundaries.**  
-   Tool handler inputs, HTTP request parameters, environment variables,
-   scraped content — validate at the boundary, trust within.
+   Tool handler inputs, HTTP request parameters, environment variables, scraped content — validate at the boundary, trust within.
 
 3. **Never log secrets.**  
-   API keys, tokens, encryption keys, and credentials must never appear in
-   logs, error messages, or audit events. Even in debug mode.
+   API keys, tokens, encryption keys, and credentials must never appear in logs, error messages, or audit events. Even in debug mode.
 
 4. **Errors are values, never panics.**  
-   Return `toolError()` or `upstreamErrorResponse()`. Never `panic()` in
-   production paths. Never expose internal error details to clients.
+   Return `toolError()` or `upstreamErrorResponse()`. Never `panic()` in production paths. Never expose internal error details to clients.
 
 5. **Encrypt sensitive data at rest.**  
-   Any new persistent storage of potentially-sensitive data must use the
-   existing encryption infrastructure (`cache.DiskCache` for cached responses,
-   `persist.DiskStore` for TTL key/value state, or the session store for
-   research sessions — all AES-256-GCM).
+   Any new persistent storage of potentially-sensitive data must use the existing encryption infrastructure (`cache.DiskCache` for cached responses, `persist.DiskStore` for TTL key/value state, or the session store for research sessions — all AES-256-GCM).
 
 6. **Respect tenant boundaries.**  
-   Any new feature touching shared state must consider multi-tenant isolation.
-   Ask: "Can tenant A see tenant B's data?" The answer must be no.
+   Any new feature touching shared state must consider multi-tenant isolation. Ask: "Can tenant A see tenant B's data?" The answer must be no.
 
 7. **Use the SSRF-safe client for all outbound HTTP.**  
-   Never use `http.DefaultClient` or `&http.Client{}` directly for fetching
-   user-specified URLs. Always use `scraper.NewSSRFSafeClient()`.
+   Never use `http.DefaultClient` or `&http.Client{}` directly for fetching user-specified URLs. Always use `scraper.NewSSRFSafeClient()`.
 
 8. **Add annotations to new tools.**  
-   Read tools must declare `readOnlyAnnotations(idempotent, openWorld)`.
-   Write tools (those that mutate server-side state or trigger an external side-effect, e.g. `memory_save`, `workspace_contribute`, `archive_source`) must use `writeAnnotations(idempotent)` instead.
-   The `TestAllToolsHaveAnnotations` test enforces this in CI.
+   Read tools must declare `readOnlyAnnotations(idempotent, openWorld)`. Write tools (those that mutate server-side state or trigger an external side-effect, e.g. `memory_save`, `workspace_contribute`, `archive_source`) must use `writeAnnotations(idempotent)` instead. The `TestAllToolsHaveAnnotations` test enforces this in CI.
 
 9. **Don't accumulate data beyond the request lifecycle.**  
-   New features should not store data indefinitely. Use TTLs. If long-term
-   storage is genuinely needed, it requires explicit opt-in + retention policy.
+   New features should not store data indefinitely. Use TTLs. If long-term storage is genuinely needed, it requires explicit opt-in + retention policy.
 
 10. **Keep the dependency footprint minimal.**  
-    Prefer standard library. Each new dependency is a supply chain risk.
-    Justify in the PR description why stdlib isn't sufficient.
+    Prefer standard library. Each new dependency is a supply chain risk. Justify in the PR description why stdlib isn't sufficient.
 
 ### Security Review Triggers
 
@@ -746,27 +537,19 @@ These changes REQUIRE security-focused code review:
 
 ## AI Agent Coding Rules
 
-When AI coding agents (Claude Code, Copilot, Cursor, etc.) work on this
-codebase, they must follow the contributor rules above PLUS these additional
-constraints:
+When AI coding agents (Claude Code, Copilot, Cursor, etc.) work on this codebase, they must follow the contributor rules above PLUS these additional constraints:
 
 ### Security-First Coding
 
-1. **Never disable security checks** to make tests pass or code compile.
-   Fix the underlying issue instead.
+1. **Never disable security checks** to make tests pass or code compile. Fix the underlying issue instead.
 
-2. **Never use `--no-verify`** on git commits. Pre-commit hooks exist for
-   a reason. If a hook fails, investigate and fix.
+2. **Never use `--no-verify`** on git commits. Pre-commit hooks exist for a reason. If a hook fails, investigate and fix.
 
-3. **Never generate or guess URLs** for fetching unless explicitly instructed.
-   SSRF can be introduced through hardcoded URLs that happen to resolve to
-   internal services.
+3. **Never generate or guess URLs** for fetching unless explicitly instructed. SSRF can be introduced through hardcoded URLs that happen to resolve to internal services.
 
-4. **Never add backdoors, debug endpoints, or admin shortcuts** that bypass
-   authentication or authorization. Even "temporary" ones.
+4. **Never add backdoors, debug endpoints, or admin shortcuts** that bypass authentication or authorization. Even "temporary" ones.
 
-5. **Never commit secrets, API keys, or credentials.** Even example values
-   that look like real keys. Use obviously-fake placeholders: `your-key-here`.
+5. **Never commit secrets, API keys, or credentials.** Even example values that look like real keys. Use obviously-fake placeholders: `your-key-here`.
 
 ### Secure Patterns to Follow
 
@@ -815,8 +598,7 @@ if provided == expected { // timing attack!
 
 ### Reporting
 
-Report security vulnerabilities privately via
-[GitHub Security Advisories](https://github.com/zoharbabin/web-researcher-mcp/security/advisories/new).
+Report security vulnerabilities privately via [GitHub Security Advisories](https://github.com/zoharbabin/web-researcher-mcp/security/advisories/new).
 
 Do not open public issues for security vulnerabilities.
 
@@ -836,8 +618,7 @@ Our vulnerability handling follows the FIRST PSIRT Services Framework:
 4. **Disclose** — coordinated disclosure with reporter, publish advisory
 5. **Learn** — post-mortem, update threat model, improve defenses
 
-All published advisories include: CVSS v4.0 score, affected versions, CWE
-identifier, and mitigation guidance.
+All published advisories include: CVSS v4.0 score, affected versions, CWE identifier, and mitigation guidance.
 
 ### Threat Model References
 
@@ -854,38 +635,16 @@ Our security controls map to MITRE ATT&CK techniques:
 
 ### Operational Incident Response vs. PSIRT
 
-The FIRST PSIRT framework above governs *vulnerability disclosure*: someone
-reports a flaw, we triage and patch it before it's exploited. That is a
-different discipline from *operational incident response* — what an operator
-does when a running deployment is actively compromised, breached, or under
-attack — which NIST SP 800-61r2 defines as four phases: Preparation,
-Detection & Analysis, Containment/Eradication/Recovery, and Post-Incident
-Activity. This project supplies the technical primitives an operator's IR
-runbook (Preparation) draws on for the Containment phase; it does not run
-the runbook itself — same shared-responsibility split as the vendor-oversight
-rows above.
+The FIRST PSIRT framework above governs *vulnerability disclosure*: someone reports a flaw, we triage and patch it before it's exploited. That is a different discipline from *operational incident response* — what an operator does when a running deployment is actively compromised, breached, or under attack — which NIST SP 800-61r2 defines as four phases: Preparation, Detection & Analysis, Containment/Eradication/Recovery, and Post-Incident Activity. This project supplies the technical primitives an operator's IR runbook (Preparation) draws on for the Containment phase; it does not run the runbook itself — same shared-responsibility split as the vendor-oversight rows above.
 
 Concrete containment actions available today, without a code change:
 
-- **Revoke a compromised token or key immediately** — the `persist.Store`-backed
-  JTI revocation list (`internal/auth`) takes effect fleet-wide (Redis-backed) or
-  per-pod (memory-backed) on the next request; rotate `ADMIN_API_KEY` to cut off
-  admin-plane access.
-- **Flush cache and sessions** — the admin cache/session flush endpoints
-  (`internal/server`) let an operator clear potentially-poisoned cached content
-  or a hijacked session without a restart.
-- **Isolate a tenant** — `/admin/data` export/erasure can pull or purge one
-  tenant's stored data (memory, analytics, workspace, sessions) independently of
-  the rest of the fleet.
-- **Correlate the timeline** — `internal/audit`'s structured, request-ID-correlated,
-  secret-redacted JSON events (PodID-tagged for cross-pod correlation) are the raw
-  material for the Detection & Analysis and Post-Incident phases; forward them to
-  a SIEM as described under [Audit Logging](#audit-logging) above.
+- **Revoke a compromised token or key immediately** — the `persist.Store`-backed JTI revocation list (`internal/auth`) takes effect fleet-wide (Redis-backed) or per-pod (memory-backed) on the next request; rotate `ADMIN_API_KEY` to cut off admin-plane access.
+- **Flush cache and sessions** — the admin cache/session flush endpoints (`internal/server`) let an operator clear potentially-poisoned cached content or a hijacked session without a restart.
+- **Isolate a tenant** — `/admin/data` export/erasure can pull or purge one tenant's stored data (memory, analytics, workspace, sessions) independently of the rest of the fleet.
+- **Correlate the timeline** — `internal/audit`'s structured, request-ID-correlated, secret-redacted JSON events (PodID-tagged for cross-pod correlation) are the raw material for the Detection & Analysis and Post-Incident phases; forward them to a SIEM as described under [Audit Logging](#audit-logging) above.
 
-Preparation (an IR plan naming roles and escalation paths) and Post-Incident
-Activity (the retrospective, regulatory breach notification) remain operator-owned,
-same as the incident-response runbook already listed in the
-[shared-responsibility model](#shared-responsibility-model).
+Preparation (an IR plan naming roles and escalation paths) and Post-Incident Activity (the retrospective, regulatory breach notification) remain operator-owned, same as the incident-response runbook already listed in the [shared-responsibility model](#shared-responsibility-model).
 
 ---
 

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -37,7 +37,7 @@ Six rules that govern every design decision:
    A developer running `go build && ./web-researcher-mcp` should not need to configure OAuth, encryption keys, or compliance profiles. An enterprise deploying for 10,000 users should have everything they need.
 
 6. **Elegant code is secure code.**  
-   Short, readable, well-tested functions are easier to audit and harder to exploit than clever abstractions. Prefer Go's standard library over third- party dependencies. One clear implementation over pluggable frameworks.
+   Short, readable, well-tested functions are easier to audit and harder to exploit than clever abstractions. Prefer Go's standard library over third-party dependencies. One clear implementation over pluggable frameworks.
 
 ---
 

--- a/docs/SECURITY_AND_COMPLIANCE.md
+++ b/docs/SECURITY_AND_COMPLIANCE.md
@@ -222,6 +222,13 @@ Token stolen (log leak, XSS, proxy compromise)    Client signs a one-time proof 
 
 A resource-server-only architecture cannot retrofit the right-hand side unilaterally — `cnf.jkt` can only be embedded by the issuing IdP at mint time. Research into current standards and the MCP ecosystem (tracked on [issue #489](https://github.com/zoharbabin/web-researcher-mcp/issues/489)) found DPoP is recommended-but-optional (RFC 9700/BCP 240), unevenly supported across IdPs (GA at Auth0/Okta/Ping/Curity; absent at AWS Cognito), still a proposal rather than a ratified requirement in the MCP spec itself, and not named by FedRAMP, DoD Zero Trust guidance, NIST 800-63B, or HIPAA's Security Rule. The realistic threat — stolen-bearer-token replay — is mitigated today via short-lived tokens, JTI revocation that survives restarts, per-tenant rate limiting, circuit breakers, and secret-redacted, request-correlated audit logging.
 
+**Design choice: mesh/ingress-terminated mTLS, not application-native.** For service-to-service traffic (the HTTP admin plane, and the Redis connection in `internal/redisbackend`), this server relies on the surrounding infrastructure to terminate mutual TLS rather than implementing a TLS client-cert handshake in application code. This is a deliberate architectural choice, not a gap deferred for later:
+
+- **No standard surveyed requires application-native mTLS.** NIST SP 800-207 (Zero Trust Architecture) is technology-neutral by design; its cloud-native companion, SP 800-207A, explicitly names sidecar/service-mesh-terminated mTLS as a compliant Zero Trust enforcement pattern. PCI-DSS v4.0.1 Requirement 4, SOC 2's CC6.1/CC6.6/CC6.7, ISO/IEC 27001:2022 Annex A 8.20/8.24, and NIST SP 800-53 Rev 5 (SC-8, SC-13, SC-23) are all written as control outcomes — "protect transmitted information," "use strong cryptography" — and are silent on which component in the stack performs the cryptographic handshake. The one control that textually resembles mTLS, NIST 800-53's IA-3(1) ("cryptographically based bidirectional authentication"), is an optional enhancement selected per impact baseline, not a universal requirement.
+- **This mirrors mainstream practice, not a compromise.** Google's BeyondProd architecture terminates mTLS-equivalent trust at the infrastructure layer specifically so "individual microservice developers aren't burdened with implementing" it. CNCF's 2024 survey puts service-mesh adoption at 42% of respondents — infra-terminated mTLS (mesh sidecar, gateway, or platform-provisioned identity) is the dominant pattern at scale, not an exception auditors tolerate reluctantly.
+- **What an audit actually checks is the control outcome, not the binary.** Auditors evaluating internal-traffic mutual authentication push back on an undocumented or incorrectly-scoped trust boundary — not on the absence of native TLS code in the application process. A documented answer of "our service mesh/ingress terminates mTLS at trust-zone boundary X, backed by cert issuance/rotation policy Y" satisfies every framework above as thoroughly as native code would.
+- **The one real gap: bare-VM / non-mesh deployments.** Where there is no sidecar or gateway to terminate mTLS (a plain VM outside Kubernetes), the standards-consistent answer is still not to build cert provisioning/rotation/revocation into this binary — it is to place a lightweight local TLS-terminating proxy in front of it, or adopt SPIFFE/SPIRE workload identity (which explicitly supports VM and bare-metal workloads via node/workload attestation, issuing short-lived X.509-SVIDs a local agent consumes). This keeps cert lifecycle management out of the application's own code, consistent with every other pattern surveyed here. Tracked on [issue #485](https://github.com/zoharbabin/web-researcher-mcp/issues/485).
+
 ### Rate Limiting (HTTP mode)
 
 Three tiers preventing abuse while allowing legitimate high-throughput research:
@@ -240,8 +247,12 @@ All configurable. Returns 429 with `Retry-After` header.
   `CACHE_ENCRYPTION_KEY` is set). File permissions 0600.
 - **In transit:** TLS 1.2+ for all outbound connections (Go stdlib default).
   HSTS header for inbound HTTP.
-- **FIPS option:** Build with `GOEXPERIMENT=boringcrypto` for FIPS 140-2
-  validated cryptographic module.
+- **FIPS option:** Build with `GOFIPS140=latest` for Go's native FIPS 140-3
+  cryptographic module (`crypto/fips140`), backed by active CMVP certificate
+  [#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247).
+  `GOEXPERIMENT=boringcrypto` is not the compliant path — BoringCrypto's own
+  certificate is [Historical](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/3678),
+  and Go's docs mark that build flag unsupported and slated for removal.
 
 ### Audit Logging
 
@@ -273,6 +284,16 @@ never persisted regardless of this flag, so it carries no GDPR erasure gap
 through `audit.MaskSecrets` so any credential echoed back by a provider is
 redacted before it reaches a sink. Audit files rotate at `AUDIT_MAX_BYTES` and
 are pruned after `AUDIT_RETENTION_DAYS` (default 180, clamped to `[180, 3650]`).
+
+**Forwarding to a SIEM or alerting pipeline.** `internal/audit/logger.go` writes
+structured JSON events to disk or stdout only — there is no built-in webhook or
+SIEM sink (see [issue #492](https://github.com/zoharbabin/web-researcher-mcp/issues/492)
+for why: breach-notification pipelines are an enterprise-tier feature gated
+behind paid support in comparable tools, not core OSS). Forward these events
+with a standard log agent instead: point Fluentd, Vector, or a syslog forwarder
+at the configured audit output path (or stdout, if running in a container
+platform that already collects it), and alert on `event_type` and `success`
+fields in your SIEM. No code change is required on this project's side.
 
 ---
 
@@ -374,7 +395,9 @@ A Business Associate Agreement (BAA) is required between the entity deploying
 this server and any covered entity whose data it processes. The server's
 encryption at rest (AES-256-GCM), encryption in transit (TLS 1.2+), access
 controls (OAuth + tenant isolation), and audit logging satisfy HIPAA Technical
-Safeguards (45 CFR 164.312). The FIPS build option (`GOEXPERIMENT=boringcrypto`)
+Safeguards (45 CFR 164.312). The FIPS build option (`GOFIPS140=latest`, Go's
+native FIPS 140-3 module, CMVP certificate
+[#5247](https://csrc.nist.gov/projects/cryptographic-module-validation-program/certificate/5247))
 satisfies NIST SP 800-111 requirements referenced by HIPAA.
 
 ### Container Security
@@ -401,7 +424,9 @@ Deployment recommendations:
 - Mount cache directory as tmpfs or encrypted volume
 - Apply network policies limiting egress to search API endpoints + Chromium
   download endpoints (for auto-update if enabled)
-- Consider seccomp profile (see `deploy/` directory when available)
+- Apply a `seccomp` profile — `RuntimeDefault` is already set in the example
+  manifests (`deploy/k8s-local/03-app.yaml`, `docs/DEPLOYMENT.md`), matching
+  the Kubernetes Pod Security Standards "Restricted" baseline
 - For environments where Chromium is not desired: set `CHROME_PATH=disabled`
   to skip browser-tier scraping entirely
 
@@ -448,6 +473,7 @@ standards — not through per-framework checkbox exercises.
 | **SOC 2 Type II** | Enterprise trust | Audit logging, rate limiting, tenant isolation, change management |
 | **NIST CSF 2.0** | US enterprise | Govern/Identify/Protect/Detect/Respond/Recover mapped to controls |
 | **GDPR / UK GDPR** | Privacy | Data minimization, purpose limitation, TTL caches; data-subject access/portability/erasure endpoints (`/admin/data`); consent record-verify-honor for regulated features |
+| **LGPD (Brazil) / PIPEDA (Canada) / DPDP Act (India) / POPIA (South Africa) / APPI (Japan) / PDPA (Singapore) / Privacy Act (Australia) / PIPL (China)** | Global privacy — **operator-owned, same shape as GDPR** | Each law's processor/intermediary-equivalent role has narrower direct statutory duties than its controller-equivalent, but every one of those duties (security safeguards, retention limitation, breach-notification support) maps to controls this project already ships (AES-256-GCM encryption, TTL caches, audit logging, `/admin/data` erasure). Cross-border-transfer mechanics and controller/processor role assignment remain the deploying entity's to configure, exactly as with GDPR above |
 | **OWASP MCP Cheat Sheet** | MCP-specific | SSRF protection, content sanitization, tool annotations, supply chain |
 | **OWASP Top 10 LLM (2025)** | AI security | Prompt injection defense, bounded agency, supply chain verification |
 | **OWASP Agentic Top 10 (2026 draft)** | AI agent security — **tool-provider slice only** | What this server owns: read-only-default tool annotations (writes non-destructive; deletion is a separate endpoint), JWT scope authorization, consent-gated + tenant-isolated + erasable memory/workspace, SSRF + HTML sanitization + untrusted-content marker, rate limits + circuit breakers + size caps, per-call audit with request-ID correlation. **Host-owned (not us):** goal/intent manipulation, cascading hallucination, multi-agent trust, the agent permission model — those live in the client that drives the tools. |
@@ -456,17 +482,21 @@ standards — not through per-framework checkbox exercises.
 | **EU Cyber Resilience Act** | Software supply chain | SBOM, signed releases, vulnerability handling, PSIRT, 5yr updates |
 | **NIS2** | EU critical infrastructure | Incident handling, supply chain, crypto, vulnerability management |
 | **FedRAMP** | US government | FIPS crypto option, access control, audit, vulnerability scanning |
-| **UK Cyber Essentials** | UK market access | Boundary protection, secure config, access control, patching |
+| **UK Cyber Essentials** | UK market access — **operator-owned** | This scheme certifies an organization's IT estate (device config, patching, access control), not an OSS artifact. There is no organization or IT estate here to certify. An operator seeking Cyber Essentials certifies their own deployment, using this project's boundary protection, secure config, access control, and patching as supporting evidence |
 | **UK NCSC CAF v4.0** | UK critical infra | 14-principle cyber assessment (covers AI risks) |
 | **BSIMM** | Security maturity | Code review, SAST, SCA, architecture analysis, vulnerability mgmt |
 | **HIPAA** | US healthcare | Encryption (AES-256), audit controls, access controls, BAA support, breach notification |
+| **NYDFS 23 NYCRR 500 / NAIC Insurance Data Security Model Law** | US financial/insurance — **operator-owned** | Both regulate the covered bank/insurer's Third-Party Service Provider oversight program, not an OSS artifact directly. This project supplies the technical evidence (encryption, access control, audit logging, vulnerability scanning) a covered entity cites in its own vendor risk assessment |
 | **HITRUST CSF** | Healthcare + cross-industry | Maps to 40+ frameworks; combined SOC 2 + HITRUST assessment |
 | **FIRST PSIRT** | Vulnerability handling | Structured triage, remediation, and disclosure for CVEs |
 | **MITRE ATT&CK** | Threat modeling | Security controls mapped to adversary techniques |
-| **Global CBPR** | Cross-border privacy | Data transfer certification for APAC/Americas markets |
+| **Global CBPR** | Cross-border privacy — **operator-owned** | This scheme certifies a business's cross-border data transfer program (APAC/Americas), not an OSS artifact. This project has no cross-border data-transfer business to certify. An operator seeking CBPR certifies their own deployment/data flows, using this project's data minimization and purpose-limitation controls as supporting evidence |
 | **IETF RFC 9700/9449** | OAuth security | Best current practice + DPoP proof-of-possession |
 | **CSA MCP Security Framework** | MCP hardening | Provenance, runtime isolation, secrets, observability |
 | **NSA MCP Security Guidance** | Government/military | Message signing, per-call scoping, trust chains |
+| **ISO 22301** | Business continuity — **operator-owned** | This standard certifies an organization's Business Continuity Management System (leadership commitment, BIA, exercise program), not an OSS artifact. This project's stateless/HPA architecture and Redis-durability options give an operator's BIA strong RTO/RPO inputs — see [Recovery objectives](DEPLOYMENT.md#recovery-objectives-rtorpo) — but the BCMS itself is the operator's |
+| **EU DORA** | EU financial-sector ICT risk — **out of scope unless hosted as SaaS** | DORA (Reg. (EU) 2022/2554) governs a financial entity's relationship with an "undertaking providing ICT services" it procures from. Self-hosting this OSS binary isn't procuring ICT services any more than self-hosting Postgres is. It attaches only if a *hosted SaaS* offering of this project sells to EU financial entities — then that SaaS operator owns Art. 28-44 obligations, the same split as the SOC 2/HIPAA rows above |
+| **ISO/IEC 42001** | AI management system — **operator-owned** | This standard certifies an organization's AI Management System (governance, risk treatment, lifecycle controls across AI-related roles), not an OSS artifact. This project is closest to an AI-system component supplier feeding an operator's own AIMS — same shared-responsibility shape as ISO 27001/UK Cyber Essentials above; it supplies technical evidence (transparency, risk-aware design, audit trails), not the management system itself |
 
 ### What Compliance Means for This Project
 
@@ -566,6 +596,15 @@ Responsibility splits three ways.
   scope, risk-treatment methodology, Statement of Applicability, internal-audit
   program, and management review (Clauses 4–10). The project satisfies the
   relevant Annex A technical controls only.
+- **NYDFS 23 NYCRR 500.11 / NAIC Insurance Data Security Model Law** — a bank or
+  insurer deploying this server must run its own Third-Party Service Provider
+  due-diligence and hold the vendor (this project) to its written information
+  security policy, same shape as a HIPAA BAA or GDPR DPA above. NAIC's Model Law
+  text itself treats NYDFS 500 compliance as satisfying the Model Law, so a
+  covered entity meeting one has effectively met both. The project supplies the
+  technical evidence (encryption, access control, audit logging, vulnerability
+  scanning); the covered entity owns the vendor-oversight program and regulatory
+  filing.
 
 This split is not a disclaimer — it is the honest shape of "compliance as
 architecture." The repository can make the technical half **provably** true; the
@@ -813,11 +852,46 @@ Our security controls map to MITRE ATT&CK techniques:
 | Auth/JWKS | T1078 (Valid Accounts), T1550 (Use Alternate Auth Material) |
 | Audit logging | T1070 (Indicator Removal) — structured, secret-redacted, request-ID-correlated events (incl. auth failures) aid detection & attribution. Note: logs are append-only JSON, not cryptographically tamper-evident. |
 
+### Operational Incident Response vs. PSIRT
+
+The FIRST PSIRT framework above governs *vulnerability disclosure*: someone
+reports a flaw, we triage and patch it before it's exploited. That is a
+different discipline from *operational incident response* — what an operator
+does when a running deployment is actively compromised, breached, or under
+attack — which NIST SP 800-61r2 defines as four phases: Preparation,
+Detection & Analysis, Containment/Eradication/Recovery, and Post-Incident
+Activity. This project supplies the technical primitives an operator's IR
+runbook (Preparation) draws on for the Containment phase; it does not run
+the runbook itself — same shared-responsibility split as the vendor-oversight
+rows above.
+
+Concrete containment actions available today, without a code change:
+
+- **Revoke a compromised token or key immediately** — the `persist.Store`-backed
+  JTI revocation list (`internal/auth`) takes effect fleet-wide (Redis-backed) or
+  per-pod (memory-backed) on the next request; rotate `ADMIN_API_KEY` to cut off
+  admin-plane access.
+- **Flush cache and sessions** — the admin cache/session flush endpoints
+  (`internal/server`) let an operator clear potentially-poisoned cached content
+  or a hijacked session without a restart.
+- **Isolate a tenant** — `/admin/data` export/erasure can pull or purge one
+  tenant's stored data (memory, analytics, workspace, sessions) independently of
+  the rest of the fleet.
+- **Correlate the timeline** — `internal/audit`'s structured, request-ID-correlated,
+  secret-redacted JSON events (PodID-tagged for cross-pod correlation) are the raw
+  material for the Detection & Analysis and Post-Incident phases; forward them to
+  a SIEM as described under [Audit Logging](#audit-logging) above.
+
+Preparation (an IR plan naming roles and escalation paths) and Post-Incident
+Activity (the retrospective, regulatory breach notification) remain operator-owned,
+same as the incident-response runbook already listed in the
+[shared-responsibility model](#shared-responsibility-model).
+
 ---
 
 ## Current Limitations
 
-- **Native mTLS for service-to-service traffic** — the server does not implement mutual-TLS client-cert authentication itself, for either the HTTP admin plane or the Redis connection (`internal/redisbackend`); connections are encrypted in transit (`REDIS_URL` supports `rediss://`, and the HTTP server can run behind TLS) but not mutually authenticated at the application layer. Deployments requiring mTLS today should terminate it at a surrounding service mesh or ingress.
+- **Native mTLS for service-to-service traffic** — the server does not implement mutual-TLS client-cert authentication itself, for either the HTTP admin plane or the Redis connection (`internal/redisbackend`); connections are encrypted in transit (`REDIS_URL` supports `rediss://`, and the HTTP server can run behind TLS) but not mutually authenticated at the application layer. This is a deliberate design choice, not a deferred gap — see [Authentication (HTTP mode)](#authentication-http-mode) for the standards research behind it. Deployments requiring mTLS today should terminate it at a surrounding service mesh or ingress; bare-VM/non-mesh deployments should use a local TLS-terminating proxy or SPIFFE/SPIRE workload identity instead of native in-binary cert handling. Status tracked on [issue #485](https://github.com/zoharbabin/web-researcher-mcp/issues/485).
 - **No DPoP / sender-constrained tokens** — the server validates bearer tokens only; it does not check a `cnf.jkt` proof-of-possession claim, because embedding that claim is the issuing IdP's responsibility and no supported IdP integration currently requires it. Stolen-bearer-token replay is mitigated via short token TTLs, JTI-based revocation, per-tenant rate limiting, and audit logging (see the design-choice discussion under [Authentication (HTTP mode)](#authentication-http-mode)). Status tracked on [issue #489](https://github.com/zoharbabin/web-researcher-mcp/issues/489).
 
 ### Multi-tenant shared Kubernetes clusters


### PR DESCRIPTION
## Summary
- Switches the FIPS build flag from `GOEXPERIMENT=boringcrypto` to `GOFIPS140=latest` (Go's native FIPS 140-3 module, active CMVP cert #5247) — BoringCrypto's own certificate moved to Historical status and the build tag is slated for removal.
- Documents the mesh/ingress-terminated mTLS design choice already resolved as by-design on #485, and the roadmap cleanup already resolved on #492 (seccomp `RuntimeDefault`, breach-notification-via-log-forwarding, several compliance frameworks reframed as operator-owned).
- Adds a "Recovery objectives (RTO/RPO)" subsection to `docs/DEPLOYMENT.md` and an "Operational Incident Response vs. PSIRT" section to `docs/SECURITY_AND_COMPLIANCE.md`.

## Test plan
- [x] `GOFIPS140=latest CGO_ENABLED=0 go build ./cmd/web-researcher-mcp` builds clean
- [x] Docs-only + Makefile change; no code paths touched
- [x] Cross-checked new doc content against closed issues #485 and #492 for accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)