### PR TITLE
fix(scripts): resolve rebuild-local's install path via PATH lookup for bare command names

### DIFF
--- a/scripts/rebuild-local.sh
+++ b/scripts/rebuild-local.sh
@@ -88,11 +88,23 @@ default_cache_dir() {
 # claude_json_install_path reads the exact binary path Claude Code's own MCP
 # config points at (~/.claude.json's mcpServers.web-researcher.command). This
 # is the authoritative "this is what Claude Code loads" source when present.
+# The config commonly stores a bare command name (e.g. "web-researcher-mcp",
+# resolved via $PATH at launch, such as a pyenv shim) rather than an absolute
+# path — resolve it the same way the shell would, via `command -v`. Without
+# this, a bare name gets treated as a literal path relative to $REPO_ROOT
+# (this script's cwd), colliding with the just-built binary sitting right
+# there and deleting it out from under the subsequent `cp`.
 claude_json_install_path() {
   local cfg="$HOME/.claude.json"
   [ -f "$cfg" ] || return 1
   command -v jq >/dev/null 2>&1 || return 1
-  jq -er '.mcpServers["web-researcher"].command // empty' "$cfg" 2>/dev/null
+  local raw
+  raw="$(jq -er '.mcpServers["web-researcher"].command // empty' "$cfg" 2>/dev/null)" || return 1
+  [ -n "$raw" ] || return 1
+  case "$raw" in
+    /*) printf '%s\n' "$raw" ;;
+    *)  command -v "$raw" 2>/dev/null ;;
+  esac
 }
 
 # discover_install_targets prints "<path>\t<source>" lines: the ~/.claude.json


### PR DESCRIPTION
## Summary

`~/.claude.json`'s `mcpServers.web-researcher.command` field commonly stores a bare command name (e.g. `web-researcher-mcp`, resolved via `$PATH` at launch — such as a pyenv shim) rather than an absolute path. `scripts/rebuild-local.sh` treated that value as a literal filesystem path relative to the repo root, colliding with the just-built binary sitting there and deleting it out from under the subsequent `cp`.

`claude_json_install_path()` now resolves a bare name via `command -v`, matching how the shell itself would resolve it, and passes absolute paths through unchanged.

## Test plan

- [x] `bash -n scripts/rebuild-local.sh` — syntax check passes
- [x] Manually exercised via `/rebuild-local` against a pyenv-shim-configured `~/.claude.json` — binary installs to the correct shim path, no self-deletion

🤖 Generated with [Claude Code](https://claude.com/claude-code)