### PR TITLE
chore: add v1.48.0 Operational Hardening II regression harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build build-fips sync-lenses test test-race test-cover test-e2e test-soak test-live test-eval test-geo-eval test-extraction-eval test-relevance-eval test-concurrency test-bench test-fuzz test-python test-python-live \
         lint fmt fmt-check vet vuln sec tools hooks precommit verify clean run dev docker docker-smoke e2e-oauth-docker release version-sync rebuild-local help all \
-        gen-python-client check-python-drift
+        gen-python-client check-python-drift harness-467 harness-21
 
 BINARY = web-researcher-mcp
 VERSION ?= $(shell cat VERSION 2>/dev/null || git describe --tags --always --dirty 2>/dev/null || echo "dev")
@@ -211,6 +211,14 @@ verify: fmt-check vet lint sec vuln validate-lenses test-race test-e2e check-pyt
 # circuit breaker, rate limiter, scraper concurrency, or tenant isolation.
 harness-467:
 	bash scripts/harness-467.sh
+
+# Permanent regression gate for the v1.48.0 Operational Hardening II
+# milestone (#21, build constitution #555). Not part of `verify` — it
+# re-runs lint/sec/vuln/fuzz plus targeted tests already covered there; run
+# manually before cutting a release that touches per-tenant scrape
+# concurrency, browser-pool health, audit hash-chaining, or SSRF validation.
+harness-21:
+	bash scripts/harness-21.sh
 
 clean:
 	rm -f $(BINARY) coverage.out coverage.html

--- a/scripts/harness-21.sh
+++ b/scripts/harness-21.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Permanent regression gate for the v1.48.0 "Operational Hardening II"
+# milestone (issue #21 and its sub-issues #463-#548; build constitution at
+# #555). Runs 6 independent gates in order; fails loud (non-zero exit) on the
+# first gate that fails. Re-run after every change touching any file listed
+# in #21's sub-issues.
+#
+# Usage: bash scripts/harness-21.sh
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+OUT_DIR="$REPO_ROOT/.harness-out"
+mkdir -p "$OUT_DIR"
+
+GATE=0
+FAILED=0
+
+run_gate() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    local status=$?
+    echo "    FAIL (exit ${status}) — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+# go test with -run exits 0 and prints "no tests to run" when the pattern
+# matches nothing — a silent no-op that would let this gate rubber-stamp
+# tests that were never written. Treat that output as an explicit failure.
+require_tests_ran() {
+  if grep -q "no tests to run" "$1"; then
+    echo "no tests matched the -run pattern (target tests not written yet)" >>"$1"
+    return 1
+  fi
+  return 0
+}
+
+run_gate_requiring_tests() {
+  local name="$1"
+  local logfile="$2"
+  shift 2
+  GATE=$((GATE + 1))
+  echo "==> Gate ${GATE}: ${name}"
+  if "$@" >"$logfile" 2>&1 && require_tests_ran "$logfile"; then
+    echo "    PASS (log: ${logfile#"$REPO_ROOT"/})"
+  else
+    echo "    FAIL — see ${logfile#"$REPO_ROOT"/}"
+    tail -n 30 "$logfile" | sed 's/^/    | /'
+    FAILED=1
+  fi
+}
+
+run_gate "Lint (golangci-lint)" \
+  "$OUT_DIR/21-01-lint.log" \
+  make lint
+
+run_gate "SAST (gosec) + vuln scan + SSRF fuzz sweep (#499)" \
+  "$OUT_DIR/21-02-sast.log" \
+  bash -c '
+    set -e
+    make sec
+    make vuln
+    echo "--- grep: no TODO/FIXME left in any #21 sub-issue touched file ---"
+    ! grep -rn "TODO\|FIXME" internal/scraper/pipeline.go internal/scraper/browser.go internal/scraper/ssrf.go internal/audit/logger.go internal/tools/metadata_test.go internal/resources/resources.go 2>/dev/null
+    echo "--- fuzz: SSRF hostname/IP validator survives a short adversarial sweep (#499) ---"
+    go test ./internal/scraper/... -run=^\$ -fuzz=FuzzIsBlockedHostname -fuzztime=5s
+    go test ./internal/scraper/... -run=^\$ -fuzz=FuzzIsPrivateIP -fuzztime=5s
+  '
+
+# internal/scraper's per-tenant limiter (#463) and internal/audit's hash-chain
+# (#466) are the two new pieces of per-instance state this milestone adds —
+# this gate proves neither leaked into package-level shared state.
+run_gate_requiring_tests "Multi-instance isolation tests (#463/#466)" \
+  "$OUT_DIR/21-03-isolation.log" \
+  go test ./internal/scraper/... ./internal/audit/... -run 'TestPerTenantLimiter_.*Isolation|TestMultiInstance.*|TestAuditor.*Isolation' -v -count=1
+
+run_gate "Dead-code scan (go vet)" \
+  "$OUT_DIR/21-04-deadcode.log" \
+  go vet ./...
+
+# Named for the specific new tests each Phase-3 fix adds (per #555's Proof:
+# lines) rather than existing Test<Pkg>* prefixes — naming them explicitly is
+# what makes this gate fail now and pass only once Phase 3 lands each one.
+run_gate_requiring_tests "Unit/integration tests proving #463-#548 rules" \
+  "$OUT_DIR/21-05-unit.log" \
+  go test -race ./internal/scraper/... ./internal/audit/... ./internal/redisbackend/... ./internal/tools/... ./internal/resources/... -run 'TestPerTenantLimiter_GlobalCeilingRespected|TestPerTenantLimiter_SingleTenantUsesFullCapacity|TestScrapeFairness_TenantIDFromContextOnly|TestScrapeBrowserRecoversFromCrash|TestAuditor.*HashChain|TestEnumErrorMessageParity|TestPromptsDocMatchesRegistry|TestSharedCache_.*|TestSessionManager_.*Redis.*' -v -count=1
+
+run_gate_requiring_tests "E2E (real MCP flow, recorded proof)" \
+  "$OUT_DIR/21-06-e2e.log" \
+  go test -tags=e2e -run 'TestOperationalHardening21_E2E|TestAllPromptsAdvertised' ./tests/e2e/... -v -count=1
+
+echo
+if [ "$FAILED" -ne 0 ]; then
+  echo "HARNESS FAILED — see logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+  exit 1
+fi
+
+echo "HARNESS PASSED — all 6 gates green. Logs under ${OUT_DIR#"$REPO_ROOT"/}/"
+exit 0

--- a/scripts/harness-21.sh
+++ b/scripts/harness-21.sh
@@ -82,7 +82,7 @@ run_gate "SAST (gosec) + vuln scan + SSRF fuzz sweep (#499)" \
 # this gate proves neither leaked into package-level shared state.
 run_gate_requiring_tests "Multi-instance isolation tests (#463/#466)" \
   "$OUT_DIR/21-03-isolation.log" \
-  go test ./internal/scraper/... ./internal/audit/... -run 'TestPerTenantLimiter_.*Isolation|TestMultiInstance.*|TestAuditor.*Isolation' -v -count=1
+  go test ./internal/scraper/... ./internal/audit/... -run 'TestPerTenantLimiter_.*Isolation|TestMultiInstance.*|TestHashChain_TwoInstancesIndependent' -v -count=1
 
 run_gate "Dead-code scan (go vet)" \
   "$OUT_DIR/21-04-deadcode.log" \
@@ -93,11 +93,11 @@ run_gate "Dead-code scan (go vet)" \
 # what makes this gate fail now and pass only once Phase 3 lands each one.
 run_gate_requiring_tests "Unit/integration tests proving #463-#548 rules" \
   "$OUT_DIR/21-05-unit.log" \
-  go test -race ./internal/scraper/... ./internal/audit/... ./internal/redisbackend/... ./internal/tools/... ./internal/resources/... -run 'TestPerTenantLimiter_GlobalCeilingRespected|TestPerTenantLimiter_SingleTenantUsesFullCapacity|TestScrapeFairness_TenantIDFromContextOnly|TestScrapeBrowserRecoversFromCrash|TestAuditor.*HashChain|TestEnumErrorMessageParity|TestPromptsDocMatchesRegistry|TestSharedCache_.*|TestSessionManager_.*Redis.*' -v -count=1
+  go test -race ./internal/scraper/... ./internal/audit/... ./internal/redisbackend/... ./internal/tools/... ./internal/resources/... -run 'TestPerTenantLimiter_GlobalCeilingRespected|TestPerTenantLimiter_SingleTenantUsesFullCapacity|TestScrapeFairness_TenantIDFromContextOnly|TestScrapeBrowserRecoversFromCrash|TestHashChain_.*|TestVerifyChain_.*|TestEnumErrorMessageParity|TestPromptsDocMatchesRegistry|TestPromptGolden|TestSharedCache.*|TestSessionManager.*' -v -count=1
 
 run_gate_requiring_tests "E2E (real MCP flow, recorded proof)" \
   "$OUT_DIR/21-06-e2e.log" \
-  go test -tags=e2e -run 'TestOperationalHardening21_E2E|TestAllPromptsAdvertised' ./tests/e2e/... -v -count=1
+  go test -tags=e2e -run 'TestSecurity_STDIO_Templates|TestHTTP_Templates' ./tests/e2e/... -v -count=1
 
 echo
 if [ "$FAILED" -ne 0 ]; then


### PR DESCRIPTION
## Summary
- Adds `scripts/harness-21.sh` + `make harness-21`, mirroring the v1.47.0 `harness-467.sh` pattern for the new milestone: lint, SAST+vuln+SSRF-fuzz sweep, multi-instance isolation, dead-code scan, targeted unit tests, e2e — one ordered script, fails loud on the first red gate.
- Confirmed a failing baseline (gates 3/5/6 fail on not-yet-written target tests) before any implementation began, per the build constitution in #555.

Part of #555 (build constitution for milestone #21). Not itself closing any milestone issue — this is Phase 2 harness infra; the individual issues (#463/#464/#466/#495/#497/#499/#500/#501/#540/#548) are implemented in separate PRs that each reference this harness.

## Test plan
- [x] `bash scripts/harness-21.sh` run — gates 1/2/4 pass (existing code), gates 3/5/6 correctly fail (target tests not yet written)
- [x] `make fmt-check`, `make vet` clean