### PR TITLE
ci: add OpenSSF Scorecard workflow + README badge

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,50 @@
+name: 🔒 OpenSSF Scorecard
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    - cron: "0 6 * * 1" # Every Monday at 06:00 UTC — matches Dependabot + CodeQL cadence
+
+# Declared at the job level below per Scorecard's workflow restrictions when
+# publish_results is true (see https://github.com/ossf/scorecard-action#workflow-restrictions):
+# no top-level env/defaults, no workflow-level write permissions.
+permissions: read-all
+
+jobs:
+  # ── 🔒 OpenSSF Scorecard ────────────────────────────────────────────────────
+  # Runs the OpenSSF Scorecard supply-chain-security check suite and publishes
+  # results to the public API (scorecard.dev) so the badge in README.md stays
+  # live, plus uploads SARIF to Security → Code scanning.
+  analyze:
+    name: 🔒 Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Required to upload SARIF results to code scanning
+      security-events: write
+      # Required to publish results to the public Scorecard API (Sigstore OIDC)
+      id-token: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code-scanning
+        uses: github/codeql-action/upload-sarif@v4.37.4
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@
 <p align="center">
   <a href="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml"><img src="https://github.com/zoharbabin/web-researcher-mcp/actions/workflows/ci.yml/badge.svg" height="20" alt="CI"></a>
   <a href="https://goreportcard.com/report/github.com/zoharbabin/web-researcher-mcp"><img src="https://goreportcard.com/badge/github.com/zoharbabin/web-researcher-mcp" height="20" alt="Go Report Card"></a>
+  <a href="https://scorecard.dev/viewer/?uri=github.com/zoharbabin/web-researcher-mcp"><img src="https://api.scorecard.dev/projects/github.com/zoharbabin/web-researcher-mcp/badge" height="20" alt="OpenSSF Scorecard"></a>
   <a href="https://pkg.go.dev/github.com/zoharbabin/web-researcher-mcp"><img src="https://pkg.go.dev/badge/github.com/zoharbabin/web-researcher-mcp.svg" height="20" alt="Go Reference"></a>
   <a href="https://opensource.org/licenses/MIT"><img src="https://img.shields.io/badge/License-MIT-yellow.svg" height="20" alt="License: MIT"></a>
   <a href="https://github.com/zoharbabin/web-researcher-mcp/releases"><img src="https://img.shields.io/github/v/release/zoharbabin/web-researcher-mcp" height="20" alt="Release"></a>


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/scorecard.yml` running the `ossf/scorecard-action` on a weekly schedule (Monday 06:00 UTC, matching Dependabot's and CodeQL's existing cadence) plus on push to `main`, with `publish_results: true` so the score is externally queryable via the public Scorecard API, and a SARIF upload step (`github/codeql-action/upload-sarif`) so findings also surface in the repo's Security tab.
- Adds the OpenSSF Scorecard badge to `README.md`, next to the existing CI/Go Report Card badges, linking to `scorecard.dev`'s viewer for this repo.

Closes #501

## Notes / deviations from the issue text
- The issue's proposed config mentions a `branch_protection_rules: read` permission key. That key doesn't exist in GitHub Actions' `permissions:` schema (valid scopes: `actions`, `attestations`, `checks`, `contents`, `deployments`, `discussions`, `id-token`, `issues`, `metadata`, `packages`, `pages`, `pull-requests`, `repository-projects`, `security-events`, `statuses`, `vulnerability-alerts`, etc. — no `branch_protection_rules` or `administration`). I fetched the actual canonical workflow from `ossf/scorecard`'s own repo (`.github/workflows/scorecard-analysis.yml`) and matched it exactly: top-level `permissions: read-all`, job-level `security-events: write` + `id-token: write` only. Branch-Protection check visibility for *classic* branch protection rules is instead controlled by an optional fine-grained PAT (`repo_token` input) per Scorecard's own docs — out of scope here per the issue's own scope-limiting language (this repo's branch rules can be picked up by the default `GITHUB_TOKEN` if they're GitHub's newer Repository Rules; if not, a follow-up PAT can be added later).
- Used the current canonical badge domain `api.scorecard.dev` (and viewer `scorecard.dev`) rather than the older `api.securityscorecards.dev` the issue mentions — I verified live that the old domain still 302-redirects to the same badge, but `ossf/scorecard-action`'s own current README documents `api.scorecard.dev` as the primary pattern, so I matched that.
- Did not touch SHA-pinning of Actions or fuzzing config, per the issue's explicit scope exclusions.

## Limitation
This cannot be verified end-to-end in this sandbox — Scorecard needs to run against the real public GitHub repo with live access to `api.scorecard.dev`/Sigstore OIDC. The actual score and whether `publish_results` succeeds can only be confirmed once this workflow runs for real on GitHub's infrastructure after merge.

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/scorecard.yml'))"` — valid YAML
- [x] `make fmt-check` — passes (no Go changes)
- [x] `git diff --stat` — only `.github/workflows/scorecard.yml` (new) and `README.md` touched
- [ ] Confirm the workflow actually runs and publishes a score post-merge (cannot be done pre-merge/in-sandbox)