### PR TITLE
fix(ci): pin ossf/scorecard-action to a real release tag

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -31,7 +31,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.4
         with:
           results_file: results.sarif
           results_format: sarif


### PR DESCRIPTION
## Summary
- The Scorecard workflow (added in #557) pins `ossf/scorecard-action@v2`, a tag that doesn't exist upstream — only fully-qualified `vX.Y.Z` tags are published. Every push to `main` has been failing this workflow since it was added.
- Pins to `v2.4.4`, the latest release.

## Test plan
- [x] YAML parses (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Scorecard workflow run on `main` after merge reports success