### PR TITLE
fix(release): address Chocolatey moderation guideline gaps

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -299,18 +299,21 @@ chocolateys:
   - name: web-researcher-mcp
     title: "Web Researcher MCP"
     authors: "Zohar Babin"
+    owners: "Zohar Babin"
     project_url: "https://github.com/zoharbabin/web-researcher-mcp"
     license_url: "https://github.com/zoharbabin/web-researcher-mcp/blob/main/LICENSE"
     project_source_url: "https://github.com/zoharbabin/web-researcher-mcp"
+    package_source_url: "https://github.com/zoharbabin/web-researcher-mcp/blob/main/.goreleaser.yml"
     docs_url: "https://github.com/zoharbabin/web-researcher-mcp/blob/main/README.md"
     bug_tracker_url: "https://github.com/zoharbabin/web-researcher-mcp/issues"
-    icon_url: "https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/assets/logo.png"
+    icon_url: "https://raw.githubusercontent.com/zoharbabin/web-researcher-mcp/main/assets/logo-final-512.png"
     copyright: "2026 Zohar Babin"
     summary: "Your AI research assistant that cites real sources and stays honest"
     description: |
       Web Researcher MCP is an MCP server that gives AI assistants web search,
       content extraction, academic / patent / SEC-filing / case-law / economic
       data lookup, and multi-step research — with real, verifiable citations.
+    release_notes: "https://github.com/zoharbabin/web-researcher-mcp/releases/tag/v{{ .Version }}"
     tags: "mcp ai research search web-scraping cli"
     require_license_acceptance: false
     source_repo: "https://push.chocolatey.org/"


### PR DESCRIPTION
## Summary
- Chocolatey's automated review on the v1.48.0 submission flagged 3 Guideline gaps (non-blocking, but reduce package quality) and 1 human-review Note.
- Adds `owners` (matches `authors`, per the Note), `package_source_url`, and `release_notes` (templated link to the GitHub release page) to the `chocolateys` block.
- Fixes `icon_url`, which 404s today — it points at `assets/logo.png`, which doesn't exist in this repo. Switched to `assets/logo-final-512.png`, which does (verified 200 via raw.githubusercontent.com).

## Test plan
- [x] `goreleaser check` passes (pre-existing unrelated deprecation warnings only)
- [x] YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"`
- [x] Verified `assets/logo-final-512.png` returns 200 from raw.githubusercontent.com; confirmed `assets/logo.png` 404s
- [ ] Next release will show these fields correctly in the generated nuspec on Chocolatey's package page

🤖 Generated with [Claude Code](https://claude.com/claude-code)