### PR TITLE
feat: add SerpBase (Google) search engine via REST API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,6 +23,7 @@ GOOGLE_CUSTOM_SEARCH_ID=your-search-engine-id
 # Optional: return extra_snippets (up to 5 additional snippets per result, uses more tokens). Default: false.
 # BRAVE_EXTRA_SNIPPETS=false
 # SERPER_API_KEY=...
+# SERPBASE_API_KEY=...  # SerpBase Google Search API (serpbase.dev); 100 free searches, then $0.30/1k queries
 # SEARCHAPI_API_KEY=...
 # TAVILY_API_KEY=tvly-...   # search API built for AI agents; clean LLM-ready content (get from app.tavily.com)
 # EXA_API_KEY=...           # neural/semantic search; paid per call (get from dashboard.exa.ai).

--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Set `SEARCH_PROVIDER=<name>` and supply that provider's key. Every provider work
 | Google PSE | `google` | `GOOGLE_CUSTOM_SEARCH_API_KEY` + `GOOGLE_CUSTOM_SEARCH_ID` | [cloud console](https://console.cloud.google.com/) + [engine](https://programmablesearchengine.google.com/) |
 | Brave | `brave` | `BRAVE_API_KEY` | [brave.com/search/api](https://brave.com/search/api/) |
 | Serper | `serper` | `SERPER_API_KEY` | [serper.dev](https://serper.dev/) |
+| SerpBase | `serpbase` | `SERPBASE_API_KEY` | [serpbase.dev](https://serpbase.dev/) |
 | SearchAPI.io | `searchapi` | `SEARCHAPI_API_KEY` | [searchapi.io](https://www.searchapi.io/) |
 | SearXNG | `searxng` | `SEARXNG_URL` | [self-hosted](https://docs.searxng.org/) |
 | Tavily | `tavily` | `TAVILY_API_KEY` | [app.tavily.com](https://app.tavily.com/) |

--- a/docs/API_SETUP.md
+++ b/docs/API_SETUP.md
@@ -164,6 +164,34 @@ export SERPER_API_KEY=your-serper-key
 
 ---
 
+## SerpBase
+
+**Free tier**: 100 free searches (no credit card), then pay-as-you-go at $0.30 / 1,000 queries
+
+SerpBase is a Google Search Results API — it returns Google organic results (plus AI Overviews when the SERP has them) as JSON, no browser and no scraping. It supports web search only; image and news queries fall through to another provider when `SEARCH_ROUTING` is enabled.
+
+### Step 1: Get an API Key
+
+1. Go to [SerpBase.dev](https://serpbase.dev/)
+2. Sign up for an account (100 free searches, no credit card required)
+3. Copy the API key from your dashboard
+4. The key is sent as an `X-API-Key` header (never in the request body)
+
+### Step 2: Configure
+
+```bash
+export SERPBASE_API_KEY=your-serpbase-key
+```
+
+To use SerpBase as your primary provider:
+
+```bash
+export SEARCH_PROVIDER=serpbase
+export SERPBASE_API_KEY=your-serpbase-key
+```
+
+---
+
 ## Tavily
 
 **Free tier**: monthly credits for development; paid plans for higher volume

--- a/docs/PROVIDERS.md
+++ b/docs/PROVIDERS.md
@@ -35,6 +35,7 @@ Understanding what backs each provider helps you reason about result overlap and
 | **[DuckDuckGo](https://duckduckgo.com/)** | Bing-sourced | Microsoft Bing (+ Bing-syndicated sources) |
 | **[Google PSE](https://programmablesearchengine.google.com/)** | Own index | Google's web index |
 | **[Serper](https://serper.dev/)** | Google-backed | Google's web index via API |
+| **[SerpBase](https://serpbase.dev/)** | Google-backed | Google's web index via API |
 | **[SearchAPI.io](https://www.searchapi.io/)** | Google-backed | Google's web index via API |
 | **[Brave](https://brave.com/search/api/)** | Own independent | Brave's own web crawler and index |
 | **[Exa](https://exa.ai/)** | Own independent | Neural/embedding-based web index |
@@ -45,7 +46,7 @@ Understanding what backs each provider helps you reason about result overlap and
 | **[Bluesky](https://bsky.app/)** | Niche | AT Protocol AppView (`public.api.bsky.app`) — Bluesky posts only |
 | **[GitHub](https://docs.github.com/en/rest/search/search)** | Niche | GitHub REST Search API — issues and pull requests only |
 
-**Practical implication**: Google PSE, Serper, and SearchAPI.io draw from the same index — using more than one adds no coverage, only redundancy. Brave and Exa bring genuinely independent results. Tavily and SearXNG aggregate results from others rather than crawling themselves.
+**Practical implication**: Google PSE, Serper, SerpBase, and SearchAPI.io draw from the same index — using more than one adds no coverage, only redundancy. Brave and Exa bring genuinely independent results. Tavily and SearXNG aggregate results from others rather than crawling themselves.
 
 ---
 
@@ -58,6 +59,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 | **[DuckDuckGo](https://duckduckgo.com/)** | ✓ | ✓ | ✓ | — | — |
 | **[Google PSE](https://programmablesearchengine.google.com/)** | ✓ | ✓ | ✓ | — | — |
 | **[Serper](https://serper.dev/)** | ✓ | ✓ | ✓ | — | — |
+| **[SerpBase](https://serpbase.dev/)** | ✓ | — | — | — | — |
 | **[SearchAPI.io](https://www.searchapi.io/)** | ✓ | ✓ | ✓ | — | — |
 | **[Brave](https://brave.com/search/api/)** | ✓ | ✓ | ✓ | ✓ | — |
 | **[Exa](https://exa.ai/)** | ✓ | — | ✓ | — | ✓ (paid, last-resort) |
@@ -89,6 +91,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 | **[Google PSE](https://programmablesearchengine.google.com/)** | 100 queries/day | $5 / 1,000 queries |
 | **[Brave](https://brave.com/search/api/)** | 2,000 queries/month | Paid plans |
 | **[Serper](https://serper.dev/)** | 2,500 queries (one-time) | Paid plans |
+| **[SerpBase](https://serpbase.dev/)** | 100 searches (free, no card) | $0.30 / 1,000 queries, pay-as-you-go |
 | **[SearchAPI.io](https://www.searchapi.io/)** | 100 searches/month | Paid plans |
 | **[Exa](https://exa.ai/)** | 1,000 requests/month | Per call beyond free tier |
 | **[Tavily](https://app.tavily.com/)** | Monthly dev credits | Paid plans |
@@ -105,6 +108,7 @@ Which tools each web search provider enables. `—` means the provider returns e
 | Independent results alongside Google | [Brave](https://brave.com/search/api/) or [Exa](https://exa.ai/) (different indices, no overlap) |
 | Semantic / conceptual search | [Exa](https://exa.ai/) |
 | LLM-ready extracted content | [Tavily](https://app.tavily.com/) |
+| Pay-as-you-go Google results, no subscription | [SerpBase](https://serpbase.dev/) |
 | Air-gapped or no vendor lock-in | [SearXNG](https://docs.searxng.org/) (self-hosted) |
 | Tech/developer community signal | [HackerNews](https://hn.algolia.com/) |
 | Reddit / community discussion signal | [Reddit](https://www.reddit.com/) |
@@ -121,6 +125,8 @@ Which tools each web search provider enables. `—` means the provider returns e
 **[Google PSE](https://programmablesearchengine.google.com/)** — The largest index. Best for broadest coverage, image search, and exact-phrase queries. Requires both an API key (via [Google Cloud Console](https://console.cloud.google.com/)) and a Programmable Search Engine ID. Free tier of 100/day is low for sustained use.
 
 **[Serper](https://serper.dev/) and [SearchAPI.io](https://www.searchapi.io/)** — Google results without the PSE setup overhead. Serper is the simpler option; SearchAPI.io supports multiple engine backends beyond Google. Both draw from Google — no coverage difference between them or vs. Google PSE.
+
+**[SerpBase](https://serpbase.dev/)** — Google organic results (plus AI Overviews when the SERP has them) as JSON, via a POST API keyed with `X-API-Key`. No subscription: pay-as-you-go at $0.30 / 1,000 queries with 100 free searches on signup (no credit card). Web search only — image/news queries fall through to another provider when routing is enabled. Same Google index as PSE/Serper/SearchAPI.io, so use it as a routing member for cost or key-rotation reasons rather than for index diversity.
 
 **[Brave](https://brave.com/search/api/)** — Own crawler, own index, privacy-first. Best all-purpose choice when you want index independence from Google/Bing and a generous free tier. Supports web, image, news, and Goggles-based custom result weighting. Also exposes local/map results via `local_search` (the only provider that does) and a LLM context endpoint used by `search_and_scrape` for faster grounding when you're on Brave's Data for AI plan.
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -148,6 +148,7 @@ type SearchConfig struct {
 	BraveAPIKey        string
 	BraveExtraSnippets bool
 	SerperAPIKey       string
+	SerpBaseAPIKey     string
 	SearchAPIKey       string
 	TavilyAPIKey       string
 	ExaAPIKey          string
@@ -286,6 +287,11 @@ func Load() (*Config, error) {
 	serperKey := os.Getenv("SERPER_API_KEY")
 	if provider == "serper" && serperKey == "" {
 		errs = append(errs, "SERPER_API_KEY is required when SEARCH_PROVIDER=serper")
+	}
+
+	serpbaseKey := os.Getenv("SERPBASE_API_KEY")
+	if provider == "serpbase" && serpbaseKey == "" {
+		errs = append(errs, "SERPBASE_API_KEY is required when SEARCH_PROVIDER=serpbase")
 	}
 
 	searxngURL := os.Getenv("SEARXNG_URL")
@@ -436,6 +442,7 @@ func Load() (*Config, error) {
 			BraveAPIKey:           braveKey,
 			BraveExtraSnippets:    braveExtraSnippets,
 			SerperAPIKey:          serperKey,
+			SerpBaseAPIKey:        serpbaseKey,
 			SearchAPIKey:          searchAPIKey,
 			TavilyAPIKey:          tavilyKey,
 			ExaAPIKey:             exaKey,

--- a/internal/search/provider.go
+++ b/internal/search/provider.go
@@ -164,7 +164,7 @@ type Deps struct {
 }
 
 // SupportedProviders lists all provider names that can be configured.
-var SupportedProviders = []string{"google", "brave", "serper", "searxng", "searchapi", "duckduckgo", "tavily", "exa", "hackernews", "reddit", "bluesky", "github"}
+var SupportedProviders = []string{"google", "brave", "serper", "serpbase", "searxng", "searchapi", "duckduckgo", "tavily", "exa", "hackernews", "reddit", "bluesky", "github"}
 
 func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 	switch cfg.Provider {
@@ -172,6 +172,8 @@ func NewProvider(cfg config.SearchConfig, deps Deps) Provider {
 		return NewBraveProvider(cfg.BraveAPIKey, BraveConfig{ExtraSnippets: cfg.BraveExtraSnippets}, deps)
 	case "serper":
 		return NewSerperProvider(cfg.SerperAPIKey, deps)
+	case "serpbase":
+		return NewSerpBaseProvider(cfg.SerpBaseAPIKey, deps)
 	case "searxng":
 		return NewSearXNGProvider(cfg.SearXNGURL, cfg.SearXNGBasicAuth, cfg.SearXNGHeaders, deps)
 	case "searchapi":
@@ -213,6 +215,10 @@ func NewProviderByName(name string, cfg config.SearchConfig, deps Deps) Provider
 	case "serper":
 		if cfg.SerperAPIKey != "" {
 			return NewSerperProvider(cfg.SerperAPIKey, deps)
+		}
+	case "serpbase":
+		if cfg.SerpBaseAPIKey != "" {
+			return NewSerpBaseProvider(cfg.SerpBaseAPIKey, deps)
 		}
 	case "searxng":
 		if cfg.SearXNGURL != "" {

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -56,6 +56,14 @@ func TestNewProvider_Serper(t *testing.T) {
 	}
 }
 
+func TestNewProvider_SerpBase(t *testing.T) {
+	cfg := config.SearchConfig{Provider: "serpbase", SerpBaseAPIKey: "key"}
+	p := NewProvider(cfg, newTestDeps(http.DefaultClient))
+	if p.Name() != "serpbase" {
+		t.Errorf("expected provider name 'serpbase', got %q", p.Name())
+	}
+}
+
 func TestNewProvider_SearXNG(t *testing.T) {
 	cfg := config.SearchConfig{Provider: "searxng", SearXNGURL: "http://localhost:8080"}
 	p := NewProvider(cfg, newTestDeps(http.DefaultClient))

--- a/internal/search/serpbase.go
+++ b/internal/search/serpbase.go
@@ -1,0 +1,137 @@
+package search
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+// SerpBaseProvider implements the SerpBase Google Search API
+// (https://serpbase.dev) — Google organic results (plus AI Overviews when the
+// SERP has them) as JSON, no browser and no scraping. SerpBase uses a POST
+// JSON contract with the key in the X-API-Key header; the response envelope
+// is {"status": 0, "organic": [...]} where status != 0 is a business error
+// (the API returns HTTP 200 with a non-zero status for request-level
+// failures). Web search only: the API has no image/news endpoints, so Images
+// and News return (nil, nil) and Router fallback handles those operations.
+type SerpBaseProvider struct {
+	apiKey  string
+	baseURL string
+	deps    Deps
+}
+
+func NewSerpBaseProvider(apiKey string, deps Deps) *SerpBaseProvider {
+	return &SerpBaseProvider{
+		apiKey:  apiKey,
+		baseURL: "https://api.serpbase.dev/google/search",
+		deps:    deps,
+	}
+}
+
+// SetBaseURL overrides the API base URL (testing).
+func (p *SerpBaseProvider) SetBaseURL(base string) { p.baseURL = base }
+
+func (p *SerpBaseProvider) Name() string { return "serpbase" }
+
+func (p *SerpBaseProvider) Web(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	var results []SearchResult
+	err := p.deps.Breaker.Execute(func() error {
+		var e error
+		results, e = p.doWebSearch(ctx, params)
+		return e
+	})
+	return results, err
+}
+
+func (p *SerpBaseProvider) Images(ctx context.Context, params ImageSearchParams) ([]ImageResult, error) {
+	return nil, nil // no image endpoint; Router fallback handles image queries
+}
+
+func (p *SerpBaseProvider) News(ctx context.Context, params NewsSearchParams) ([]NewsResult, error) {
+	return nil, nil // no news endpoint; Router fallback handles news queries
+}
+
+func (p *SerpBaseProvider) doWebSearch(ctx context.Context, params WebSearchParams) ([]SearchResult, error) {
+	body := map[string]any{
+		"q":   buildQuery(params),
+		"num": clamp(params.NumResults, 1, 10),
+	}
+	if params.Country != "" {
+		body["gl"] = params.Country
+	}
+	if params.Language != "" {
+		body["hl"] = params.Language
+	}
+
+	respBody, err := p.doRequest(ctx, body)
+	if err != nil {
+		return nil, err
+	}
+
+	var resp serpBaseResponse
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return nil, fmt.Errorf("failed to parse serpbase response: %w", err)
+	}
+	if resp.Status != 0 {
+		return nil, fmt.Errorf("serpbase API error: status=%d message=%q", resp.Status, resp.Message)
+	}
+
+	var results []SearchResult
+	for _, r := range resp.Organic {
+		results = append(results, SearchResult{
+			Title:       r.Title,
+			URL:         r.Link,
+			Snippet:     r.Snippet,
+			DisplayLink: r.DisplayLink,
+		})
+	}
+	return results, nil
+}
+
+func (p *SerpBaseProvider) doRequest(ctx context.Context, payload map[string]any) ([]byte, error) {
+	jsonBody, err := json.Marshal(payload)
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "POST", p.baseURL, bytes.NewReader(jsonBody))
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-API-Key", p.apiKey)
+
+	resp, err := p.deps.HTTPClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode == 429 {
+		return nil, fmt.Errorf("serpbase: rate limited: %w", circuit.ErrRateLimit)
+	}
+	if resp.StatusCode >= 400 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return nil, fmt.Errorf("serpbase API error %d: %s", resp.StatusCode, string(body))
+	}
+
+	return io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+}
+
+type serpBaseResponse struct {
+	Status  int    `json:"status"`
+	Message string `json:"message,omitempty"`
+	Organic []struct {
+		Title       string `json:"title"`
+		Link        string `json:"link"`
+		URL         string `json:"url"`
+		DisplayLink string `json:"display_link"`
+		Snippet     string `json:"snippet"`
+	} `json:"organic"`
+}

--- a/internal/search/serpbase_test.go
+++ b/internal/search/serpbase_test.go
@@ -1,0 +1,132 @@
+package search
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+func newSerpBaseTestDeps() Deps {
+	return Deps{
+		HTTPClient: http.DefaultClient,
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5, ResetTimeout: 60}),
+	}
+}
+
+// newSerpBaseTestServer returns a SerpBase provider wired to a test server
+// that asserts the X-API-Key header and returns the given status+body.
+func newSerpBaseTestServer(t *testing.T, handler http.HandlerFunc) (*SerpBaseProvider, *httptest.Server) {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	p := NewSerpBaseProvider("test-key", newSerpBaseTestDeps())
+	p.SetBaseURL(srv.URL)
+	return p, srv
+}
+
+func TestSerpBaseWebSearch(t *testing.T) {
+	var gotBody map[string]any
+	p, _ := newSerpBaseTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("want POST, got %s", r.Method)
+		}
+		if r.Header.Get("X-API-Key") != "test-key" {
+			t.Errorf("missing/wrong X-API-Key header: %q", r.Header.Get("X-API-Key"))
+		}
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		_, _ = w.Write([]byte(`{
+			"status": 0,
+			"request_id": "req_abc",
+			"organic": [
+				{"rank": 1, "title": "First", "link": "https://a.example/x", "display_link": "a.example", "snippet": "first snippet"},
+				{"rank": 2, "title": "Second", "link": "https://b.example/y", "display_link": "b.example", "snippet": "second snippet"}
+			]
+		}`))
+	})
+
+	results, err := p.Web(context.Background(), WebSearchParams{Query: "golang", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(results) != 2 {
+		t.Fatalf("want 2 results, got %d", len(results))
+	}
+	if gotBody["q"] != "golang" {
+		t.Errorf("request body q = %v, want golang", gotBody["q"])
+	}
+	if gotBody["num"] != float64(5) {
+		t.Errorf("request body num = %v, want 5", gotBody["num"])
+	}
+	if results[0].Title != "First" || results[0].URL != "https://a.example/x" || results[0].Snippet != "first snippet" {
+		t.Errorf("unexpected first result: %+v", results[0])
+	}
+	if results[1].DisplayLink != "b.example" {
+		t.Errorf("unexpected displayLink: %q", results[1].DisplayLink)
+	}
+}
+
+func TestSerpBaseWebSearchCountryLanguage(t *testing.T) {
+	var gotBody map[string]any
+	p, _ := newSerpBaseTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		_ = json.Unmarshal(body, &gotBody)
+		_, _ = w.Write([]byte(`{"status": 0, "organic": []}`))
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "x", NumResults: 3, Country: "DE", Language: "de"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotBody["gl"] != "DE" || gotBody["hl"] != "de" {
+		t.Errorf("expected gl=DE hl=de, got gl=%v hl=%v", gotBody["gl"], gotBody["hl"])
+	}
+}
+
+func TestSerpBaseWebSearchErrorEnvelope(t *testing.T) {
+	// SerpBase returns HTTP 200 with a non-zero status for business errors.
+	p, _ := newSerpBaseTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"status": 1, "message": "invalid query"}`))
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "x", NumResults: 5})
+	if err == nil {
+		t.Fatal("want error for non-zero status envelope, got nil")
+	}
+	if !strings.Contains(err.Error(), "status=1") {
+		t.Errorf("error should surface envelope status, got %v", err)
+	}
+}
+
+func TestSerpBaseRateLimit(t *testing.T) {
+	p, _ := newSerpBaseTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "x", NumResults: 5})
+	if !errors.Is(err, circuit.ErrRateLimit) {
+		t.Errorf("want circuit.ErrRateLimit, got %v", err)
+	}
+}
+
+func TestSerpBaseImagesNewsNoop(t *testing.T) {
+	p, _ := newSerpBaseTestServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Error("noop capability must not hit the network")
+	})
+
+	imgs, err := p.Images(context.Background(), ImageSearchParams{Query: "x"})
+	if err != nil || imgs != nil {
+		t.Errorf("Images should return (nil, nil), got (%v, %v)", imgs, err)
+	}
+	news, err := p.News(context.Background(), NewsSearchParams{Query: "x"})
+	if err != nil || news != nil {
+		t.Errorf("News should return (nil, nil), got (%v, %v)", news, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds **SerpBase** (https://serpbase.dev) as a web search provider — Google organic results (plus AI Overviews when the SERP has them) as JSON, no browser, no scraping. SerpBase slots in alongside the existing Google-backed providers (Serper, SearchAPI.io) with the same POST + `X-API-Key` contract pattern as `serper.go`.

## Background

The provider set already covers Google via Serper, SearchAPI.io, and Google PSE, but all three require subscriptions or cloud-console setup. SerpBase is pay-as-you-go ($0.30/1k queries, 100 free searches on signup, no credit card), which makes it a useful routing member for cost-sensitive or key-rotation scenarios — same index, no coverage difference, which is exactly why the docs frame it as a routing choice rather than an independent index.

## Changes

- **New**: `internal/search/serpbase.go` — provider mirroring the Serper adapter (POST JSON body, `X-API-Key` header, 429 → `circuit.ErrRateLimit`). SerpBase's envelope is `{"status": 0, "organic": [...]}` where a non-zero `status` is a business error returned as HTTP 200 — the adapter surfaces that as a Go error. Web search only: `Images`/`News` return `(nil, nil)` so the Router's capability fallback keeps working (same no-op pattern as Exa/Tavily).
- **Updated**: `internal/search/provider.go` — `serpbase` registered in `SupportedProviders`, `NewProvider`, and `NewProviderByName` (key-gated).
- **Updated**: `internal/config/config.go` — `SERPBASE_API_KEY` env var, `SearchConfig.SerpBaseAPIKey`, and required-key validation when `SEARCH_PROVIDER=serpbase`.
- **New**: `internal/search/serpbase_test.go` — httptest coverage: header/body assertions, country/language params, business-error envelope (HTTP 200 + `status != 0`), rate limit, and noop capabilities.
- **Updated**: `internal/search/search_test.go` — `TestNewProvider_SerpBase` factory test.
- **Docs**: README provider table, `docs/PROVIDERS.md` (index classification, capability matrix, free tier, quick-pick, provider notes), `docs/API_SETUP.md` (setup section), `.env.example`.

## Design decisions

| Decision | Rationale |
|----------|-----------|
| API key via `SERPBASE_API_KEY` env var | Follows the existing `SERPER_API_KEY` / `SEARCHAPI_API_KEY` convention |
| POST JSON + `X-API-Key` header | SerpBase's actual API contract (POST-only; GET + query-param key is outdated) |
| `SetBaseURL` for tests | Same pattern as `ExaProvider`; Serper hardcodes its URL, but the package already supports overridable base URLs |
| Business-error envelope → Go error | SerpBase returns HTTP 200 with `status != 0` on request failures; silently returning `[]` would hide quota/query errors |
| `Images`/`News` return `(nil, nil)` | SerpBase has no image/news endpoints; the no-op pattern is what the `Provider` interface documents for missing capabilities (Router fallback, no breaker trips) |
| `q`/`num`/`gl`/`hl` request fields | Mirrors the Serper adapter's mapping of `WebSearchParams` |

## Testing

- `go build ./...` — clean
- `go vet ./...` — clean
- `go test ./internal/search/ ./internal/config/` — pass (6 new SerpBase tests included)
- `go test ./internal/tools/ -run 'Provider|WebSearch|Meta|Enum|Search'` — pass
- Graceful degradation: when `SERPBASE_API_KEY` is unset, `NewProviderByName` returns nil and routing skips the provider — no crash, other providers unaffected
- Note: `TestBrandResearchNXDomainSubdomainNotAccepted` in `internal/tools` fails in this sandbox due to a wildcard DNS resolver (verified identical failure on pristine `main`); unrelated to this change
- Python client: `make gen-python-client` run; no drift (provider enum is not part of the generated client schema)

## Related

- No existing SerpBase references in code or issues (dedup verified before writing)
