### PR TITLE
fix(deps): bump Go toolchain to 1.25.13

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Check formatting (gofmt -s)
@@ -145,7 +145,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
       - name: Verify tool docs/annotations match the registry
         run: |
@@ -165,7 +165,7 @@ jobs:
       - uses: actions/checkout@v7
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
       - uses: actions/setup-python@v7
         with:
@@ -207,7 +207,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - uses: actions/setup-node@v7
@@ -334,7 +334,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.25.12"]
+        go-version: ["1.25.13"]
     steps:
       - uses: actions/checkout@v7
 
@@ -347,7 +347,7 @@ jobs:
         run: go test -race -coverprofile=coverage.out -covermode=atomic -count=1 ./...
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.25.12'
+        if: matrix.go-version == '1.25.13'
         uses: codecov/codecov-action@v7
         with:
           files: ./coverage.out
@@ -357,7 +357,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact
-        if: matrix.go-version == '1.25.12'
+        if: matrix.go-version == '1.25.13'
         uses: actions/upload-artifact@v7
         with:
           name: coverage
@@ -378,7 +378,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Run fuzz targets (20s each)
@@ -417,7 +417,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       # The -run alternation MUST match the test name prefixes (TestHTTP_/TestOAuth_)
@@ -467,7 +467,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Build binary
@@ -505,7 +505,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       # govulncheck: known CVEs in module dependencies.
@@ -545,7 +545,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - uses: actions/setup-python@v7
@@ -581,7 +581,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Run sustained-load soak test
@@ -616,7 +616,7 @@ jobs:
 
       - uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Run trust-suite accuracy eval

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
-          go-version: "1.25.12"
+          go-version: "1.25.13"
           cache: true
 
       # ── Fast-fail gates (before any slow or authenticated steps) ──────────────

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/zoharbabin/web-researcher-mcp
 
-go 1.25.12
+go 1.25.13
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0


### PR DESCRIPTION
## Summary
- Bumps the pinned Go toolchain from 1.25.12 → 1.25.13 in `go.mod` and all `go-version` occurrences in `.github/workflows/{ci,codeql,release}.yml`.
- Fixes 6 stdlib CVEs newly disclosed against 1.25.12 that govulncheck's live vulnerability DB now flags: GO-2026-6090 (crypto/tls), GO-2026-6089 (net/http), GO-2026-6088 (encoding/xml), GO-2026-5972 (encoding/asn1), plus golang.org/x/net/idna surfaced transitively via net/http. These were failing the required "🛡️ Security Scan" check on unrelated PRs (e.g. #576) with zero code changes on their part.
- Leaves `ci.yml`'s `test-gate` job name (`🧪 Test · Go 1.25.12`) unchanged — confirmed via `gh api .../branches/main/protection` that this exact string is the required branch-protection status check context, deliberately decoupled from the matrix version per the job's own comment. Renaming it would break required-check matching for every future PR.

## Test plan
- [x] `go build ./...` — passes on go1.25.13
- [x] `go vet ./...` — clean
- [x] `go tool govulncheck ./...` — "No vulnerabilities found" (was reporting 6 findings on 1.25.12)
- [x] `go test -race -count=1 ./...` — run locally, all green
- [x] `go mod tidy` — no diff (go.sum unaffected by toolchain-line bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)