### PR TITLE
fix(ci): pin actions/setup-node to a commit SHA

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,7 +210,7 @@ jobs:
           go-version: "1.25.13"
           cache: true
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -470,7 +470,7 @@ jobs:
 
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
-      - uses: actions/setup-node@v7
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: "22"
 


### PR DESCRIPTION
## Summary
- `actions/setup-node@v7` in `ci.yml` and `release.yml` was missed by the earlier batch SHA-pinning pass in #578, and still shows as an open `PinnedDependenciesID` (GitHubAction not pinned by hash) code-scanning alert.
- Pins both occurrences to `820762786026740c76f36085b0efc47a31fe5020 # v7`, the current commit for the `v7` tag.

## Test plan
- [x] `actionlint` on both files: no new findings (only pre-existing, unrelated shellcheck style warnings)
- [ ] CI passes