### PR TITLE
fix(deps): document GO-2026-5932 as unreachable, ignore in osv-scanner

### DIFF
--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -1,0 +1,3 @@
+[[IgnoredVulns]]
+id = "GO-2026-5932"
+reason = "golang.org/x/crypto/openpgp is pulled in only via github.com/securego/gosec/v2 (go.mod 'tool' directive, lint-time only). Confirmed unreachable: `go list -deps ./cmd/web-researcher-mcp/...` shows zero transitive dependency on this package or on gosec/genai. Not imported by project source, never compiled into the shipped binary. govulncheck (call-graph-aware) reports 'No vulnerabilities found'."


### PR DESCRIPTION
## Summary
Resolves the last open `VulnerabilitiesID` code-scanning alert (#95).

`golang.org/x/crypto/openpgp` (advisory GO-2026-5932: package is unmaintained/unsafe-by-design, no fixed version exists) is pulled in transitively only via `gosec` — a `tool` directive in `go.mod`, used for linting only.

Verified non-exploitable, not just "no fix available":
- `go list -deps ./cmd/web-researcher-mcp/...` — the actual shipped binary's full dependency closure — has zero references to `openpgp`, `gosec`, or `google.golang.org/genai` (the chain that pulls it in).
- `go tool govulncheck ./...` (call-graph-aware, unlike Scorecard's raw OSV match) reports "No vulnerabilities found."

Scorecard's Vulnerabilities check runs `osv-scanner` as a library against the repo and honors `osv-scanner.toml` next to `go.sum` — added an `IgnoredVulns` entry with the reachability evidence as the reason, per GitHub's own remediation guidance for this alert.

## Test plan
- [x] `go build ./...`, `go vet ./...` unaffected (docs-only change, no Go source touched)
- [x] Reachability re-verified via `go list -deps` and `govulncheck` this session
- [ ] CI passes
- [ ] Confirm next Scorecard run on `main` closes alert #95