### PR TITLE
fix(deps): bump mkdocs-material to pull in patched pymdown-extensions

### DIFF
--- a/.github/pip/docs-requirements.in
+++ b/.github/pip/docs-requirements.in
@@ -1,1 +1,2 @@
-mkdocs-material==9.6.14
+mkdocs-material==9.7.7
+pymdown-extensions>=11.0.1  # CVE-2026-67422 (ReDoS), CVE-2026-61632 (b64 path traversal) — mkdocs-material's own pin allows 10.x

--- a/.github/pip/docs-requirements.txt
+++ b/.github/pip/docs-requirements.txt
@@ -331,9 +331,9 @@ mkdocs-get-deps==0.2.2 \
     --hash=sha256:8ee8d5f316cdbbb2834bc1df6e69c08fe769a83e040060de26d3c19fad3599a1 \
     --hash=sha256:e7878cbeac04860b8b5e0ca31d3abad3df9411a75a32cde82f8e44b6c16ff650
     # via mkdocs
-mkdocs-material==9.6.14 \
-    --hash=sha256:39d795e90dce6b531387c255bd07e866e027828b7346d3eba5ac3de265053754 \
-    --hash=sha256:3b9cee6d3688551bf7a8e8f41afda97a3c39a12f0325436d76c86706114b721b
+mkdocs-material==9.7.7 \
+    --hash=sha256:8ea9bb1737a5b524a5f9dcf2e1b4ebda8274ae3008aa7845720a97083bef708f \
+    --hash=sha256:c0649c065b1b0512d60aad8c10f947f8e455284475239b364b610f2deb4d0855
     # via -r .github/pip/docs-requirements.in
 mkdocs-material-extensions==1.3.1 \
     --hash=sha256:10c9511cea88f568257f960358a467d12b970e1f7b2c0e5fb2bb48cab1928443 \
@@ -359,10 +359,12 @@ pygments==2.21.0 \
     --hash=sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9 \
     --hash=sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c
     # via mkdocs-material
-pymdown-extensions==10.21.3 \
-    --hash=sha256:72cfcf55f07aea0d4af2c4f11dd4e52466ddfb1bb819673146398e0bd3a77354 \
-    --hash=sha256:d7a5d08014fc571e80ca21dd6f854e31f94c489800350564d55d15b3c41e76b6
-    # via mkdocs-material
+pymdown-extensions==11.0.1 \
+    --hash=sha256:db3943a62bab7e03af1364f0c4083e64b91fb097675a4b6cceccfbe9a77e5eb2 \
+    --hash=sha256:dd2905ae6fc5b75582fafb139a1266ffc754705efa902aa50067fa7ff4f94ec0
+    # via
+    #   -r .github/pip/docs-requirements.in
+    #   mkdocs-material
 python-dateutil==2.9.0.post0 \
     --hash=sha256:37dd54208da7e1cd875388217d5e00ebd4179249f90fb72437e91a35459a0ad3 \
     --hash=sha256:a8b2bc7bffae282281c8140a97d3aa9c14da0b136dfe83f850eea9a5f7470427


### PR DESCRIPTION
## Summary
- `pymdown-extensions` 10.21.3 (transitive via `mkdocs-material==9.6.14` in `.github/pip/docs-requirements.txt`) is vulnerable to CVE-2026-67422 (ReDoS in caret/tilde/betterem/magiclink extensions) and CVE-2026-61632 (path traversal via `b64` extension).
- `mkdocs-material`'s own dependency pin (`pymdown-extensions~=10.2`) blocks upgrading past 10.x. Version 9.7.0+ relaxes this to `>=10.2` (no upper bound), unblocking the fix.
- Bumped `mkdocs-material` to 9.7.7 (latest) and pinned `pymdown-extensions>=11.0.1` directly (fixes both CVEs — path traversal fixed in 11.0.0, ReDoS fixed in 11.0.1). Regenerated the hash-locked lockfile with `pip-compile --generate-hashes` under Python 3.13 (matches `docs.yml`'s `python-version: "3.x"` on `ubuntu-latest`).
- Note: this repo's `mkdocs.yml` `markdown_extensions` only enables `admonition`, `pymdownx.details`, `pymdownx.superfences`, `pymdownx.tabbed` — none of the vulnerable extensions (`caret`/`tilde`/`betterem`/`magiclink`/`b64`) were actually reachable, but a real fix exists so no reason to leave it open.

Closes Dependabot alerts #15 and #16.

## Test plan
- [x] `pip install --require-hashes -r .github/pip/docs-requirements.txt` in a scratch venv — installs cleanly, `pymdown-extensions==11.0.1` confirmed
- [x] `mkdocs build` against this repo's actual `mkdocs.yml` — builds successfully
- [x] CI (build/lint/docs-drift/python-drift) — pending