### PR TITLE
fix(search): stop forcing reaction-count sort on github provider

### DIFF
--- a/internal/search/github.go
+++ b/internal/search/github.go
@@ -83,8 +83,6 @@ func (p *GitHubProvider) doSearch(ctx context.Context, params WebSearchParams) (
 
 	qp := url.Values{}
 	qp.Set("q", q)
-	qp.Set("sort", "reactions")
-	qp.Set("order", "desc")
 	qp.Set("per_page", strconv.Itoa(n))
 
 	body, err := githubAPIRequest(ctx, p.deps.HTTPClient, p.baseURL, "/search/issues?"+qp.Encode(), p.token)

--- a/internal/search/github_test.go
+++ b/internal/search/github_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -248,6 +249,26 @@ func TestGitHubProviderSendsTokenWhenConfigured(t *testing.T) {
 	}
 	if gotAuth != "Bearer secret-token" {
 		t.Errorf("Authorization = %q, want Bearer secret-token", gotAuth)
+	}
+}
+
+// TestGitHubProviderDefaultsToRelevanceRanking proves issue #593: the search
+// query must not force sort=reactions, which discards GitHub's own best-match
+// relevance ranking in favor of raw popularity (surfacing unrelated
+// high-reaction items over an exact-name match).
+func TestGitHubProviderDefaultsToRelevanceRanking(t *testing.T) {
+	t.Parallel()
+	var gotQuery url.Values
+	p := newGHTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.Query()
+		w.Write([]byte(`{"total_count":0,"items":[]}`))
+	})
+
+	if _, err := p.Web(context.Background(), WebSearchParams{Query: "web-researcher-mcp"}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := gotQuery.Get("sort"); got == "reactions" {
+		t.Errorf("sort = %q, must not force reactions sort — it discards relevance ranking (issue #593)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `web_search(provider="github")` unconditionally set `sort=reactions&order=desc` on every GitHub Search API call, discarding the API's own text-relevance ("best match") ranking.
- Effect: an exact repo-name query like `web-researcher-mcp` returned unrelated large repos' issues/PRs (whichever had the most reactions anywhere on GitHub) instead of the actual `zoharbabin/web-researcher-mcp` repo's own issues.

## Root cause
`internal/search/github.go:86-87` (pre-fix):
```go
qp.Set("sort", "reactions")
qp.Set("order", "desc")
```
Per the GitHub Search API, omitting `sort` returns best-match relevance ordering; forcing `sort=reactions` discards it entirely.

## Fix
Drop the hardcoded sort override — the query now relies on the API's default relevance ranking. Minimal, scoped change; no new params added.

## Test
Added `TestGitHubProviderDefaultsToRelevanceRanking` in `internal/search/github_test.go`, which asserts the outgoing request never sets `sort=reactions`. Confirmed it fails against pre-fix code (red) and passes post-fix (green).

## Verification
- `go build ./...` — OK
- `go test ./internal/search/... -race` — OK (all GitHub provider tests green)
- `go test ./internal/tools/... -run 'TestToolsDocMatchesRegistry|TestProvidersDocStructuredDomainTable'` — OK, no doc drift
- `gofmt -l` on changed files — clean

Fixes #593