### PR TITLE
fix(get_research_session): distinguish out-of-range stepId from a missing/expired session

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -944,8 +944,8 @@ Recorded outcome state is bounded (most-recent 200 events, FIFO) and tenant/user
 - OpenWorld: false (reads internal state only)
 
 ### Error Conditions
-- Session not found → "Session not found or expired. Sessions last 4 hours from last activity."
-- Step not found → error with step number
+- Session not found or expired → "Session not found or expired. Sessions last 4 hours from last activity."
+- `stepId` out of range on a valid session (#620) → distinct message stating the requested step and the session's actual valid range, e.g. "Step 99 not found — this session has steps 1-3." — kept separate from the session-missing message above so a caller can tell "the session is fine, you asked for a step it doesn't have" apart from "the whole session is gone."
 
 ### Cache
 - No cache (reads internal session state)

--- a/internal/redisbackend/session.go
+++ b/internal/redisbackend/session.go
@@ -234,7 +234,7 @@ func (m *SessionManager) GetStep(tenantID, userID, sessionID string, stepNum int
 			return &step, nil
 		}
 	}
-	return nil, session.ErrSessionNotFound
+	return nil, &session.StepNotFoundError{SessionID: sessionID, StepID: stepNum, StepCount: len(sess.Steps)}
 }
 
 func (m *SessionManager) Delete(tenantID, userID, sessionID string) {

--- a/internal/redisbackend/session_coverage_test.go
+++ b/internal/redisbackend/session_coverage_test.go
@@ -151,8 +151,13 @@ func TestSessionManagerGetStep(t *testing.T) {
 		t.Errorf("StepNumber = %d, want 2", step.StepNumber)
 	}
 
-	if _, err := m.GetStep("tenant-1", "u1", idx.ID, 99); err == nil {
-		t.Error("expected error for nonexistent step number")
+	_, err = m.GetStep("tenant-1", "u1", idx.ID, 99)
+	var stepErr *session.StepNotFoundError
+	if !errors.As(err, &stepErr) {
+		t.Fatalf("expected *session.StepNotFoundError for an out-of-range step on a valid session, got %T: %v", err, err)
+	}
+	if stepErr.StepID != 99 || stepErr.StepCount != 3 {
+		t.Errorf("expected StepID=99 StepCount=3, got StepID=%d StepCount=%d", stepErr.StepID, stepErr.StepCount)
 	}
 
 	if _, err := m.GetStep("tenant-1", "u1", "missing-id", 1); err == nil {

--- a/internal/session/errors.go
+++ b/internal/session/errors.go
@@ -36,3 +36,20 @@ type SessionNotFoundError struct {
 func (e *SessionNotFoundError) Error() string { return "session not found" }
 
 func (e *SessionNotFoundError) Unwrap() error { return ErrSessionNotFound }
+
+// StepNotFoundError indicates the session itself exists (and is unexpired)
+// but the requested step number was never recorded — distinct from
+// SessionNotFoundError/ErrSessionExpired so a caller can tell "your session
+// is fine, you just asked for a step it doesn't have" apart from "your whole
+// session is gone" (#620).
+type StepNotFoundError struct {
+	SessionID string
+	StepID    int
+	// StepCount is the number of steps currently recorded on the session, so
+	// callers can report the valid range (1..StepCount).
+	StepCount int
+}
+
+func (e *StepNotFoundError) Error() string {
+	return "step not found"
+}

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -355,7 +355,7 @@ func (m *MemoryManager) GetStep(tenantID, userID, sessionID string, stepNum int)
 			return &step, nil
 		}
 	}
-	return nil, fmt.Errorf("step %d not found", stepNum)
+	return nil, &StepNotFoundError{SessionID: sessionID, StepID: stepNum, StepCount: len(sess.Steps)}
 }
 
 func (m *MemoryManager) Delete(tenantID, userID, sessionID string) {

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -447,6 +447,21 @@ func TestGetStep(t *testing.T) {
 	if err == nil {
 		t.Error("expected error for nonexistent step")
 	}
+	var stepErr *StepNotFoundError
+	if !errors.As(err, &stepErr) {
+		t.Fatalf("expected *StepNotFoundError for an out-of-range step on a valid session, got %T: %v", err, err)
+	}
+	if stepErr.StepID != 99 || stepErr.StepCount != 3 {
+		t.Errorf("expected StepID=99 StepCount=3, got StepID=%d StepCount=%d", stepErr.StepID, stepErr.StepCount)
+	}
+
+	// A truly missing session must still surface SessionNotFoundError, not
+	// StepNotFoundError — the two failure modes stay distinguishable (#620).
+	_, err = m.GetStep("tenant-1", "u1", "nonexistent-id", 1)
+	var notFound *SessionNotFoundError
+	if !errors.As(err, &notFound) {
+		t.Fatalf("expected *SessionNotFoundError for a nonexistent session, got %T: %v", err, err)
+	}
 }
 
 func TestMaxStepsEnforcement(t *testing.T) {

--- a/internal/tools/getsession.go
+++ b/internal/tools/getsession.go
@@ -3,11 +3,14 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/zoharbabin/web-researcher-mcp/internal/auth"
+	"github.com/zoharbabin/web-researcher-mcp/internal/session"
 )
 
 type getSessionInput struct {
@@ -36,6 +39,14 @@ func registerGetSession(srv *mcp.Server, deps Dependencies) {
 			if err != nil {
 				recordToolCall(deps, "get_research_session", time.Since(start), err, "upstream_error", false)
 				auditToolCall(ctx, deps, "get_research_session", time.Since(start), err, "upstream_error")
+
+				var stepErr *session.StepNotFoundError
+				if errors.As(err, &stepErr) {
+					if stepErr.StepCount <= 0 {
+						return toolError(fmt.Sprintf("Step %d not found — this session has no recorded steps yet.", stepErr.StepID)), nil, nil
+					}
+					return toolError(fmt.Sprintf("Step %d not found — this session has steps 1-%d.", stepErr.StepID, stepErr.StepCount)), nil, nil
+				}
 				return toolError("Session not found or expired. Sessions last 4 hours from last activity."), nil, nil
 			}
 

--- a/internal/tools/getsession_test.go
+++ b/internal/tools/getsession_test.go
@@ -1,0 +1,53 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+// TestGetSessionStepOutOfRangeReportsValidRange (#620): a stepId beyond what
+// the session actually recorded must produce a message that says so and
+// states the valid range — not the generic "not found or expired" string
+// used for a truly missing/expired session. Collapsing the two made it
+// impossible for a caller to tell "your session is fine, you just asked for
+// a step it doesn't have" apart from "your whole session is gone".
+func TestGetSessionStepOutOfRangeReportsValidRange(t *testing.T) {
+	deps := setupTestDeps()
+	sid, _ := startSession(t, deps, "")
+	if sid == "" {
+		t.Fatal("no session created")
+	}
+
+	_, res := callTool(t, deps, "get_research_session", map[string]any{"sessionId": sid, "stepId": 99})
+	if !res.IsError {
+		t.Fatal("expected an error result for an out-of-range stepId")
+	}
+	msg := res.Content[0].(*mcp.TextContent).Text
+	if strings.Contains(msg, "Session not found or expired") {
+		t.Errorf("out-of-range stepId must not reuse the generic missing/expired message, got %q", msg)
+	}
+	if !strings.Contains(msg, "99") {
+		t.Errorf("expected the requested stepId (99) in the message, got %q", msg)
+	}
+	if !strings.Contains(msg, "1") {
+		t.Errorf("expected the valid step range (this session only has step 1) in the message, got %q", msg)
+	}
+}
+
+// TestGetSessionUnknownIDStillReportsGenericMessage (#620): a session ID that
+// was never created (or has expired) must keep the original generic message
+// — only the valid-session/out-of-range-step case gets the new specific one.
+func TestGetSessionUnknownIDStillReportsGenericMessage(t *testing.T) {
+	deps := setupTestDeps()
+
+	_, res := callTool(t, deps, "get_research_session", map[string]any{"sessionId": "nonexistent-session-id", "stepId": 1})
+	if !res.IsError {
+		t.Fatal("expected an error result for a nonexistent sessionId")
+	}
+	msg := res.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(msg, "Session not found or expired") {
+		t.Errorf("expected the generic missing/expired message for a nonexistent session, got %q", msg)
+	}
+}


### PR DESCRIPTION
## Summary
- `get_research_session`'s `GetStep` path discarded the specific error and always returned the generic `"Session not found or expired..."` message, whether the session was truly gone or just valid-but-missing that step.
- Added `session.StepNotFoundError{SessionID, StepID, StepCount}`, returned by both `GetStep` implementations (`MemoryManager` and the Redis-backed `SessionManager` — the latter previously misused `ErrSessionNotFound` for this case too, which would have silently defeated the fix under a Redis-backed deployment).
- `get_research_session` now uses `errors.As` to detect this case and returns e.g. `"Step 99 not found — this session has steps 1-3."`; a truly missing/expired session still gets the original generic message.

## Success KPIs
- Out-of-range `stepId` on a valid session never returns the generic missing/expired string.
- The specific message states both the requested step and the actual valid range.
- A genuinely nonexistent/expired session's error message is unchanged (no behavior regression for that path).

## Tests added (run in CI via `go test -race ./...`)
- `internal/tools/getsession_test.go`: `TestGetSessionStepOutOfRangeReportsValidRange`, `TestGetSessionUnknownIDStillReportsGenericMessage` — exercise the tool end-to-end over the real MCP transport.
- `internal/session/manager_test.go` (`TestGetStep`): asserts `errors.As` into `*StepNotFoundError` with the right `StepID`/`StepCount`, and that a nonexistent session still yields `*SessionNotFoundError`.
- `internal/redisbackend/session_coverage_test.go` (`TestSessionManagerGetStep`): same assertions against the Redis-backed manager (fake Redis backend, no external dependency).

## Test plan
- [x] `go build ./...`
- [x] `go vet ./internal/tools/... ./internal/session/... ./internal/redisbackend/...`
- [x] `go test -race ./internal/tools/... ./internal/session/... ./internal/redisbackend/...` (all green)
- [x] `go tool golangci-lint run` on the same packages (0 issues)
- [x] `make check-python-drift` (no output-schema change, clean)
- [x] `docs/TOOLS.md` Error Conditions section updated for `get_research_session`
- [ ] CI green on this PR

Fixes #620