### PR TITLE
fix(session): decrement stats://sessions activeSessions on completion

### DIFF
--- a/internal/redisbackend/session.go
+++ b/internal/redisbackend/session.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/cipher"
 	"encoding/json"
+	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
@@ -56,6 +57,14 @@ func (m *SessionManager) blobKey(tenantID, userID, sessionID string) string {
 // are "userID:sessionID" so per-session keys can be reconstructed.
 func (m *SessionManager) tenantSetKey(tenantID string) string {
 	return m.b.key("session:index", tenantID)
+}
+
+// completedSetKey indexes sessions in a tenant that have been marked complete
+// via MarkComplete, so ActiveCount can subtract a cheap SCard from the raw
+// per-tenant SCard instead of loading every session blob to check a field
+// (#622) — the same cost profile the existing ActiveCount already relies on.
+func (m *SessionManager) completedSetKey(tenantID string) string {
+	return m.b.key("session:completed", tenantID)
 }
 
 func setMember(userID, sessionID string) string { return normUser(userID) + ":" + sessionID }
@@ -210,6 +219,27 @@ func (m *SessionManager) RecordOutcome(tenantID, userID, sessionID string, ev se
 	return nil
 }
 
+// MarkComplete flags a session as finished (#622) so ActiveCount stops
+// counting it toward the live-session gauge, without deleting it — a
+// completed session stays readable via GetFull/GetIndex until its TTL
+// expires.
+func (m *SessionManager) MarkComplete(tenantID, userID, sessionID string) error {
+	sess, err := m.load(tenantID, userID, sessionID)
+	if err != nil {
+		return err
+	}
+	sess.Completed = true
+	sess.LastUsed = nowUTC()
+	if err := m.save(sess); err != nil {
+		return err
+	}
+	pipe := m.b.client.TxPipeline()
+	pipe.SAdd(m.ctx, m.completedSetKey(tenantID), setMember(userID, sessionID))
+	pipe.Expire(m.ctx, m.completedSetKey(tenantID), m.ttl)
+	_, err = pipe.Exec(m.ctx)
+	return err
+}
+
 func (m *SessionManager) GetIndex(tenantID, userID, sessionID string) (*session.SessionIndex, bool) {
 	sess, err := m.load(tenantID, userID, sessionID)
 	if err != nil {
@@ -246,6 +276,9 @@ func (m *SessionManager) Delete(tenantID, userID, sessionID string) {
 	// Remove both the new member form ("userID:sessionID") and the legacy bare
 	// "sessionID" member, so no stale index entry inflates SCard/eviction.
 	pipe.SRem(m.ctx, m.tenantSetKey(tenantID), setMember(userID, sessionID), sessionID)
+	// Also drop it from the completed-set (#622) so a deleted session never
+	// inflates that set's SCard against a since-reused tenant.
+	pipe.SRem(m.ctx, m.completedSetKey(tenantID), setMember(userID, sessionID))
 	_, _ = pipe.Exec(m.ctx)
 }
 
@@ -259,6 +292,10 @@ func (m *SessionManager) DeleteAll() {
 	idxIter := m.b.client.Scan(m.ctx, 0, m.b.key("session:index", "*"), 100).Iterator()
 	for idxIter.Next(m.ctx) {
 		_ = m.b.client.Del(m.ctx, idxIter.Val()).Err()
+	}
+	completedIter := m.b.client.Scan(m.ctx, 0, m.b.key("session:completed", "*"), 100).Iterator()
+	for completedIter.Next(m.ctx) {
+		_ = m.b.client.Del(m.ctx, completedIter.Val()).Err()
 	}
 }
 
@@ -312,18 +349,40 @@ func (m *SessionManager) DeleteByTenant(tenantID string) int {
 		m.Delete(tenantID, uid, sid)
 	}
 	_ = m.b.client.Del(m.ctx, m.tenantSetKey(tenantID)).Err()
+	_ = m.b.client.Del(m.ctx, m.completedSetKey(tenantID)).Err()
 	return len(members)
 }
 
+// ActiveCount returns the number of live, NOT-YET-COMPLETED sessions (#622):
+// per tenant, the index set's cardinality minus the completed-set's
+// cardinality. Both are cheap SCards — this deliberately avoids loading every
+// session blob just to check a Completed field, which would turn a stats call
+// into an O(sessions) fan-out of Redis GETs.
 func (m *SessionManager) ActiveCount() int {
 	var total int
 	iter := m.b.client.Scan(m.ctx, 0, m.b.key("session:index", "*"), 100).Iterator()
 	for iter.Next(m.ctx) {
-		if n, err := m.b.client.SCard(m.ctx, iter.Val()).Result(); err == nil {
-			total += int(n)
+		indexKey := iter.Val()
+		n, err := m.b.client.SCard(m.ctx, indexKey).Result()
+		if err != nil {
+			continue
+		}
+		tenantID := m.tenantIDFromIndexKey(indexKey)
+		completed, _ := m.b.client.SCard(m.ctx, m.completedSetKey(tenantID)).Result()
+		if live := int(n) - int(completed); live > 0 {
+			total += live
 		}
 	}
 	return total
+}
+
+// tenantIDFromIndexKey inverts tenantSetKey: strips the "session:index:"
+// namespace prefix (with the deployment's KeyPrefix) to recover the tenantID
+// that was scanned, so ActiveCount can look up that tenant's completed-set
+// without a separate tenant enumeration.
+func (m *SessionManager) tenantIDFromIndexKey(key string) string {
+	prefix := m.b.key("session:index", "")
+	return strings.TrimPrefix(key, prefix)
 }
 
 func (m *SessionManager) Close() {} // client lifecycle owned by Backends.Close

--- a/internal/redisbackend/session_coverage_test.go
+++ b/internal/redisbackend/session_coverage_test.go
@@ -195,6 +195,104 @@ func TestSessionManagerActiveCountAndDeleteAll(t *testing.T) {
 	}
 }
 
+// TestSessionManagerActiveCountExcludesCompleted proves the #622 fix on the
+// Redis backend: ActiveCount decrements when a session is marked complete,
+// across multiple tenants (guarding against a fix that only works for a
+// single tenant's index/completed-set pairing), while the session itself
+// stays readable via GetFull — completion is a flag, not a deletion.
+func TestSessionManagerActiveCountExcludesCompleted(t *testing.T) {
+	b := newTestBackend(t)
+	m := b.SessionManager()
+
+	idxA1, err := m.Create("tenant-A", "u1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if _, err := m.Create("tenant-A", "u1"); err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	idxB1, err := m.Create("tenant-B", "u1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+
+	if got := m.ActiveCount(); got != 3 {
+		t.Fatalf("ActiveCount before completion = %d, want 3", got)
+	}
+
+	if err := m.MarkComplete("tenant-A", "u1", idxA1.ID); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if err := m.MarkComplete("tenant-B", "u1", idxB1.ID); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+
+	if got := m.ActiveCount(); got != 1 {
+		t.Errorf("ActiveCount after completing 2 of 3 = %d, want 1", got)
+	}
+
+	full, err := m.GetFull("tenant-A", "u1", idxA1.ID)
+	if err != nil {
+		t.Fatalf("completed session should still load via GetFull: %v", err)
+	}
+	if !full.Completed {
+		t.Error("Session.Completed should be true after MarkComplete")
+	}
+
+	idx, ok := m.GetIndex("tenant-A", "u1", idxA1.ID)
+	if !ok || !idx.Completed {
+		t.Errorf("GetIndex should report Completed=true, got ok=%v idx=%+v", ok, idx)
+	}
+}
+
+// TestSessionManagerMarkCompleteNotFound proves MarkComplete surfaces the
+// typed not-found error for an unknown session, same convention as
+// SetResearchGoal.
+func TestSessionManagerMarkCompleteNotFound(t *testing.T) {
+	b := newTestBackend(t)
+	m := b.SessionManager()
+
+	err := m.MarkComplete("tenant-1", "u1", "missing-id")
+	var nf *session.SessionNotFoundError
+	if !errors.As(err, &nf) {
+		t.Fatalf("expected typed SessionNotFoundError for unknown session, got %v", err)
+	}
+}
+
+// TestSessionManagerDeleteRemovesFromCompletedSet proves Delete cleans up the
+// completed-set membership too, so a deleted-then-recreated session in the
+// same tenant doesn't inherit a stale "completed" mark from an unrelated
+// former session that happened to reuse the set (#622 bookkeeping).
+func TestSessionManagerDeleteRemovesFromCompletedSet(t *testing.T) {
+	b := newTestBackend(t)
+	m := b.SessionManager()
+
+	idx, err := m.Create("tenant-1", "u1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if err := m.MarkComplete("tenant-1", "u1", idx.ID); err != nil {
+		t.Fatalf("MarkComplete: %v", err)
+	}
+	if got := m.ActiveCount(); got != 0 {
+		t.Fatalf("ActiveCount after completing the only session = %d, want 0", got)
+	}
+
+	m.Delete("tenant-1", "u1", idx.ID)
+
+	idx2, err := m.Create("tenant-1", "u1")
+	if err != nil {
+		t.Fatalf("Create: %v", err)
+	}
+	if got := m.ActiveCount(); got != 1 {
+		t.Errorf("ActiveCount after deleting the completed session and creating a fresh one = %d, want 1", got)
+	}
+	got, ok := m.GetIndex("tenant-1", "u1", idx2.ID)
+	if !ok || got.Completed {
+		t.Errorf("fresh session must not inherit completed state, ok=%v idx=%+v", ok, got)
+	}
+}
+
 // TestSessionManagerClose verifies Close is a safe no-op on the Redis-backed
 // manager — the underlying client's lifecycle is owned by Backends.Close, not
 // by the SessionManager, so this must never close the shared client out from

--- a/internal/session/interface.go
+++ b/internal/session/interface.go
@@ -30,6 +30,14 @@ type Manager interface {
 	// a missing/expired session is a silent no-op (returns nil) — outcome
 	// telemetry must never fail or alter a tool's own result.
 	RecordOutcome(tenantID, userID, sessionID string, ev OutcomeEvent) error
+	// MarkComplete flags a session as finished so ActiveCount excludes it from
+	// the live-session gauge (#622). The session itself is NOT deleted — it stays
+	// readable via GetFull/GetIndex until its TTL expires, since a completed
+	// session remains a valid format_bibliography/get_research_session source.
+	// Returns an error for a missing/expired session, same convention as
+	// SetResearchGoal; the caller (sequential_search, run right after a
+	// successful AppendStep) treats it as best-effort and ignores the error.
+	MarkComplete(tenantID, userID, sessionID string) error
 	// GetIndex returns the lightweight index for a session, or ok=false.
 	GetIndex(tenantID, userID, sessionID string) (*SessionIndex, bool)
 	// GetFull loads the full session payload.

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -210,6 +210,35 @@ func (m *MemoryManager) SetTotalStepsEstimate(tenantID, userID, sessionID string
 	return nil
 }
 
+// MarkComplete flags a session as finished (#622) so ActiveCount stops
+// counting it toward the live-session gauge, without deleting it — a
+// completed session stays readable via GetFull/GetIndex until its TTL expires.
+func (m *MemoryManager) MarkComplete(tenantID, userID, sessionID string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	key := sessionKey(tenantID, userID, sessionID)
+	idx, ok := m.index[key]
+	if !ok {
+		return ErrSessionNotFound
+	}
+
+	sess, err := m.store.Load(key)
+	if err != nil {
+		return err
+	}
+
+	sess.Completed = true
+	sess.LastUsed = time.Now()
+	if err := m.store.Save(key, sess, m.config.SessionTTL); err != nil {
+		return err
+	}
+
+	idx.Completed = true
+	idx.LastUsed = sess.LastUsed
+	return nil
+}
+
 func (m *MemoryManager) AddSources(tenantID, userID, sessionID string, sources []ResearchSource) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -412,10 +441,19 @@ func (m *MemoryManager) Close() {
 	close(m.done)
 }
 
+// ActiveCount returns the number of live, NOT-YET-COMPLETED sessions (#622) —
+// a session marked complete via MarkComplete stays in m.index (readable until
+// TTL expiry) but no longer counts toward this gauge.
 func (m *MemoryManager) ActiveCount() int {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	return len(m.index)
+	n := 0
+	for _, idx := range m.index {
+		if !idx.Completed {
+			n++
+		}
+	}
+	return n
 }
 
 func (m *MemoryManager) deleteUnlocked(key string) {
@@ -527,6 +565,7 @@ func buildIndexFromSession(sess *Session) *SessionIndex {
 		TotalStepsEstimate: sess.TotalStepsEstimate,
 		CreatedAt:          sess.CreatedAt,
 		LastUsed:           sess.LastUsed,
+		Completed:          sess.Completed,
 		StepCount:          len(sess.Steps),
 		ActiveGaps:         sess.Gaps,
 		Sources:            sess.Sources,

--- a/internal/session/manager_test.go
+++ b/internal/session/manager_test.go
@@ -379,6 +379,50 @@ func TestActiveCount(t *testing.T) {
 	}
 }
 
+// TestActiveCountExcludesCompletedSessions proves the #622 fix: ActiveCount
+// decrements when a session is marked complete, but the session itself stays
+// readable (get_research_session / format_bibliography still work on it) —
+// completion is a flag, not a deletion.
+func TestActiveCountExcludesCompletedSessions(t *testing.T) {
+	m := newTestManager(5*time.Minute, 10)
+	defer m.Close()
+
+	idx1, _ := m.Create("tenant-1", "u1")
+	m.Create("tenant-1", "u1")
+
+	if got := m.ActiveCount(); got != 2 {
+		t.Fatalf("expected 2 active sessions before completion, got %d", got)
+	}
+
+	if err := m.MarkComplete("tenant-1", "u1", idx1.ID); err != nil {
+		t.Fatalf("MarkComplete failed: %v", err)
+	}
+
+	if got := m.ActiveCount(); got != 1 {
+		t.Errorf("expected 1 active session after completing one, got %d", got)
+	}
+
+	got, ok := m.GetIndex("tenant-1", "u1", idx1.ID)
+	if !ok {
+		t.Fatal("completed session should still be readable via GetIndex")
+	}
+	if !got.Completed {
+		t.Error("index should report Completed=true after MarkComplete")
+	}
+}
+
+// TestMarkCompleteNotFound proves MarkComplete surfaces ErrSessionNotFound for
+// a missing session, same convention as SetResearchGoal — sequential_search
+// treats this as best-effort and ignores the error.
+func TestMarkCompleteNotFound(t *testing.T) {
+	m := newTestManager(5*time.Minute, 10)
+	defer m.Close()
+
+	if err := m.MarkComplete("tenant-1", "u1", "does-not-exist"); !errors.Is(err, ErrSessionNotFound) {
+		t.Errorf("expected ErrSessionNotFound, got %v", err)
+	}
+}
+
 func TestSessionIDsAreUnique(t *testing.T) {
 	m := newTestManager(5*time.Minute, 100)
 	defer m.Close()

--- a/internal/session/types.go
+++ b/internal/session/types.go
@@ -10,12 +10,17 @@ type Session struct {
 	// TotalStepsEstimate is the caller's latest estimate of total steps needed,
 	// set via sequential_search's totalStepsEstimate field and persisted across
 	// steps so it survives even when a later step omits it (#525).
-	TotalStepsEstimate int              `json:"totalStepsEstimate,omitempty"`
-	CreatedAt          time.Time        `json:"createdAt"`
-	LastUsed           time.Time        `json:"lastUsed"`
-	Steps              []ResearchStep   `json:"steps"`
-	Sources            []ResearchSource `json:"sources"`
-	Gaps               []KnowledgeGap   `json:"gaps"`
+	TotalStepsEstimate int       `json:"totalStepsEstimate,omitempty"`
+	CreatedAt          time.Time `json:"createdAt"`
+	LastUsed           time.Time `json:"lastUsed"`
+	// Completed is set by MarkComplete when the caller submits a step with
+	// nextStepNeeded:false. It exists solely so ActiveCount can exclude finished
+	// sessions from the "live" gauge (#622) — a completed session is not deleted
+	// and stays readable via GetFull/GetIndex until its TTL expires.
+	Completed bool             `json:"completed,omitempty"`
+	Steps     []ResearchStep   `json:"steps"`
+	Sources   []ResearchSource `json:"sources"`
+	Gaps      []KnowledgeGap   `json:"gaps"`
 	// Outcomes is the bounded per-session record of tool outcomes (provider
 	// attempt/success + error kind), feeding the cross-call error-pattern and
 	// provider-stats aggregation surfaced in get_research_session (#99). Capped
@@ -123,16 +128,20 @@ type SessionIndex struct {
 	ResearchGoal    string `json:"researchGoal"`
 	// TotalStepsEstimate mirrors Session.TotalStepsEstimate (#525) — the latest
 	// caller-supplied estimate, persisted so it survives steps that omit it.
-	TotalStepsEstimate int              `json:"totalStepsEstimate,omitempty"`
-	CreatedAt          time.Time        `json:"createdAt"`
-	LastUsed           time.Time        `json:"lastUsed"`
-	StepCount          int              `json:"stepCount"`
-	Summary            string           `json:"summary"`
-	StepIndex          []StepIndexEntry `json:"stepIndex"`
-	LastSteps          []ResearchStep   `json:"lastSteps"`
-	ActiveGaps         []KnowledgeGap   `json:"activeGaps"`
-	Sources            []ResearchSource `json:"sources"`
-	Warning            string           `json:"warning,omitempty"`
+	TotalStepsEstimate int       `json:"totalStepsEstimate,omitempty"`
+	CreatedAt          time.Time `json:"createdAt"`
+	LastUsed           time.Time `json:"lastUsed"`
+	// Completed mirrors Session.Completed (#622) — surfaced on the index so
+	// get_research_session and ActiveCount agree on completion state without
+	// loading the full session.
+	Completed  bool             `json:"completed,omitempty"`
+	StepCount  int              `json:"stepCount"`
+	Summary    string           `json:"summary"`
+	StepIndex  []StepIndexEntry `json:"stepIndex"`
+	LastSteps  []ResearchStep   `json:"lastSteps"`
+	ActiveGaps []KnowledgeGap   `json:"activeGaps"`
+	Sources    []ResearchSource `json:"sources"`
+	Warning    string           `json:"warning,omitempty"`
 	// ErrorPatterns surfaces recurring error kinds (count >= ErrorPatternMinCount)
 	// across the session; ProviderStats reports per-provider attempt/success
 	// counts. Both are derived from Session.Outcomes at index-build time (#99).

--- a/internal/tools/sequential.go
+++ b/internal/tools/sequential.go
@@ -355,6 +355,15 @@ func registerSequentialSearch(srv *mcp.Server, deps Dependencies) {
 			return toolError(fmt.Sprintf("Could not record this research step: %v. Start a new session by setting stepNumber=1 without a sessionId.", err)), nil, nil
 		}
 
+		// Flag the session complete so stats://sessions' activeSessions gauge
+		// stops counting it (#622). Best-effort: AppendStep just succeeded above,
+		// so the session exists; a failure here would only mean the gauge stays
+		// one session high until TTL expiry — it must never fail this tool call.
+		if !input.NextStepNeeded {
+			_ = deps.Sessions.MarkComplete(tenantID, userID, sessionID)
+			idx.Completed = true
+		}
+
 		output := buildSequentialResponse(idx, input)
 
 		// Iterative-depth assist (#67). quick (default) is a no-op — byte-for-byte

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -813,6 +813,69 @@ func TestSequentialSearchTool(t *testing.T) {
 	}
 }
 
+// TestSequentialSearchMarkCompleteDecrementsActiveCount proves the #622 fix
+// end-to-end: creating a session increments deps.Sessions.ActiveCount() (what
+// stats://sessions' activeSessions passes through), and completing it via
+// nextStepNeeded:false decrements it back — without deleting the session, so
+// it stays readable via get_research_session.
+func TestSequentialSearchMarkCompleteDecrementsActiveCount(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	before := deps.Sessions.ActiveCount()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "sequential_search",
+		Arguments: map[string]any{
+			"searchStep":     "Initial search for topic X",
+			"stepNumber":     float64(1),
+			"nextStepNeeded": true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+	var output map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	sessionID := output["sessionId"].(string)
+
+	if got := deps.Sessions.ActiveCount(); got != before+1 {
+		t.Fatalf("ActiveCount after creating a session = %d, want %d", got, before+1)
+	}
+
+	res, err = session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "sequential_search",
+		Arguments: map[string]any{
+			"searchStep":     "Found relevant paper on topic X",
+			"stepNumber":     float64(2),
+			"nextStepNeeded": false,
+			"sessionId":      sessionID,
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool step 2 failed: %v", err)
+	}
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &output); err != nil {
+		t.Fatalf("failed to parse step 2 output: %v", err)
+	}
+	if output["isComplete"] != true {
+		t.Fatal("expected isComplete=true on final step")
+	}
+
+	if got := deps.Sessions.ActiveCount(); got != before {
+		t.Errorf("ActiveCount after completing the session = %d, want %d (back to baseline)", got, before)
+	}
+
+	if _, ok := deps.Sessions.GetIndex("default", "", sessionID); !ok {
+		t.Error("completed session should still be readable via get_research_session's backing GetIndex")
+	}
+}
+
 // TestSequentialSearchMissingSessionOnStep2 verifies that a step > 1 with no
 // sessionId is rejected with guidance rather than silently forking a new,
 // orphaned session (which would abandon the real research trail after a caller


### PR DESCRIPTION
## Summary

Fixes #622. `stats://sessions`' `activeSessions` count incremented when a `sequential_search` session was created but never decremented when that session was explicitly marked complete (`nextStepNeeded: false`) — `ActiveCount()` just counted every live session in the TTL window, with no completion awareness anywhere in the session data model.

## Root cause

- `internal/session/manager.go`: `MemoryManager.ActiveCount()` = `len(m.index)`.
- `internal/redisbackend/session.go`: `SessionManager.ActiveCount()` summed per-tenant `SCard` of the session index set.
- Neither `Session` nor `SessionIndex` (`internal/session/types.go`) had a completion field; `sequential_search`'s `isComplete` response field was computed transiently from `!input.NextStepNeeded` and never persisted.

## Fix

- Added `Completed bool` to `Session` and `SessionIndex`.
- Added `MarkComplete(tenantID, userID, sessionID string) error` to the `session.Manager` interface, implemented in both backends:
  - `MemoryManager.MarkComplete` — load→mutate→save→rebuild-index (same pattern as `SetResearchGoal`).
  - `redisbackend.SessionManager.MarkComplete` — same pattern, plus adds the session to a new per-tenant `session:completed:{tenantID}` Redis SET.
- Fixed both `ActiveCount()` implementations to exclude completed sessions:
  - In-memory: filter `m.index` on `!idx.Completed` (already in memory, no extra cost).
  - Redis: subtract the completed-set's `SCard` from the index-set's `SCard` per tenant — stays O(tenants), never loads a session blob just to check a field.
- `Delete`/`DeleteAll`/`DeleteByTenant` (Redis) clean up completed-set membership so a deleted session can't leave a stale mark behind.
- Wired `sequential_search` (`internal/tools/sequential.go`) to call `MarkComplete` best-effort right after a successful `AppendStep` when `nextStepNeeded: false`.

Completion is a flag, not a deletion — a completed session stays fully readable via `get_research_session` / `format_bibliography` until its TTL expires, since that's a legitimate post-completion use case (export/resumability).

## Success criteria (KPIs)

- `stats://sessions`' `activeSessions` count returns to baseline after every created session in that count is marked complete.
- No regression to the existing "live sessions in the TTL window" contract for in-progress sessions.
- Works identically on both `session.Manager` backends (in-memory + Redis), consistent with every other manager method.
- Zero behavior change to `get_research_session`/`format_bibliography` — completed sessions remain fully readable.

## Tests (run in CI)

- `internal/session/manager_test.go`: `TestActiveCountExcludesCompletedSessions`, `TestMarkCompleteNotFound`.
- `internal/redisbackend/session_coverage_test.go`: `TestSessionManagerActiveCountExcludesCompleted` (multi-tenant), `TestSessionManagerMarkCompleteNotFound`, `TestSessionManagerDeleteRemovesFromCompletedSet`.
- `internal/tools/tools_test.go`: `TestSequentialSearchMarkCompleteDecrementsActiveCount` — end-to-end via the real `sequential_search` tool call, asserting `deps.Sessions.ActiveCount()` (what `stats://sessions` passes through) before/after completion, and that the completed session is still readable via `GetIndex`.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/session/... ./internal/redisbackend/... ./internal/resources/... ./internal/tools/...`
- [x] `golangci-lint run ./...`
- [x] `make check-python-drift` (no tool schema change — no client regen needed)
- [x] `TestOutputSchemaMatchesResponse` / `TestToolsDocMatchesRegistry` / `TestAllToolsHaveAnnotations` (unaffected — no tool output/schema change)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)