### PR TITLE
fix(search): EPO patent search returns irrelevant non-English results

### DIFF
--- a/internal/search/epo.go
+++ b/internal/search/epo.go
@@ -133,12 +133,24 @@ func (e *EPOProvider) buildCQL(params PatentSearchParams) string {
 	if params.Query != "" {
 		// Split query into individual keywords for broad matching.
 		// EPO CQL treats quoted strings as exact phrases which is too restrictive.
+		//
+		// Use ta= (title+abstract), not txt= (title+abstract+description+claims)
+		// (#623). txt= matches anywhere in a patent's full text, including
+		// boilerplate background sections — a query like "lithium ion battery
+		// anode" ANDed via txt= matched 201,808 documents live against EPO OPS,
+		// because unrelated filings (e.g. Japanese gaming-machine patents
+		// describing a generic backup battery in passing) satisfy all four
+		// keyword clauses without being topically about the query at all. OPS
+		// returns no relevance ranking for such a broad full-text match, so
+		// these false positives can surface anywhere, including position 1.
+		// The same live query scoped to ta= matched 14,199 documents, and every
+		// one of the top 25 was genuinely about a lithium-ion battery anode.
 		words := strings.Fields(params.Query)
 		if len(words) == 1 {
-			clauses = append(clauses, "txt="+words[0])
+			clauses = append(clauses, "ta="+words[0])
 		} else {
 			for _, w := range words {
-				clauses = append(clauses, "txt="+w)
+				clauses = append(clauses, "ta="+w)
 			}
 		}
 	}
@@ -162,7 +174,7 @@ func (e *EPOProvider) buildCQL(params PatentSearchParams) string {
 	}
 
 	if len(clauses) == 0 {
-		return "txt=patent"
+		return "ta=patent"
 	}
 	return strings.Join(clauses, " AND ")
 }

--- a/internal/search/epo_test.go
+++ b/internal/search/epo_test.go
@@ -244,28 +244,37 @@ func TestEPOProvider_CQLConstruction(t *testing.T) {
 		{
 			name:   "multi-word query splits into keywords",
 			params: PatentSearchParams{Query: "video encoding"},
-			want:   `txt=video AND txt=encoding`,
+			want:   `ta=video AND ta=encoding`,
 		},
 		{
 			name:   "single word query",
 			params: PatentSearchParams{Query: "AI", Assignee: "Google", Inventor: "Smith"},
-			want:   `txt=AI AND pa="Google" AND in="Smith"`,
+			want:   `ta=AI AND pa="Google" AND in="Smith"`,
 		},
 		{
 			name:   "with date range and office",
 			params: PatentSearchParams{Query: "network", PatentOffice: "EP", YearFrom: 2020, YearTo: 2024},
-			want:   `txt=network AND pn=EP AND pd>=2020 AND pd<=2024`,
+			want:   `ta=network AND pn=EP AND pd>=2020 AND pd<=2024`,
 		},
 		{
 			name:   "multi-word with all fields",
 			params: PatentSearchParams{Query: "language model inference", Assignee: "Apple", PatentOffice: "EP"},
-			want:   `txt=language AND txt=model AND txt=inference AND pa="Apple" AND pn=EP`,
+			want:   `ta=language AND ta=model AND ta=inference AND pa="Apple" AND pn=EP`,
 		},
 		{
 			// #530: cpc_code becomes an actual cpc= CQL clause, not free text.
 			name:   "with cpc code",
 			params: PatentSearchParams{Query: "battery", CPCCode: "H01M10/00"},
-			want:   `txt=battery AND cpc=H01M10/00`,
+			want:   `ta=battery AND cpc=H01M10/00`,
+		},
+		{
+			// #623: ta= (title+abstract) replaces txt= (full text including
+			// description/claims) to avoid boilerplate-text false positives —
+			// see the doc comment on buildCQL's query clause for the live
+			// EPO OPS evidence (201,808 vs 14,199 matches for the same query).
+			name:   "keyword-only query uses ta not txt",
+			params: PatentSearchParams{Query: "lithium ion battery anode"},
+			want:   `ta=lithium AND ta=ion AND ta=battery AND ta=anode`,
 		},
 	}
 


### PR DESCRIPTION
## Root cause

`EPOProvider.buildCQL` split a free-text query into keywords and ANDed them as `txt=word1 AND txt=word2 ...`. EPO OPS's `txt` field matches a patent's **entire text** — title, abstract, description, and claims — not just the parts that describe what the invention actually is.

Live verification against the real EPO OPS API (query `lithium ion battery anode`, same CQL our code builds):

| Field code | Total matches | Top-25 relevance |
|---|---|---|
| `txt=` (before) | 201,808 | 7/25 English-titled battery patents, **18/25 Japanese pachinko/gaming-machine patents** (`遊技機`) — exact repro of the reported bug |
| `ta=` (after) | 14,199 | 25/25 genuinely about lithium-ion battery anodes, all with English titles |

Root cause: boilerplate hardware-description text in unrelated filings (e.g. a gaming machine's generic backup-battery description) trivially satisfies all 4 ANDed keyword clauses under full-text matching. EPO OPS applies no relevance ranking to a match set this broad, so these false positives can land anywhere in the result order — including position 1, which is exactly the non-deterministic-looking symptom in the issue (the same query returns different top results across calls).

`ta=` (title + abstract only) scopes the match to text that specifically describes the invention, cutting the candidate pool 10–14x and eliminating the false positives in live testing.

## Fix

`internal/search/epo.go` — `buildCQL` now emits `ta=` instead of `txt=` for both the per-keyword clauses and the no-filter fallback clause. No other clause type (`pa=`, `in=`, `pn=`, `cpc=`, `pd>=`/`pd<=`) is affected.

## Out of scope (confirmed separately, per the issue's own note)

The issue also flagged `patent_search(..., provider: "searchapi")` hitting `"circuit breaker open"`. Confirmed directly against SearchAPI's endpoint: `429 "You have used all of the searches for the month. Please upgrade your plan on SearchApi.io."` — this is the configured SearchAPI test account's own exhausted monthly quota, correctly tripping our breaker. Not a product bug; no action taken here.

## KPIs / success criteria

- `buildCQL` emits `ta=`, never `txt=`, for keyword clauses — locked in by `TestEPOProvider_CQLConstruction`.
- Zero regression to the other clause types (assignee/inventor/office/cpc/date range) — unchanged, covered by the same table.
- No live-EPO CI test added: EPO credentials aren't available in CI (free-registration, optional feature). Live evidence above was gathered manually against the real OPS API with locally configured credentials and is not repeatable in CI — the deterministic, CI-enforced regression guard is the updated `buildCQL` unit test table.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test -race ./internal/search/...` — all EPO provider tests pass, including the updated/added CQL construction cases
- [x] `golangci-lint run ./internal/search/...` — 0 issues
- [x] Live verification against the real EPO OPS API reproducing the exact reported bug (`txt=`) and confirming the fix (`ta=`)
- [x] Live verification that the SearchAPI breaker report is an unrelated, already-exhausted account quota

Fixes #623