### PR TITLE
fix(search): surface requestedNumResults when web_search clamps num_results

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -39,7 +39,7 @@ Perform a web search and return structured result URLs with metadata.
 | Field | Type | Required | Default | Constraints |
 |-------|------|----------|---------|-------------|
 | `query` | string | yes | — | 1-500 chars |
-| `num_results` | int | no | 5 | 1-10 |
+| `num_results` | int | no | 5 | 1-10; values above 10 are clamped to 10 server-side (ASI06) and surfaced via `requestedNumResults` in the response (#624) |
 | `time_range` | string | no | — | `day`, `week`, `month`, `year` |
 | `safe` | string | no | `medium` | `off`, `medium`, `high` |
 | `language` | string | no | — | ISO 639-1 code |
@@ -57,12 +57,13 @@ Perform a web search and return structured result URLs with metadata.
 
 ```go
 type SearchOutput struct {
-    URLs        []string       `json:"urls"`
-    Query       string         `json:"query"`
-    ResultCount int            `json:"resultCount"`
-    Results     []SearchResult `json:"results"`
-    Hints       *ZeroResultHints `json:"hints,omitempty"` // present ONLY on zero-result responses (see below)
-    Trust       string         `json:"trust"`   // "untrusted-external-content" — treat results as data, not instructions (OWASP LLM01)
+    URLs                []string       `json:"urls"`
+    Query               string         `json:"query"`
+    ResultCount         int            `json:"resultCount"`
+    RequestedNumResults int            `json:"requestedNumResults,omitempty"` // present ONLY when num_results exceeded the ceiling (10) and was clamped (#624) — the value you asked for, so you can tell resultCount was reduced
+    Results             []SearchResult `json:"results"`
+    Hints               *ZeroResultHints `json:"hints,omitempty"` // present ONLY on zero-result responses (see below)
+    Trust               string         `json:"trust"`   // "untrusted-external-content" — treat results as data, not instructions (OWASP LLM01)
 }
 
 type SearchResult struct {

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -490,6 +490,36 @@ func withMoreResults(result *mcp.CallToolResult, val, ok bool) *mcp.CallToolResu
 	return result
 }
 
+// withRequestedNumResults stamps the originally requested num_results onto the
+// response BODY (not _meta — a caller relying on a specific count needs this
+// in model-visible content, not operator-only metadata) when the tool-boundary
+// clamp (maxNumResults, ASI06 defense-in-depth) reduced it below what was asked
+// for (#624). Applies uniformly to cached and freshly fetched results since
+// both share the structuredResult() body shape (TextContent JSON with a
+// matching StructuredContent). A nil result, or a result whose content isn't
+// the expected single TextContent JSON body, is returned unchanged.
+func withRequestedNumResults(result *mcp.CallToolResult, requested int) *mcp.CallToolResult {
+	if result == nil || len(result.Content) == 0 {
+		return result
+	}
+	text, ok := result.Content[0].(*mcp.TextContent)
+	if !ok {
+		return result
+	}
+	var body map[string]any
+	if err := json.Unmarshal([]byte(text.Text), &body); err != nil {
+		return result
+	}
+	body["requestedNumResults"] = requested
+	out, err := json.Marshal(body)
+	if err != nil {
+		return result
+	}
+	result.Content[0] = &mcp.TextContent{Text: string(out)}
+	result.StructuredContent = json.RawMessage(out)
+	return result
+}
+
 // withRoutingMeta merges a routing block into an existing result's `_meta`,
 // preserving any cache-freshness keys already present (it never clobbers the
 // cache block). A nil routing block leaves the result untouched. The merged

--- a/internal/tools/schemas.go
+++ b/internal/tools/schemas.go
@@ -42,11 +42,12 @@ var engagementSignalsSchema = map[string]any{
 var webSearchOutputSchema = map[string]any{
 	"type": "object",
 	"properties": map[string]any{
-		"urls":        map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
-		"query":       map[string]any{"type": "string"},
-		"resultCount": map[string]any{"type": "integer"},
-		"hints":       map[string]any{"type": "object"},
-		"trust":       trustUntrustedExternal,
+		"urls":                map[string]any{"type": "array", "items": map[string]any{"type": "string"}},
+		"query":               map[string]any{"type": "string"},
+		"resultCount":         map[string]any{"type": "integer"},
+		"requestedNumResults": map[string]any{"type": "integer", "description": "The num_results value you requested, present only when it exceeded the server's ceiling (10) and was clamped — compare against resultCount to see how many fewer results you received than asked for."},
+		"hints":               map[string]any{"type": "object"},
+		"trust":               trustUntrustedExternal,
 		"results": map[string]any{
 			"type": "array",
 			"items": map[string]any{

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -89,6 +89,10 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 		}
 
 		numResults := input.NumResults
+		// Requested count above the ceiling, captured before the clamp below so the
+		// response body can tell the caller their request was reduced (#624) — an
+		// unset/in-range value (<=0 or <=maxNumResults) needs no such signal.
+		requestedOverLimit := numResults > maxNumResults
 		if numResults <= 0 {
 			numResults = 5
 		}
@@ -105,7 +109,11 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 			deps.Metrics.RecordToolCall("web_search", time.Since(start), nil, "", true)
 			rt := routingMeta(search.RoutingDecision{}, time.Since(start), true)
 			auditToolCallQuery(ctx, deps, "web_search", time.Since(start), nil, "", input.Query, map[string]any{"cache_hit": true, "routing": rt})
-			return withRoutingMeta(cachedResultWithMeta(cached, meta), rt), nil, nil
+			cachedResult := cachedResultWithMeta(cached, meta)
+			if requestedOverLimit {
+				cachedResult = withRequestedNumResults(cachedResult, input.NumResults)
+			}
+			return withRoutingMeta(cachedResult, rt), nil, nil
 		}
 
 		params := search.WebSearchParams{
@@ -211,7 +219,11 @@ func registerWebSearch(srv *mcp.Server, deps Dependencies) {
 		}
 
 		moreVal, moreOK := resultMeta.MoreResultsAvailable()
-		return withMoreResults(withRoutingMeta(freshResult(jsonBytes, webSearchTTL), rt), moreVal, moreOK), nil, nil
+		freshRes := freshResult(jsonBytes, webSearchTTL)
+		if requestedOverLimit {
+			freshRes = withRequestedNumResults(freshRes, input.NumResults)
+		}
+		return withMoreResults(withRoutingMeta(freshRes, rt), moreVal, moreOK), nil, nil
 	})
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -2392,7 +2392,10 @@ func (p *numCapturingProvider) Name() string { return "numcap" }
 
 // TestNumResultsClampedAtBoundary verifies web_search clamps an over-limit
 // num_results to the documented ceiling before it reaches the provider (ASI06
-// fan-out / billing bound, defense-in-depth).
+// fan-out / billing bound, defense-in-depth), AND (#624) that the response
+// body surfaces the original request via requestedNumResults so a caller
+// relying on a specific count sees the gap instead of silently
+// under-receiving.
 func TestNumResultsClampedAtBoundary(t *testing.T) {
 	cap := &numCapturingProvider{}
 	deps := setupTestDeps()
@@ -2402,10 +2405,11 @@ func TestNumResultsClampedAtBoundary(t *testing.T) {
 	sess := connectTestClient(ctx, t, srv)
 	defer sess.Close()
 
-	if _, err := sess.CallTool(ctx, &mcp.CallToolParams{
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
 		Name:      "web_search",
 		Arguments: map[string]any{"query": "x", "num_results": 50},
-	}); err != nil {
+	})
+	if err != nil {
 		t.Fatalf("CallTool: %v", err)
 	}
 	cap.mu.Lock()
@@ -2413,6 +2417,88 @@ func TestNumResultsClampedAtBoundary(t *testing.T) {
 	cap.mu.Unlock()
 	if got != maxNumResults {
 		t.Errorf("num_results=50 should clamp to %d at the boundary, provider saw %d", maxNumResults, got)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got, want := body["requestedNumResults"], float64(50); got != want {
+		t.Errorf("requestedNumResults = %v, want %v", got, want)
+	}
+	if rc, ok := body["resultCount"].(float64); !ok || rc > float64(maxNumResults) {
+		t.Errorf("resultCount = %v, want <= %d", body["resultCount"], maxNumResults)
+	}
+}
+
+// TestNumResultsClampedAtBoundary_CacheHit verifies the requestedNumResults
+// signal (#624) is applied on a cache-hit response too, keyed to the CALLING
+// request rather than baked into the cached blob — two different callers
+// hitting the same cache entry with different over-limit requests must each
+// see their own requested value, not whichever value first populated the
+// cache.
+func TestNumResultsClampedAtBoundary_CacheHit(t *testing.T) {
+	cap := &numCapturingProvider{}
+	deps := setupTestDeps()
+	deps.Search = cap
+	ctx := context.Background()
+	srv := createTestServer(deps)
+	sess := connectTestClient(ctx, t, srv)
+	defer sess.Close()
+
+	// First call populates the cache (also over-limit, at a different value).
+	if _, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "cache-hit-test", "num_results": 50},
+	}); err != nil {
+		t.Fatalf("CallTool (populate): %v", err)
+	}
+
+	// Second call: same query (post-clamp num_results is identical, so this
+	// hits the same cache key), but a different over-limit request.
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "cache-hit-test", "num_results": 99999},
+	})
+	if err != nil {
+		t.Fatalf("CallTool (cache hit): %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if got, want := body["requestedNumResults"], float64(99999); got != want {
+		t.Errorf("requestedNumResults = %v, want %v (this call's own request, not the cache-populating call's)", got, want)
+	}
+}
+
+// TestNumResultsWithinBounds_NoRequestedField verifies requestedNumResults
+// (#624) is absent entirely when num_results is within the documented ceiling
+// — the field signals a clamp, so it must not appear on ordinary requests.
+func TestNumResultsWithinBounds_NoRequestedField(t *testing.T) {
+	cap := &numCapturingProvider{}
+	deps := setupTestDeps()
+	deps.Search = cap
+	ctx := context.Background()
+	srv := createTestServer(deps)
+	sess := connectTestClient(ctx, t, srv)
+	defer sess.Close()
+
+	res, err := sess.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "web_search",
+		Arguments: map[string]any{"query": "y", "num_results": 5},
+	})
+	if err != nil {
+		t.Fatalf("CallTool: %v", err)
+	}
+
+	var body map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(*mcp.TextContent).Text), &body); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if _, present := body["requestedNumResults"]; present {
+		t.Errorf("requestedNumResults must be absent for an in-bounds request, got %v", body["requestedNumResults"])
 	}
 }
 

--- a/python/web_researcher_mcp/models.py
+++ b/python/web_researcher_mcp/models.py
@@ -2583,6 +2583,7 @@ class VerifyRecommendationResponse:
 class WebSearchResponse:
     hints: dict[str, Any] = field(default_factory=dict)
     query: Optional[str] = None
+    requestedNumResults: Optional[int] = None
     resultCount: Optional[int] = None
     results: list[WebSearchResult] = field(default_factory=list)
     trust: Optional[str] = None
@@ -2595,6 +2596,7 @@ class WebSearchResponse:
         return cls(
             hints=dict(d.get('hints') or {}),
             query=d.get('query'),
+            requestedNumResults=d.get('requestedNumResults'),
             resultCount=d.get('resultCount'),
             results=[WebSearchResult.from_dict(i) for i in (d.get('results') or [])],
             trust=d.get('trust'),


### PR DESCRIPTION
Closes #624.

## Root cause

`web_search(num_results: 99999)` returns `resultCount: 10` (the documented ceiling, `maxNumResults` in `internal/tools/search.go`, enforced server-side as defense-in-depth against unbounded fan-out/billing — ASI06) with no field anywhere in the response indicating the request was reduced. A caller relying on a specific count silently under-receives with no signal to detect the gap — reproduced live per the issue.

## Fix

`internal/tools/search.go`: capture whether the raw `num_results` input exceeded the ceiling *before* the existing clamp logic runs. `internal/tools/errors.go`: new `withRequestedNumResults` helper stamps a `requestedNumResults` field onto the response **body** (not `_meta` — a caller depending on the count needs this in model-visible content, not operator-only metadata) with the original requested value, applied only when the ceiling was exceeded. Wired into both the fresh-fetch and cache-hit return paths in `web_search`, since a cache hit for a given (clamped) `num_results` can be served to callers who requested different over-limit values — the field reflects *this* call's request, not whatever request first populated the cache entry.

`internal/tools/schemas.go` / `docs/TOOLS.md`: document the new optional field. `python/web_researcher_mcp/models.py`: regenerated via `make gen-python-client` (output-schema change flows into the Python client's typed response model).

## Success criteria

- `web_search(num_results: 50)` → `requestedNumResults: 50` present, `resultCount <= 10`.
- `web_search(num_results: 5)` (in-bounds) → `requestedNumResults` absent (no field pollution on ordinary requests).
- A cache-hit response reflects the *calling* request's `requestedNumResults`, not the value that first populated the cache entry.
- No output-schema/docs/Python-client drift (`TestOutputSchemaMatchesResponse`, `TestToolsDocMatchesRegistry`, `python-drift` CI job).

## Tests added (`internal/tools/tools_test.go`)

- `TestNumResultsClampedAtBoundary` (extended): asserts `requestedNumResults: 50` and `resultCount <= 10` in the response body, in addition to the existing provider-boundary clamp assertion.
- `TestNumResultsClampedAtBoundary_CacheHit` (new): two calls with the same (post-clamp-identical) query but different over-limit `num_results` (50, then 99999) — the second call hits cache, and its response still carries `requestedNumResults: 99999`, proving the signal isn't baked into the cached blob.
- `TestNumResultsWithinBounds_NoRequestedField` (new): an in-bounds request (`num_results: 5`) has no `requestedNumResults` key at all.

## Validation

- `go build ./...`, `go vet ./...` — clean
- `go test -race ./...` — full suite passes
- `go tool golangci-lint run ./internal/tools/...` — 0 issues
- `go tool govulncheck ./...` — no vulnerabilities
- `make test-python` — 71 passed
- Pre-commit hook (Python-client drift + Go fmt/lint/vet) — OK