### PR TITLE
docs(dist): add Chocolatey install instructions to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,11 @@ scoop bucket add zoharbabin https://github.com/zoharbabin/scoop-bucket
 scoop install web-researcher-mcp
 ```
 
+**Chocolatey (Windows):**
+```powershell
+choco install web-researcher-mcp
+```
+
 **Homebrew Cask (macOS — Developer ID-signed + notarized binary):**
 ```bash
 brew install --cask zoharbabin/tap/web-researcher-mcp

--- a/docs/RELEASE_SIGNING.md
+++ b/docs/RELEASE_SIGNING.md
@@ -111,7 +111,7 @@ Signing unlocks the OS package managers — some validate/prefer signed binaries
 
 PATs cannot be minted by `gh`/the API (browser-only by design): GitHub → Settings → Developer settings → Fine-grained tokens.
 
-> **Chocolatey:** the first submission goes through manual moderation; README.md does not yet document a `choco install web-researcher-mcp` line. All other channels (WinGet, Scoop, Homebrew Cask) are already live.
+> **Chocolatey:** moderation cleared for v1.49.0 (`PackageStatus: Approved`) — all four channels (WinGet, Scoop, Chocolatey, Homebrew Cask) are live. README.md documents `choco install web-researcher-mcp`.
 
 ## Local secret convention (maintainer)
 


### PR DESCRIPTION
## Summary
- Adds the `choco install web-researcher-mcp` section to README.md (moderation cleared for v1.49.0 — `PackageStatus: Approved`)
- Corrects `docs/RELEASE_SIGNING.md`'s stale note that said README didn't document Chocolatey yet

Fixes #493

Note: #493 was closed earlier today with a comment claiming this was already done — that claim was incorrect (README had no Chocolatey section at the time). This PR lands the actual fix.