### PR TITLE
ci: bump github/codeql-action init/autobuild/analyze to 4.37.8

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,15 +43,15 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           languages: go
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
+        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
         with:
           category: "/language:go"


### PR DESCRIPTION
## Summary
- Bumps `github/codeql-action/init`, `autobuild`, and `analyze` to v4.37.8 together in `.github/workflows/codeql.yml`.
- Supersedes #690, #689, #686, which each bumped one action reference in isolation. CodeQL requires all three to be the same version — that's why each of those PRs failed CI with `Loaded a configuration file for version '4.37.7', but running version '4.37.8'`.

## Test plan
- [x] CI green on this branch (CodeQL · Go job passes with matched versions)