### PR TITLE
fix(verify_citation): gate claimAddressed on the claim's distinguishing entity

### DIFF
--- a/internal/content/claim.go
+++ b/internal/content/claim.go
@@ -389,6 +389,78 @@ func claimHasMatchedNumber(terms []string, words map[string]struct{}) bool {
 	return false
 }
 
+// claimSentenceSplitter is a lightweight sentence boundary for
+// claimDistinguishingTerms — deliberately not splitSentences, which drops
+// fragments under 12 chars (fine for evidence extraction over long body text,
+// wrong here since claims themselves are often short single sentences).
+var claimSentenceSplitter = regexp.MustCompile(`[.!?]+\s+`)
+
+// claimDistinguishingTerms returns the subset of terms whose token was
+// capitalized in the original claim text and was not the first word of a
+// sentence — i.e. proper-noun-like tokens the claim itself singles out as
+// specific, as opposed to generic/topic vocabulary (#675). A raw ratio of
+// matched/total claim terms weighs "study" and "Alzheimer's" equally; this
+// identifies the terms that actually make a claim specific (and, in a false
+// claim, wrong). Sentence-initial capitalization is a grammar artifact
+// ("This study...") and is excluded so ordinary claim-opening words are never
+// mistaken for a distinguishing entity.
+func claimDistinguishingTerms(claim string, terms []string) []string {
+	termSet := make(map[string]struct{}, len(terms))
+	for _, t := range terms {
+		termSet[t] = struct{}{}
+	}
+
+	var distinguishing []string
+	seen := make(map[string]struct{})
+	for _, sentence := range claimSentenceSplitter.Split(strings.TrimSpace(claim), -1) {
+		fields := strings.FieldsFunc(sentence, func(r rune) bool {
+			return !unicode.IsLetter(r) && !unicode.IsNumber(r)
+		})
+		for i, f := range fields {
+			if i == 0 || !unicode.IsUpper([]rune(f)[0]) {
+				continue
+			}
+			lower := strings.ToLower(f)
+			if _, ok := termSet[lower]; !ok {
+				continue
+			}
+			if _, dup := seen[lower]; dup {
+				continue
+			}
+			seen[lower] = struct{}{}
+			distinguishing = append(distinguishing, lower)
+		}
+	}
+	return distinguishing
+}
+
+// ClaimDistinguishingTermsCovered reports whether every claim-critical
+// distinguishing term (#675, see claimDistinguishingTerms) appears in text.
+// hasDistinguishing reports whether the claim had any such term to check at
+// all — when false, the caller should fall back to ratio-only behavior
+// unchanged, since there is nothing distinguishing to gate on (e.g. a purely
+// quantitative or generic claim). This is a document-level presence check
+// (like ClaimTermCoverage, not the windowed peak) because a missing
+// distinguishing term is missing regardless of which window the raw ratio
+// peaks in.
+func ClaimDistinguishingTermsCovered(text, claim string) (covered, hasDistinguishing bool) {
+	terms := claimTerms(claim)
+	distinguishing := claimDistinguishingTerms(claim, terms)
+	if len(distinguishing) == 0 {
+		return true, false
+	}
+	if strings.TrimSpace(text) == "" {
+		return false, true
+	}
+	words := wordSet(strings.ToLower(stripReferencesSection(text)))
+	for _, t := range distinguishing {
+		if !termMatches(words, t) {
+			return false, true
+		}
+	}
+	return true, true
+}
+
 // termSuffixes are inflectional endings stripped by stemTerm so a claim term
 // and its inflected form in the source text (e.g. claim "voted" vs. source
 // "vote") are recognized as the same word (#523). Ordered longest first so

--- a/internal/content/claim_test.go
+++ b/internal/content/claim_test.go
@@ -376,6 +376,53 @@ func TestClaimTermCoverageWindowedExcludesNumberedReferenceListWithoutHeader(t *
 // TestClaimTermsKeepsNumericTokens reproduces part of #523: a claim's
 // numeric-only tokens (e.g. a vote count) must survive tokenization even
 // though they're shorter than the 3-char minimum applied to words.
+// TestClaimDistinguishingTermsExcludesSentenceInitialWords is a regression
+// test for #675: sentence-initial capitalization ("This study...") is a
+// grammar artifact, not a signal of significance, and must not be flagged as
+// a distinguishing term.
+func TestClaimDistinguishingTermsExcludesSentenceInitialWords(t *testing.T) {
+	claim := "This study demonstrates CRISPR-Cas9 CAR-T cures Alzheimer's disease"
+	terms := claimTerms(claim)
+	distinguishing := claimDistinguishingTerms(claim, terms)
+	joined := strings.Join(distinguishing, ",")
+	for _, want := range []string{"crispr", "cas9", "car", "alzheimer"} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("expected distinguishing term %q, got %v", want, distinguishing)
+		}
+	}
+	for _, notWant := range []string{"this", "study", "demonstrates", "cures", "disease"} {
+		if strings.Contains(joined, notWant) {
+			t.Errorf("generic/sentence-initial term %q must not be distinguishing, got %v", notWant, distinguishing)
+		}
+	}
+}
+
+// TestClaimDistinguishingTermsCoveredRequiresAllToMatch is the direct
+// regression test for #675's ratio-blind-spot fix: a real CAR-T/CRISPR-Cas9
+// source that matches most of a false claim's capitalized terms but not its
+// one actually-distinguishing entity (Alzheimer's) must report covered=false.
+func TestClaimDistinguishingTermsCoveredRequiresAllToMatch(t *testing.T) {
+	text := "This paper describes a CRISPR-Cas9 CAR-T therapy for lymphoma patients."
+	claim := "This study demonstrates CRISPR-Cas9 CAR-T cures Alzheimer's disease"
+	covered, hasDistinguishing := ClaimDistinguishingTermsCovered(text, claim)
+	if !hasDistinguishing {
+		t.Fatal("expected claim with capitalized proper nouns to have distinguishing terms")
+	}
+	if covered {
+		t.Error("expected covered=false: Alzheimer's never appears in the source")
+	}
+}
+
+// TestClaimDistinguishingTermsCoveredNoDistinguishingTerms guards the
+// fallback: a claim with no capitalized/distinguishing terms reports
+// hasDistinguishing=false so callers apply ratio-only behavior unchanged.
+func TestClaimDistinguishingTermsCoveredNoDistinguishingTerms(t *testing.T) {
+	_, hasDistinguishing := ClaimDistinguishingTermsCovered("some source text", "cell therapy cures cancer")
+	if hasDistinguishing {
+		t.Error("a claim with no capitalized terms must report hasDistinguishing=false")
+	}
+}
+
 func TestClaimTermsKeepsNumericTokens(t *testing.T) {
 	terms := claimTerms("The FOMC voted 9-3 with Hammack, Kashkari, and Logan dissenting")
 	joined := strings.Join(terms, ",")

--- a/internal/tools/claim_coverage.go
+++ b/internal/tools/claim_coverage.go
@@ -111,6 +111,13 @@ func claimCoverageFromContent(body, fetchURL, claim string) claimCoverageResult 
 	// was actually read). Partial overlap → evidence shown, NOT flagged (the human
 	// judges). Strong overlap → addressed.
 	matched, total := content.ClaimTermCoverageWindowed(body, claim, 0)
+	// A claim's distinguishing entity (e.g. "Alzheimer's" in a claim that is
+	// otherwise all generic study/disease vocabulary) can be entirely absent
+	// from the source while enough incidental terms still clear the ratio
+	// threshold below (#675) — so it gates claimAddressed independently of
+	// the ratio, never loosening it (a claim with no distinguishing term at
+	// all is unaffected).
+	distinguishingCovered, hasDistinguishing := content.ClaimDistinguishingTermsCovered(body, claim)
 	ev := content.ExtractClaimEvidence(body, claim)
 	// content.WordCount, not strings.Fields: CJK/Thai/Lao/Khmer/Myanmar text has
 	// no inter-word spaces, so a complete non-Latin-script source would otherwise
@@ -135,7 +142,7 @@ func claimCoverageFromContent(body, fetchURL, claim string) claimCoverageResult 
 		out.Support = claimPartiallyAddressed
 	case matched == 0:
 		out.Support = claimNotAddressed
-	case float64(matched)/float64(total) >= claimAddressedThreshold:
+	case float64(matched)/float64(total) >= claimAddressedThreshold && (!hasDistinguishing || distinguishingCovered):
 		out.Support = claimAddressed
 	default:
 		out.Support = claimPartiallyAddressed

--- a/internal/tools/claim_coverage_test.go
+++ b/internal/tools/claim_coverage_test.go
@@ -26,6 +26,61 @@ func TestSanitizeClaimFetchError_MasksSecrets(t *testing.T) {
 	}
 }
 
+// carTLymphomaAbstract is the real abstract of the live #675 repro source
+// (nature.com/articles/s41586-022-05140-y, fetched 2026-08-24) — a CAR-T/CRISPR-Cas9
+// lymphoma paper that never mentions Alzheimer's.
+const carTLymphomaAbstract = `Recently, chimeric antigen receptor (CAR)-T cell therapy has shown great ` +
+	`promise in treating haematological malignancies. However, CAR-T cell therapy currently has several ` +
+	`limitations. Here we successfully developed a two-in-one approach to generate non-viral, gene-specific ` +
+	`targeted CAR-T cells through CRISPR-Cas9. Using the optimized protocol, we demonstrated feasibility in a ` +
+	`preclinical study by inserting an anti-CD19 CAR cassette into the AAVS1 safe-harbour locus. Furthermore, ` +
+	`an innovative type of anti-CD19 CAR-T cell with PD1 integration was developed and showed superior ability ` +
+	`to eradicate tumour cells in xenograft models. In adoptive therapy for relapsed or refractory aggressive ` +
+	`B cell non-Hodgkin lymphoma, we observed a high rate of 87.5 percent complete remission and durable ` +
+	`responses without serious adverse events in eight patients. Notably, these enhanced CAR-T cells were ` +
+	`effective even at a low infusion dose and with a low percentage of CAR-positive cells. Single-cell ` +
+	`analysis showed that the electroporation method resulted in a high percentage of memory T cells in ` +
+	`infusion products, and PD1 interference enhanced anti-tumour immune functions, further validating the ` +
+	`advantages of non-viral, PD1-integrated CAR-T cells. Collectively, our results demonstrate the high ` +
+	`safety and efficacy of non-viral, gene-specific integrated CAR-T cells, thus providing an innovative ` +
+	`technology for CAR-T cell therapy.`
+
+// TestClaimCoverageFromContent_DistinguishingEntityGate is a regression test for
+// #675: the real CAR-T/CRISPR-Cas9 lymphoma paper above genuinely mentions CRISPR,
+// Cas9, and CAR — enough generic/topic overlap to have cleared claimAddressedThreshold
+// under the old pure-ratio gate — but never mentions the fabricated claim's one
+// actually-distinguishing (and false) entity, Alzheimer's. That must block
+// claimAddressed regardless of how much other vocabulary matched.
+func TestClaimCoverageFromContent_DistinguishingEntityGate(t *testing.T) {
+	claim := "This study demonstrates CRISPR-Cas9 CAR-T cures Alzheimer's disease"
+	out := claimCoverageFromContent(carTLymphomaAbstract, "https://example.com/paper", claim)
+	if out.Support == claimAddressed {
+		t.Errorf("false claim with an unmatched distinguishing entity (Alzheimer's) must not reach claimAddressed, got %q", out.Support)
+	}
+}
+
+// TestClaimCoverageFromContent_DistinguishingEntityGateAllowsTrueClaim guards the
+// no-regression requirement from #675: a claim whose distinguishing entities all
+// genuinely appear in the source must still reach claimAddressed.
+func TestClaimCoverageFromContent_DistinguishingEntityGateAllowsTrueClaim(t *testing.T) {
+	claim := "CRISPR-Cas9 CAR-T cells achieved 87.5 percent complete remission in B cell lymphoma patients"
+	out := claimCoverageFromContent(carTLymphomaAbstract, "https://example.com/paper", claim)
+	if out.Support != claimAddressed {
+		t.Errorf("true claim whose distinguishing entities all match must reach claimAddressed, got %q", out.Support)
+	}
+}
+
+// TestClaimCoverageFromContent_DistinguishingEntityGateNoDistinguishingTerms
+// guards #675's fallback: a claim made entirely of generic/lowercase vocabulary
+// has no distinguishing term to gate on, so ratio-only behavior must be unchanged.
+func TestClaimCoverageFromContent_DistinguishingEntityGateNoDistinguishingTerms(t *testing.T) {
+	claim := "cell therapy cures cancer with high safety and efficacy"
+	out := claimCoverageFromContent(carTLymphomaAbstract, "https://example.com/paper", claim)
+	if out.Support != claimAddressed {
+		t.Errorf("claim with no distinguishing term should fall back to ratio-only behavior, got %q", out.Support)
+	}
+}
+
 // TestClaimCoverageFromContent_CJKNotMisflaggedAsSparse is a regression test:
 // claimCoverageFromContent used strings.Fields to count words, which collapses
 // a complete CJK article (no ASCII whitespace) to ~1 "word" and fires a false


### PR DESCRIPTION
## Summary
- `claimCoverageFromContent` gated `claimAddressed` purely on the matched/total term ratio, weighing generic vocabulary the same as a claim's one actually-distinguishing entity.
- Live repro (verified against the real source): a false claim ("...CRISPR-Cas9 CAR-T cures Alzheimer's disease") against a real CAR-T/lymphoma paper returned `claimAddressed`, because the paper genuinely discusses CRISPR-Cas9/CAR-T — just never Alzheimer's.
- Added `content.ClaimDistinguishingTermsCovered`: identifies capitalized, non-sentence-initial claim terms and requires ALL of them to be present in the source before `claimAddressed` is allowed. Claims with no such term are unaffected (ratio-only fallback).

Note on deviation from the issue's "How" wording: the issue's step 2 describes capping when "none" of the distinguishing terms matched. Verifying against the real repro source showed 3 of the claim's 4 distinguishing terms (CRISPR, Cas9, CAR) do genuinely appear in the paper — only "Alzheimer's" is absent. A "none matched" gate would not have blocked this exact repro, so the gate requires ALL distinguishing terms to match, not just one.

## Test plan
- [x] `go test ./internal/content/... ./internal/tools/...` — all pass, including new regression tests using the real paper's abstract text
- [x] `go test -race ./internal/content/... ./internal/tools/...`
- [x] `go vet ./...`
- [x] `go tool golangci-lint run ./internal/content/... ./internal/tools/...` — 0 issues
- [x] True-claim and no-distinguishing-term cases added to guard against regressing #523

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)