### PR TITLE
fix(scraper): DNS NXDOMAIN classification + soft bot-wall detection

### DIFF
--- a/docs/ERROR_HANDLING.md
+++ b/docs/ERROR_HANDLING.md
@@ -78,14 +78,14 @@ type ScrapeError struct {
 
 | Kind | Constant | Triggers | Tier Examples |
 |------|----------|----------|---------------|
-| Network | `ErrNetwork` | DNS failure, timeout, connection refused, TLS error | Any tier's HTTP client |
+| Network | `ErrNetwork` | Transient fault: timeout, connection refused, TLS error (NOT a DNS NXDOMAIN — see Not Found) | Any tier's HTTP client |
 | Validation | `ErrValidation` | Unsupported scheme, empty host, SSRF / private-IP / blocked-hostname denial, domain allowlist | pipeline (validation chokepoint) |
-| Blocked | `ErrBlocked` | HTTP 403, remote bot detection (a real site refusing us) | stealth/html (403) |
+| Blocked | `ErrBlocked` | HTTP 403, remote bot detection (a real site refusing us) — hard interstitials (Cloudflare/CAPTCHA/Anubis PoW) and soft signup/login/subscribe gates (Crunchbase/SimilarWeb-style anti-bot pages) alike | stealth/html (403) |
 | Browser | `ErrBrowser` | Chrome not found, launch failed, connect failed | browser tier only |
 | Content | `ErrContent` | Page loaded but <100 bytes of useful text extracted | All tiers (composite failure) |
 | Auth | `ErrAuth` | HTTP 401, login redirect detected | stealth, html |
 | Rate Limit | `ErrRateLimit` | HTTP 429 | Any tier's HTTP client |
-| Not Found | `ErrNotFound` | HTTP 404/410 — dead link, resource gone | stealth/html/browser |
+| Not Found | `ErrNotFound` | HTTP 404/410 (dead link), or a DNS NXDOMAIN ("no such host" / `ERR_NAME_NOT_RESOLVED`) — the domain does not exist and never will on retry | stealth/html/browser, and `networkError()` for any tier's raw dial failure |
 
 `ErrValidation` is distinct from `ErrBlocked` on purpose: a validation/security rejection is a **permanent** client error (the URL itself is invalid or disallowed), so it is **never retryable** and must not be reported as transient bot-detection. `ErrBlocked` is reserved for a real remote site actively refusing the request (HTTP 403 / bot walls), which is retryable from a different source.
 
@@ -95,7 +95,7 @@ Each tier uses these to create appropriately-typed errors:
 
 | Function | Creates | Used By |
 |----------|---------|---------|
-| `networkError(url, tier, cause)` | `ErrNetwork` | All tiers on HTTP failures |
+| `networkError(url, tier, cause)` | `ErrNetwork`, or `ErrNotFound` when `cause` is a DNS NXDOMAIN (`isDNSNotFound`: "no such host" / `ERR_NAME_NOT_RESOLVED`) | All tiers on HTTP/dial failures |
 | `validationError(url, tier, cause, detail)` | `ErrValidation` | Pipeline chokepoint on bad scheme/host, SSRF denial, allowlist |
 | `blockedError(url, tier, cause, detail)` | `ErrBlocked` | stealth/html on remote HTTP 403 |
 | `browserError(url, cause, detail)` | `ErrBrowser` | browser tier on init/launch failure |
@@ -165,9 +165,9 @@ Rate limited (google). Wait 60 seconds and retry, or try a different provider.
 | `auth_required` | Provider HTTP 401 / invalid API key → `check_api_key`; scrape login wall (`ErrAuth`) → `inform_user` | false | `check_api_key` (provider) or `inform_user` (scrape) |
 | `blocked` | HTTP 403, remote bot detection | false | `inform_user` |
 | `validation` | Invalid input params, unsupported scheme, or SSRF / private-IP / blocked-host / allowlist denial | false | `inform_user` |
-| `network` | DNS failure, timeout, connection refused | true | `retry_after_delay` |
+| `network` | Transient fault: timeout, connection refused (NOT DNS NXDOMAIN — see `not_found`) | true | `retry_after_delay` |
 | `content_empty` | Page loaded but no text extracted | true | `report_bug` |
-| `not_found` | HTTP 404/410 — page does not exist (dead link) | false | `inform_user` |
+| `not_found` | HTTP 404/410 (page does not exist), or a DNS NXDOMAIN (domain does not exist) | false | `inform_user` |
 | `browser_unavailable` | Chrome not found/failed | false | `report_bug` |
 | `config` | Unknown/unconfigured provider | false | `try_different_provider` or `check_api_key` |
 | `upstream_unavailable` | General provider failure | true | `try_different_provider` |

--- a/internal/scraper/errors.go
+++ b/internal/scraper/errors.go
@@ -8,14 +8,14 @@ import (
 type ErrorKind int
 
 const (
-	ErrNetwork    ErrorKind = iota // DNS, timeout, connection refused, TLS
+	ErrNetwork    ErrorKind = iota // transient network fault: timeout, connection refused, TLS (NOT DNS NXDOMAIN — that's ErrNotFound, a permanent failure)
 	ErrBlocked                     // remote bot detection / HTTP 403 (a real site refusing us)
 	ErrBrowser                     // Chrome not found, launch failed, connect failed
 	ErrContent                     // Page loaded but no usable content extracted
 	ErrAuth                        // HTTP 401, login redirect
 	ErrRateLimit                   // HTTP 429
 	ErrValidation                  // permanent client/security rejection: bad scheme, empty host, SSRF / private-IP / blocked-hostname denial. NOT retryable.
-	ErrNotFound                    // HTTP 404/410 — the resource does not exist. Definite, NOT retryable (a dead link, not a transient fault).
+	ErrNotFound                    // HTTP 404/410, or a DNS NXDOMAIN ("no such host") — the resource/domain does not exist. Definite, NOT retryable (a dead link, not a transient fault).
 )
 
 // scrapeKindPriority ranks error kinds by how DEFINITIVE they are, so the
@@ -63,7 +63,28 @@ func newScrapeError(kind ErrorKind, url, tier string, cause error, msg string) *
 	return &ScrapeError{Kind: kind, Message: msg, Cause: cause, URL: url, Tier: tier}
 }
 
+// isDNSNotFound reports whether a raw dial/navigation error is a DNS NXDOMAIN
+// — Go's HTTP client says "no such host"; go-rod/Chrome's navigation error
+// says "ERR_NAME_NOT_RESOLVED". Both mean the domain does not exist and never
+// will on retry: a PERMANENT failure, distinct from a transient dial/timeout
+// fault.
+func isDNSNotFound(cause error) bool {
+	if cause == nil {
+		return false
+	}
+	return containsAny(cause.Error(), "no such host", "err_name_not_resolved")
+}
+
+// networkError classifies a raw dial/HTTP failure. Every scrape tier
+// (markdown, stealth, html, jina, browser, and every native-route scraper)
+// funnels its raw client error through this single call site, so a DNS
+// NXDOMAIN is caught once here — reported as ErrNotFound (permanent,
+// non-retryable) rather than the generic ErrNetwork bucket the tool layer
+// unconditionally marks retryable (issue #674).
 func networkError(url, tier string, cause error) *ScrapeError {
+	if isDNSNotFound(cause) {
+		return newScrapeError(ErrNotFound, url, tier, cause, fmt.Sprintf("DNS lookup failed: %v", cause))
+	}
 	return newScrapeError(ErrNetwork, url, tier, cause, fmt.Sprintf("network error: %v", cause))
 }
 
@@ -138,7 +159,18 @@ func classifyRawError(err error, url string) *ScrapeError {
 		// A definite not-found across tiers — a dead link, not transient. Checked
 		// before the generic network bucket so it isn't reported as retryable.
 		return newScrapeError(ErrNotFound, url, "", err, s)
-	case containsAny(s, "no such host", "connection refused", "timeout", "deadline exceeded", "network", "navigation failed"):
+	case containsAny(s, "no such host", "err_name_not_resolved"):
+		// A DNS NXDOMAIN is a PERMANENT failure — the domain does not exist and
+		// never will on retry. Checked before the generic network bucket (and
+		// before "no such host" would otherwise fall into it) so it is reported
+		// as ErrNotFound (non-retryable, inform_user) rather than the transient
+		// ErrNetwork bucket, which the tool layer unconditionally retries. (This
+		// mirrors networkError()'s isDNSNotFound check, which catches the same
+		// condition at each tier's raw-error call site; this branch is the
+		// composite-aggregation fallback for a raw error that reaches Scrape()
+		// without having passed through a tier's networkError() call.)
+		return newScrapeError(ErrNotFound, url, "", err, s)
+	case containsAny(s, "connection refused", "timeout", "deadline exceeded", "network", "navigation failed"):
 		return networkError(url, "", err)
 	case containsAny(s, "blocked", "403", "forbidden"):
 		return blockedError(url, "", err, s)
@@ -190,6 +222,20 @@ var botWallMarkers = []string{
 	// even on public portals; the pipeline must reject it and not cache it.
 	"please enter your viewer credentials",
 	"request access to the brand owner",
+	// Soft signup/login/subscribe gates — a well-formed HTTP 200 page whose real
+	// content is short and ends in a CTA instead of a hard CAPTCHA/JS challenge.
+	// This is the anti-bot pattern Crunchbase/SimilarWeb-style sites use for
+	// anonymous traffic (issue #661). These phrases are generic enough to appear
+	// legitimately gate-like, but — like every marker above — only fire when
+	// paired with the short-content gate (botWallMaxBytes) below, never when a
+	// phrase merely appears somewhere inside a long real article.
+	"sign up to continue",
+	"log in to continue",
+	"subscribe to continue",
+	"create a free account",
+	"view full profile",
+	"unlock full access",
+	"sign up for free to view",
 }
 
 // looksLikeBotWall reports whether short extracted content is a bot/JS-wall

--- a/internal/scraper/errors_test.go
+++ b/internal/scraper/errors_test.go
@@ -2,6 +2,7 @@ package scraper
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -94,6 +95,137 @@ on building better solutions to this problem.`
 		strings.Repeat("The methodology examines computational hardness assumptions and the trade-off between verifier cost and prover work in distributed systems. ", 20)
 	if looksLikeBotWall(longPoWArticle) {
 		t.Errorf("a long article about PoW (len=%d) must not be flagged as a bot-wall", len(longPoWArticle))
+	}
+}
+
+// TestClassifyRawError_DNSNotFound: a DNS NXDOMAIN ("no such host") is a
+// permanent failure and must map to ErrNotFound (non-retryable), not the
+// generic ErrNetwork bucket (which implies a retry will help). Regression
+// guard for GitHub issue #674.
+func TestClassifyRawError_DNSNotFound(t *testing.T) {
+	t.Parallel()
+	err := fmt.Errorf("Get \"https://this-domain-should-not-exist-zzz12345.com\": dial tcp: lookup this-domain-should-not-exist-zzz12345.com: no such host")
+	se := classifyRawError(err, "https://this-domain-should-not-exist-zzz12345.com")
+	if se.Kind != ErrNotFound {
+		t.Errorf("NXDOMAIN error → kind %v, want ErrNotFound", se.Kind)
+	}
+}
+
+// TestClassifyRawError_TransientNetworkStillRetryable is the regression guard
+// alongside TestClassifyRawError_DNSNotFound: a genuinely transient network
+// fault (connection refused, timeout, temporary DNS server failure — NOT "no
+// such host") must still classify as ErrNetwork so the NXDOMAIN fix doesn't
+// accidentally make ALL network errors non-retryable.
+func TestClassifyRawError_TransientNetworkStillRetryable(t *testing.T) {
+	t.Parallel()
+	cases := []string{
+		"dial tcp 127.0.0.1:1: connect: connection refused",
+		"context deadline exceeded",
+		"dial tcp: i/o timeout",
+	}
+	for _, msg := range cases {
+		se := classifyRawError(errors.New(msg), "https://example.com")
+		if se.Kind != ErrNetwork {
+			t.Errorf("%q → kind %v, want ErrNetwork", msg, se.Kind)
+		}
+	}
+}
+
+// TestLooksLikeBotWall_SoftGate: regression guard for GitHub issue #661.
+// Crunchbase/SimilarWeb-style anti-bot pages return HTTP 200 with a short,
+// well-formed page whose real content ends in a login/signup/subscribe CTA
+// instead of a hard CAPTCHA/JS-challenge interstitial. These must be detected
+// as a bot-wall when short, but a long real article that merely mentions one
+// of the same phrases in passing (e.g. a footer CTA) must NOT be flagged.
+func TestLooksLikeBotWall_SoftGate(t *testing.T) {
+	t.Parallel()
+
+	// Short, gate-dominated content — the entire extracted page IS the gate.
+	softGates := []string{
+		"Create a free account to see this company's full profile.",
+		"Sign up to continue reading this report.",
+		"Log in to continue viewing SimilarWeb traffic estimates.",
+		"Subscribe to continue reading this article.",
+		"View full profile: sign up for free to view detailed company data.",
+		"Unlock full access to this report by creating an account.",
+		"Sign up for free to view the complete traffic analysis.",
+	}
+	for _, c := range softGates {
+		if !looksLikeBotWall(c) {
+			t.Errorf("expected soft-gate bot-wall detection for %q", c)
+		}
+	}
+
+	// Negative: a long, real article that happens to contain one of the new
+	// soft-gate phrases once, in a footer-like trailing sentence, must NOT be
+	// flagged — the size gate (botWallMaxBytes) must hold exactly as it does
+	// for the pre-existing hard-challenge markers.
+	longArticleWithFooterCTA := strings.Repeat(
+		"This in-depth analysis covers the company's market position, funding history, and competitive landscape in detail. ", 30,
+	) + "Sign up to continue receiving our newsletter with more analysis like this."
+	if looksLikeBotWall(longArticleWithFooterCTA) {
+		t.Errorf("a long real article (len=%d) mentioning a soft-gate phrase in a footer must not be flagged as a bot-wall", len(longArticleWithFooterCTA))
+	}
+
+	// Ordinary short content that doesn't match any marker is not a bot-wall.
+	if looksLikeBotWall("Welcome to our company page. We build great products.") {
+		t.Error("ordinary short content must not be a soft-gate bot-wall")
+	}
+}
+
+// TestPipeline_SoftGateTreatedAsBlocked: end-to-end regression guard for issue
+// #661 — an HTTP 200 response whose entire body is a short Crunchbase/SimilarWeb-
+// style signup gate must surface as ErrBlocked, not a successful low-content scrape.
+func TestPipeline_SoftGateTreatedAsBlocked(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		_, _ = w.Write([]byte(`<html><head><title>Acme Corp - Company Profile</title></head><body>` +
+			`<h1>Acme Corp</h1><p>Create a free account to see this company's full profile, including funding rounds and key people.</p>` +
+			`</body></html>`))
+	}))
+	defer ts.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	_, err := p.Scrape(testCtx(), ts.URL, 50000)
+	if err == nil {
+		t.Fatal("expected an error for a soft signup-gate page, got success")
+	}
+	se, ok := err.(*ScrapeError)
+	if !ok || se.Kind != ErrBlocked {
+		t.Errorf("soft signup gate should be ErrBlocked, got %T kind=%v", err, err)
+	}
+}
+
+// TestPipeline_LongArticleWithFooterCTA_NotBlocked: negative counterpart to
+// TestPipeline_SoftGateTreatedAsBlocked — a long, real article that happens to
+// contain a soft-gate phrase in a trailing footer sentence must scrape
+// successfully, never be misclassified as blocked.
+func TestPipeline_LongArticleWithFooterCTA_NotBlocked(t *testing.T) {
+	body := strings.Repeat(
+		"This in-depth analysis covers the company's market position, funding history, and competitive landscape in substantial detail. ", 30,
+	) + "Sign up to continue receiving our newsletter with more analysis like this."
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "text/html")
+		fmt.Fprintf(w, `<html><head><title>Deep Dive Article</title></head><body><article>%s</article></body></html>`, body)
+	}))
+	defer ts.Close()
+
+	orig := statFile
+	statFile = func(path string) (any, error) { return nil, fmt.Errorf("not found") }
+	defer func() { statFile = orig }()
+
+	p := NewPipeline(PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true, ChromePath: chromeDisabled})
+	result, err := p.Scrape(testCtx(), ts.URL, 50000)
+	if err != nil {
+		t.Fatalf("expected a successful scrape for a long real article, got error: %v", err)
+	}
+	if !strings.Contains(result.Content, "in-depth analysis") {
+		t.Errorf("expected real article content in scrape result, got: %s", result.Content[:min(200, len(result.Content))])
 	}
 }
 

--- a/internal/tools/audit_bibliography_test.go
+++ b/internal/tools/audit_bibliography_test.go
@@ -653,7 +653,7 @@ func TestAuditBibliographyThinContentCount(t *testing.T) {
 	// 3 of 5 entries fetch thin (<150 word) pages; the other 2 fetch a full article.
 	thin := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<html><body><article><p>Please subscribe to continue reading this article.</p></article></body></html>`))
+		_, _ = w.Write([]byte(`<html><body><article><p>This page contains only a brief summary of the topic, with no further detail available here.</p></article></body></html>`))
 	}))
 	defer thin.Close()
 	full := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -166,8 +166,9 @@ func scrapeErrorToToolError(se *scraper.ScrapeError) ToolError {
 		te.Retryable = true
 		te.SuggestedAction = ActionReportBug
 	case scraper.ErrNotFound:
-		// A definite 404/410 — a dead link, not a transient fault. The user must
-		// fix the URL; never retry, never file a bug.
+		// A definite 404/410, or a DNS NXDOMAIN ("no such host") — a dead link or
+		// nonexistent domain, not a transient fault. The user must fix the URL;
+		// never retry, never file a bug.
 		te.Retryable = false
 		te.SuggestedAction = ActionInformUser
 	case scraper.ErrAuth:

--- a/internal/tools/scrape.go
+++ b/internal/tools/scrape.go
@@ -506,7 +506,7 @@ func scrapeErrorResponse(err error, url string) *mcp.CallToolResult {
 	case scraper.ErrContent:
 		msg = fmt.Sprintf("No content extracted from %s. May need browser rendering. Report at %s", url, issueURL)
 	case scraper.ErrNotFound:
-		msg = fmt.Sprintf("Not found: %s returned 404/410 — the page does not exist. Check the URL.", url)
+		msg = fmt.Sprintf("Not found: %s does not exist (404/410, or the domain could not be resolved). Check the URL.", url)
 	case scraper.ErrAuth:
 		msg = fmt.Sprintf("Auth required: %s is behind a login wall.", url)
 	case scraper.ErrRateLimit:

--- a/internal/tools/scrape_errors_test.go
+++ b/internal/tools/scrape_errors_test.go
@@ -429,8 +429,11 @@ func TestScrapeTool_Success_NotAffected(t *testing.T) {
 	}
 }
 
-// Regression test: DNS failure returns network error
-func TestScrapeTool_DNSFailure_ReturnsNetworkError(t *testing.T) {
+// Regression test for issue #674: a DNS NXDOMAIN ("no such host") is a
+// PERMANENT failure (the domain does not exist and never will on retry), so
+// it must classify as not_found/non-retryable — NOT the generic transient
+// network/retryable bucket.
+func TestScrapeTool_DNSFailure_ReturnsNotFoundError(t *testing.T) {
 	ctx := context.Background()
 	deps := Dependencies{
 		Cache:    cache.NewNoop(),
@@ -458,7 +461,57 @@ func TestScrapeTool_DNSFailure_ReturnsNetworkError(t *testing.T) {
 	}
 	text := res.Content[0].(*mcp.TextContent).Text
 	if strings.Contains(text, issueURL) {
-		t.Errorf("network errors should NOT suggest filing an issue, got: %s", text)
+		t.Errorf("NXDOMAIN errors should NOT suggest filing an issue, got: %s", text)
+	}
+	if !strings.Contains(text, `"kind":"not_found"`) {
+		t.Errorf("expected kind=not_found for NXDOMAIN, got: %s", text)
+	}
+	if !strings.Contains(text, `"retryable":false`) {
+		t.Errorf("expected retryable=false for NXDOMAIN, got: %s", text)
+	}
+	if !strings.Contains(text, `"suggestedAction":"inform_user"`) {
+		t.Errorf("expected inform_user action for NXDOMAIN, got: %s", text)
+	}
+}
+
+// TestScrapeTool_ConnectionRefused_ReturnsRetryableNetworkError is a
+// regression guard alongside the NXDOMAIN test above: a genuinely transient
+// fault (connection refused) must remain ErrNetwork/retryable — the NXDOMAIN
+// fix must not make ALL network errors non-retryable.
+func TestScrapeTool_ConnectionRefused_ReturnsRetryableNetworkError(t *testing.T) {
+	ctx := context.Background()
+	deps := Dependencies{
+		Cache:    cache.NewNoop(),
+		Search:   &mockProvider{},
+		Scraper:  scraper.NewPipeline(scraper.PipelineConfig{MaxConcurrency: 2, AllowPrivateIPs: true}),
+		Content:  content.NewProcessor(),
+		Sessions: func() session.Manager { m, _ := session.NewManager(session.Config{MaxSessions: 100}); return m }(),
+		Metrics:  metrics.NewCollector(),
+		Auditor:  audit.NewNoop(),
+		Logger:   slog.Default(),
+	}
+	srv := createTestServer(deps)
+	client := connectTestClient(ctx, t, srv)
+	defer client.Close()
+
+	// A closed local port: the connection is refused, which is transient (a
+	// server could start listening later) — distinct from a nonexistent domain.
+	res, err := client.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "scrape_page",
+		Arguments: map[string]any{"url": "http://127.0.0.1:1/page"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected error response for a closed port")
+	}
+	text := res.Content[0].(*mcp.TextContent).Text
+	if !strings.Contains(text, `"kind":"network"`) {
+		t.Errorf("expected kind=network for connection refused, got: %s", text)
+	}
+	if !strings.Contains(text, `"retryable":true`) {
+		t.Errorf("expected retryable=true for connection refused (regression: NXDOMAIN fix must not affect transient network errors), got: %s", text)
 	}
 }
 

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -1413,7 +1413,7 @@ func TestScrapePageSparsityWarning(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Write([]byte(`<!DOCTYPE html><html><head><title>Thin</title></head><body><article>
-<p>Please subscribe to continue reading this article. Access is limited to subscribers only at this time.</p>
+<p>This page contains only a brief summary of the topic, with no further detail currently available here at this time.</p>
 </article></body></html>`))
 	}))
 	defer ts.Close()
@@ -1532,7 +1532,7 @@ func TestSearchAndScrapeSparseSources(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Write([]byte(`<!DOCTYPE html><html><head><title>Thin</title></head><body><article>
-<p>Please subscribe to continue reading this article. Access is limited to subscribers only at this time.</p>
+<p>This page contains only a brief summary of the topic, with no further detail currently available here at this time.</p>
 </article></body></html>`))
 	}))
 	defer ts.Close()
@@ -1592,7 +1592,7 @@ func TestSearchAndScrapeSparseSourcesWithFilterByQuery(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
 		w.Write([]byte(`<!DOCTYPE html><html><head><title>Thin</title></head><body><article>
-<p>Please subscribe to continue reading this article. Access is limited to subscribers only at this time.</p>
+<p>This page contains only a brief summary of the topic, with no further detail currently available here at this time.</p>
 </article></body></html>`))
 	}))
 	defer ts.Close()

--- a/internal/tools/verify_citation_test.go
+++ b/internal/tools/verify_citation_test.go
@@ -132,7 +132,7 @@ func TestVerifyCitation_ClaimContrastSignal(t *testing.T) {
 func TestVerifyCitationSparseClaim(t *testing.T) {
 	page := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Content-Type", "text/html")
-		_, _ = w.Write([]byte(`<html><body><article><p>Please subscribe to continue reading this article about vaccine efficacy.</p></article></body></html>`))
+		_, _ = w.Write([]byte(`<html><body><article><p>This page contains only a short note about vaccine efficacy research, with no additional detail provided here.</p></article></body></html>`))
 	}))
 	defer page.Close()
 


### PR DESCRIPTION
## Summary

Two related scraper error-classification bugs, bundled in one PR because both edit `internal/scraper/errors.go`:

- **#661** — soft signup/paywall bot-walls (Crunchbase, SimilarWeb) misclassified as successful scrapes. `looksLikeBotWall` only had 18 hard-CAPTCHA/JS-challenge markers, with zero coverage for a short, well-formed HTTP 200 page whose real content ends in a login/signup/subscribe CTA. Added generic soft-gate phrases (`"sign up to continue"`, `"create a free account"`, etc.), still paired with the existing `botWallMaxBytes` short-content gate so a long real article mentioning one of these phrases in passing is never flagged.
- **#674** — DNS NXDOMAIN (`"no such host"`) misclassified as a retryable `network` error. It's a permanent failure — the domain doesn't exist and never will on retry — but was lumped into the same `ErrNetwork` bucket as transient faults. Now classified as `ErrNotFound` (`kind:"not_found"`, `retryable:false`, `suggestedAction:"inform_user"`), matching how 404/410 are already handled. Fixed at the single `networkError()` call site every tier's raw dial/HTTP failure passes through, plus `classifyRawError()`'s composite-aggregation fallback. Also covers Chrome's `ERR_NAME_NOT_RESOLVED` (the browser tier's equivalent signal).

Several pre-existing sparsity/thin-content test fixtures (#358) coincidentally used `"Please subscribe to continue reading this article."` as their stand-in for "genuinely short real content" — which now correctly matches the new soft-gate markers. Updated those fixtures to neutral text so they keep testing the sparsity path rather than being reclassified as blocked.

Also fixed `internal/tools/scrape.go`'s `ErrNotFound` message, which claimed "returned 404/410" — inaccurate now that a DNS failure (no HTTP round trip at all) can produce this kind — and updated `docs/ERROR_HANDLING.md`'s error-kind taxonomy.

Closes #661
Closes #674

## Test plan

- [x] `internal/scraper/errors_test.go`: `TestLooksLikeBotWall_SoftGate` (positive soft-gate phrases + negative long-article-with-footer-CTA guard), `TestPipeline_SoftGateTreatedAsBlocked`, `TestPipeline_LongArticleWithFooterCTA_NotBlocked`
- [x] `internal/scraper/errors_test.go`: `TestClassifyRawError_DNSNotFound`, `TestClassifyRawError_TransientNetworkStillRetryable` (regression: connection-refused/timeout stay `ErrNetwork`)
- [x] `internal/tools/scrape_errors_test.go`: `TestScrapeTool_DNSFailure_ReturnsNotFoundError`, `TestScrapeTool_ConnectionRefused_ReturnsRetryableNetworkError`
- [x] `gofmt -l` clean on all touched files
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go tool golangci-lint run` — 0 issues
- [x] `go test -race ./internal/scraper/... ./internal/tools/...` — pass
- [x] `go test ./...` — full suite green

🤖 Generated with [Claude Code](https://claude.com/claude-code)