### PR TITLE
fix(academic): citation_graph influence filter, provider fallback, rate-limit provider name (#655, #656, #664)

### DIFF
--- a/cmd/gen-python-client/main.go
+++ b/cmd/gen-python-client/main.go
@@ -160,6 +160,13 @@ func (m *mockAcademicProvider) Citations(_ context.Context, _ string, _ int) ([]
 func (m *mockAcademicProvider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
 	return nil, nil
 }
+
+// SupportsInfluenceSignal implements search.CitationSearcher, mirroring real
+// OpenAlex (this mock is named "openalex"): counts-only edges, no influence
+// signal (#655). Without this, the mock stops satisfying CitationSearcher at
+// runtime and citation_graph silently drops out of the generated schema.
+func (m *mockAcademicProvider) SupportsInfluenceSignal() bool { return false }
+
 func (m *mockAcademicProvider) ResolveByDOI(_ context.Context, doi string) (*search.AcademicResult, error) {
 	if doi == "10.1234/x" {
 		return &search.AcademicResult{Title: "t", DOI: doi, Year: 2024, Source: "openalex"}, nil

--- a/internal/search/domain.go
+++ b/internal/search/domain.go
@@ -135,6 +135,13 @@ type DOIResolver interface {
 type CitationSearcher interface {
 	Citations(ctx context.Context, seedID string, numResults int) ([]AcademicResult, error)
 	References(ctx context.Context, seedID string, numResults int) ([]AcademicResult, error)
+	// SupportsInfluenceSignal reports whether this provider populates
+	// AcademicResult.IsInfluential on the edges it returns (Semantic Scholar
+	// does; OpenAlex — counts-only edges — does not, #655). citation_graph's
+	// influential_only filter must no-op (pass results through unfiltered)
+	// when this is false, rather than discard every result on the mistaken
+	// assumption that an unset IsInfluential means "not influential."
+	SupportsInfluenceSignal() bool
 }
 
 // PaperFetcher fetches full paper metadata by DOI or Semantic Scholar paper ID.

--- a/internal/search/openalex.go
+++ b/internal/search/openalex.go
@@ -206,6 +206,12 @@ func (p *OpenAlexProvider) References(ctx context.Context, seedID string, numRes
 	return out, err
 }
 
+// SupportsInfluenceSignal implements CitationSearcher: OpenAlex's edges are
+// counts-only (see the Citations/References doc comments above) and never
+// populate IsInfluential (#655). citation_graph's influential_only filter
+// must no-op for this provider rather than discard every result.
+func (p *OpenAlexProvider) SupportsInfluenceSignal() bool { return false }
+
 // resolveWorkID resolves a DOI or OpenAlex URL/ID to a short OpenAlex work ID
 // (e.g. "W2741809807"). Returns "" if the seed can't be resolved.
 func (p *OpenAlexProvider) resolveWorkID(ctx context.Context, seedID string) (string, error) {

--- a/internal/search/semanticscholar.go
+++ b/internal/search/semanticscholar.go
@@ -154,6 +154,10 @@ func (s *SemanticScholarProvider) References(ctx context.Context, seedID string,
 	return s.edges(ctx, s2PaperPath(seedID)+"/references", numResults, false)
 }
 
+// SupportsInfluenceSignal implements CitationSearcher: Semantic Scholar
+// annotates every citation edge with isInfluential (#655).
+func (s *SemanticScholarProvider) SupportsInfluenceSignal() bool { return true }
+
 func (s *SemanticScholarProvider) edges(ctx context.Context, path string, numResults int, forward bool) ([]AcademicResult, error) {
 	var out []AcademicResult
 	err := s.deps.Breaker.Execute(func() error {

--- a/internal/tools/academic.go
+++ b/internal/tools/academic.go
@@ -180,7 +180,13 @@ func registerAcademicSearch(srv *mcp.Server, deps Dependencies) {
 			}
 		}
 
-		// Strategy 3: Try academic providers directly (non-router mode, deterministic order)
+		// Strategy 3: Try academic providers directly (non-router mode,
+		// deterministic order). A rate-limited (or otherwise failing)
+		// provider is skipped, not treated as exhausting the whole ladder
+		// (#503, #697) — isRateLimitError now also matches
+		// circuit.ErrCircuitOpen (#664), so a mid-ladder provider with an
+		// open breaker must not abort the search for every healthy provider
+		// listed after it.
 		if len(results) == 0 && input.Provider == "" {
 			for _, name := range search.SupportedAcademicProviders {
 				ap, ok := deps.AcademicProviders[name]
@@ -191,8 +197,6 @@ func registerAcademicSearch(srv *mcp.Server, deps Dependencies) {
 				if err == nil && len(apiResults) > 0 {
 					results = apiResults
 					providerSource = name
-					break
-				} else if err != nil && isRateLimitError(err) {
 					break
 				}
 			}

--- a/internal/tools/academic_test.go
+++ b/internal/tools/academic_test.go
@@ -434,3 +434,55 @@ func TestAcademicSearchPlaceholderTriggersHints(t *testing.T) {
 		t.Errorf("papers must be empty, got %d", len(papers))
 	}
 }
+
+// laddderStepAcademicProvider is a mock academic provider that returns a
+// fixed name, a fixed error (nil for a healthy provider), and results.
+type ladderStepAcademicProvider struct {
+	name    string
+	err     error
+	results []search.AcademicResult
+}
+
+func (p *ladderStepAcademicProvider) Name() string { return p.name }
+func (p *ladderStepAcademicProvider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock (ladder step)"}
+}
+func (p *ladderStepAcademicProvider) Scholarly(_ context.Context, _ search.AcademicSearchParams) ([]search.AcademicResult, error) {
+	return p.results, p.err
+}
+func (p *ladderStepAcademicProvider) Citations(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, nil
+}
+func (p *ladderStepAcademicProvider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, nil
+}
+
+// TestAcademicSearchSkipsCircuitOpenProviderInLadder is the #697 regression
+// guard for the #503 anti-pattern reintroduced via isRateLimitError's #664
+// widening to match circuit.ErrCircuitOpen: Strategy 3's provider ladder
+// (search.SupportedAcademicProviders order: openalex, crossref, pubmed,
+// semanticscholar, core, exa) must skip a mid-ladder provider whose circuit
+// breaker is open rather than aborting the whole ladder — a healthy provider
+// listed later (core) must still be reached.
+func TestAcademicSearchSkipsCircuitOpenProviderInLadder(t *testing.T) {
+	deps := setupTestDeps()
+	deps.AcademicProviders = map[string]search.AcademicProvider{
+		"openalex":        &ladderStepAcademicProvider{name: "openalex"}, // no results, no error
+		"semanticscholar": &ladderStepAcademicProvider{name: "semanticscholar", err: circuit.ErrCircuitOpen},
+		"core": &ladderStepAcademicProvider{name: "core", results: []search.AcademicResult{
+			{Title: "Healthy Result", DOI: "10.1/healthy", Source: "core"},
+		}},
+	}
+
+	out, res := callTool(t, deps, "academic_search", map[string]any{"query": "gene editing"})
+	if res.IsError {
+		t.Fatalf("unexpected error result")
+	}
+	if out["source"] != "core" {
+		t.Fatalf("source = %v, want %q (a circuit-open provider must not abort the ladder for healthy providers after it)", out["source"], "core")
+	}
+	papers, _ := out["papers"].([]any)
+	if len(papers) != 1 {
+		t.Fatalf("expected 1 paper from core, got %d", len(papers))
+	}
+}

--- a/internal/tools/citationgraph.go
+++ b/internal/tools/citationgraph.go
@@ -81,10 +81,10 @@ func registerCitationGraph(srv *mcp.Server, deps Dependencies) {
 			// resolves it. When the caller did NOT pin a provider, retry the whole
 			// traversal on OpenAlex before surfacing an error. An EXPLICIT provider is
 			// honored exclusively (Design Rule 7) — no silent substitution.
-			if input.Provider == "" && providerName == "semanticscholar" && isPaperNotFoundErr(err) {
+			if input.Provider == "" && providerName == "semanticscholar" && (isPaperNotFoundErr(err) || isRateLimitError(err)) {
 				if fb, fbName, ok := fallbackCitationSearcher(deps, providerName); ok {
 					if cb, rf, ferr := traverseCitations(ctx, fb, input.Paper, direction, num); ferr == nil {
-						citedBy, references, providerName, err = cb, rf, fbName, nil
+						citedBy, references, searcher, providerName, err = cb, rf, fb, fbName, nil
 					} else {
 						// Both providers failed (#434): name both providers and both
 						// underlying errors — never silently drop the fallback's own
@@ -98,7 +98,13 @@ func registerCitationGraph(srv *mcp.Server, deps Dependencies) {
 			}
 		}
 
-		if input.InfluentialOnly {
+		// #655: influential_only is a documented no-op for providers that don't
+		// supply the influence signal (OpenAlex) - filtering unconditionally on
+		// IsInfluential would discard every result, since the zero value is
+		// indistinguishable from "not influential." Only filter when the searcher
+		// that actually produced these results (the fallback, if one fired) reports
+		// it supplies the signal.
+		if input.InfluentialOnly && searcher.SupportsInfluenceSignal() {
 			citedBy = filterInfluential(citedBy)
 			references = filterInfluential(references)
 		}

--- a/internal/tools/citationgraph_test.go
+++ b/internal/tools/citationgraph_test.go
@@ -235,6 +235,62 @@ func TestCitationGraphAutoFallbackToOpenAlex(t *testing.T) {
 	}
 }
 
+// flatFallbackOpenAlexProvider implements AcademicProvider + CitationSearcher,
+// named "openalex", SupportsInfluenceSignal()==false — matching real OpenAlex
+// (counts only). Unlike mockAcademicProvider (whose Citations mock carries a
+// deliberately-unused IsInfluential:true noise field), every result here has
+// IsInfluential left at its false zero value, so a wrongly-applied
+// influential_only filter would actually zero out the results rather than
+// passing by coincidence.
+type flatFallbackOpenAlexProvider struct{}
+
+func (f *flatFallbackOpenAlexProvider) Name() string { return "openalex" }
+func (f *flatFallbackOpenAlexProvider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock OpenAlex (flat, no influence signal)"}
+}
+func (f *flatFallbackOpenAlexProvider) Scholarly(_ context.Context, _ search.AcademicSearchParams) ([]search.AcademicResult, error) {
+	return nil, nil
+}
+func (f *flatFallbackOpenAlexProvider) Citations(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return []search.AcademicResult{{Title: "Cites It", URL: "https://doi.org/10.2/y", DOI: "10.2/y", Year: 2025, Source: "openalex"}}, nil
+}
+func (f *flatFallbackOpenAlexProvider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return []search.AcademicResult{{Title: "Foundational", URL: "https://doi.org/10.0/z", DOI: "10.0/z", Year: 2017, Source: "openalex"}}, nil
+}
+func (f *flatFallbackOpenAlexProvider) SupportsInfluenceSignal() bool { return false }
+
+// TestCitationGraphAutoFallbackToOpenAlexHonorsFallbackInfluenceSignal is the
+// #697 regression guard for citationgraph.go's `searcher` reassignment on
+// fallback (line ~87): the influential_only capability check at line ~107
+// must run against the searcher that actually PRODUCED the results (the
+// OpenAlex fallback), not the originally-attempted (failed) Semantic Scholar.
+// Semantic Scholar claims SupportsInfluenceSignal()==true; OpenAlex does not.
+// If the check were still keyed on the stale primary searcher/provider,
+// influential_only would wrongly filter OpenAlex's un-flagged (IsInfluential
+// left false) results down to zero instead of passing them through.
+func TestCitationGraphAutoFallbackToOpenAlexHonorsFallbackInfluenceSignal(t *testing.T) {
+	deps := setupTestDeps()
+	deps.AcademicProviders = map[string]search.AcademicProvider{
+		"semanticscholar": &failingS2Provider{},
+		"openalex":        &flatFallbackOpenAlexProvider{},
+	}
+	out, res := callTool(t, deps, "citation_graph", map[string]any{
+		"paper": "10.1038/nature14539", "influential_only": true,
+	})
+	if res.IsError {
+		t.Fatalf("auto-select should fall back to OpenAlex, got error result")
+	}
+	if out["provider"] != "openalex" {
+		t.Fatalf("provider=%v, want openalex (fallback must have fired)", out["provider"])
+	}
+	if cb, _ := out["citedByCount"].(float64); cb != 1 {
+		t.Errorf("citedByCount=%v, want 1 (OpenAlex result must pass through unfiltered: it doesn't supply the influence signal, so influential_only must be a no-op for it)", out["citedByCount"])
+	}
+	if rc, _ := out["referencesCount"].(float64); rc != 1 {
+		t.Errorf("referencesCount=%v, want 1 (unfiltered — no influence signal, no-op)", out["referencesCount"])
+	}
+}
+
 // TestCitationGraphAutoFallbackOnCircuitOpen is the #664 regression guard: when
 // no provider is pinned and Semantic Scholar's circuit breaker is already OPEN
 // (returning the bare circuit.ErrCircuitOpen sentinel, not a "paper not found"

--- a/internal/tools/citationgraph_test.go
+++ b/internal/tools/citationgraph_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
 	"github.com/zoharbabin/web-researcher-mcp/internal/search"
 )
 
@@ -30,6 +31,52 @@ func (f *failingS2Provider) Citations(_ context.Context, _ string, _ int) ([]sea
 func (f *failingS2Provider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
 	return nil, fmt.Errorf("semanticscholar: paper not found")
 }
+func (f *failingS2Provider) SupportsInfluenceSignal() bool { return true }
+
+// circuitOpenS2Provider implements AcademicProvider + CitationSearcher and
+// models Semantic Scholar's circuit breaker already OPEN (#664) — every
+// Citations/References call returns the bare circuit.ErrCircuitOpen sentinel,
+// exactly what search.Deps.Breaker.Execute returns once a breaker trips,
+// without any "semanticscholar:" wrapping. Named "semanticscholar" so the
+// auto-select path picks it first.
+type circuitOpenS2Provider struct{}
+
+func (f *circuitOpenS2Provider) Name() string { return "semanticscholar" }
+func (f *circuitOpenS2Provider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock S2 (circuit open)"}
+}
+func (f *circuitOpenS2Provider) Scholarly(_ context.Context, _ search.AcademicSearchParams) ([]search.AcademicResult, error) {
+	return nil, circuit.ErrCircuitOpen
+}
+func (f *circuitOpenS2Provider) Citations(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, circuit.ErrCircuitOpen
+}
+func (f *circuitOpenS2Provider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, circuit.ErrCircuitOpen
+}
+func (f *circuitOpenS2Provider) SupportsInfluenceSignal() bool { return true }
+
+// rateLimitedS2Provider is circuitOpenS2Provider's companion (#664): models a
+// Semantic Scholar call that returns the wrapped 429 sentinel directly (the
+// breaker hasn't tripped open yet, but this call is itself rate-limited),
+// exercising the same widened fallback condition via isRateLimitError rather
+// than errors.Is(err, circuit.ErrCircuitOpen).
+type rateLimitedS2Provider struct{}
+
+func (f *rateLimitedS2Provider) Name() string { return "semanticscholar" }
+func (f *rateLimitedS2Provider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock S2 (rate limited)"}
+}
+func (f *rateLimitedS2Provider) Scholarly(_ context.Context, _ search.AcademicSearchParams) ([]search.AcademicResult, error) {
+	return nil, fmt.Errorf("semanticscholar: rate limited: %w", circuit.ErrRateLimit)
+}
+func (f *rateLimitedS2Provider) Citations(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, fmt.Errorf("semanticscholar: rate limited: %w", circuit.ErrRateLimit)
+}
+func (f *rateLimitedS2Provider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return nil, fmt.Errorf("semanticscholar: rate limited: %w", circuit.ErrRateLimit)
+}
+func (f *rateLimitedS2Provider) SupportsInfluenceSignal() bool { return true }
 
 // depsWithS2AndOpenAlex wires BOTH a failing semanticscholar (preferred on
 // auto-select) and the working openalex mock, so the #228 auto-fallback can be
@@ -93,19 +140,76 @@ func TestCitationGraphInvalidDirection(t *testing.T) {
 	}
 }
 
+// TestCitationGraphInfluentialOnly is the #655 regression guard: influential_only
+// must filter when the active provider supplies the influence signal (Semantic
+// Scholar) but pass results through UNFILTERED when it doesn't (OpenAlex) —
+// per the documented contract, not silently discard everything.
 func TestCitationGraphInfluentialOnly(t *testing.T) {
-	// mock: citedBy has IsInfluential=true (kept), references has false (dropped).
-	out, res := callTool(t, setupTestDeps(), "citation_graph", map[string]any{"paper": "10.1/x", "influential_only": true})
-	if res.IsError {
-		t.Fatalf("unexpected error")
-	}
-	if cb, _ := out["citedByCount"].(float64); cb != 1 {
-		t.Errorf("influential citedBy kept: got %v", out["citedByCount"])
-	}
-	if rc, _ := out["referencesCount"].(float64); rc != 0 {
-		t.Errorf("non-influential references should be filtered out, got %v", out["referencesCount"])
-	}
+	t.Run("semanticscholar filters to influential edges", func(t *testing.T) {
+		// influentialAndFlatS2Provider (below) has citedBy IsInfluential=true
+		// (kept) and references IsInfluential=false (dropped) — same fixture
+		// shape the old (pre-#655) test used, now against a provider that
+		// actually claims to support the signal.
+		deps := setupTestDeps()
+		deps.AcademicProviders = map[string]search.AcademicProvider{
+			"semanticscholar": &influentialAndFlatS2Provider{},
+		}
+		out, res := callTool(t, deps, "citation_graph", map[string]any{"paper": "10.1/x", "influential_only": true})
+		if res.IsError {
+			t.Fatalf("unexpected error")
+		}
+		if out["provider"] != "semanticscholar" {
+			t.Fatalf("provider=%v, want semanticscholar", out["provider"])
+		}
+		if cb, _ := out["citedByCount"].(float64); cb != 1 {
+			t.Errorf("influential citedBy kept: got %v", out["citedByCount"])
+		}
+		if rc, _ := out["referencesCount"].(float64); rc != 0 {
+			t.Errorf("non-influential references should be filtered out, got %v", out["referencesCount"])
+		}
+	})
+
+	t.Run("openalex passes through unfiltered (no influence signal)", func(t *testing.T) {
+		// mockAcademicProvider is named "openalex" and reports
+		// SupportsInfluenceSignal()==false, matching real OpenAlex (counts-only
+		// edges). influential_only must be a no-op: both citedBy and references
+		// come back at full count, not zeroed out.
+		out, res := callTool(t, setupTestDeps(), "citation_graph", map[string]any{"paper": "10.1/x", "influential_only": true})
+		if res.IsError {
+			t.Fatalf("unexpected error")
+		}
+		if out["provider"] != "openalex" {
+			t.Fatalf("provider=%v, want openalex", out["provider"])
+		}
+		if cb, _ := out["citedByCount"].(float64); cb != 1 {
+			t.Errorf("pass-through citedBy: got %v, want 1 (unfiltered)", out["citedByCount"])
+		}
+		if rc, _ := out["referencesCount"].(float64); rc != 1 {
+			t.Errorf("pass-through references: got %v, want 1 (unfiltered — no influence signal, no-op)", out["referencesCount"])
+		}
+	})
 }
+
+// influentialAndFlatS2Provider implements AcademicProvider + CitationSearcher,
+// named "semanticscholar", SupportsInfluenceSignal()==true. Citations returns
+// one influential edge, References returns one non-influential edge — used to
+// exercise the influential_only FILTERING branch (#655).
+type influentialAndFlatS2Provider struct{}
+
+func (f *influentialAndFlatS2Provider) Name() string { return "semanticscholar" }
+func (f *influentialAndFlatS2Provider) Metadata() search.ProviderMeta {
+	return search.ProviderMeta{Regions: []string{"*"}, RateClass: "free", Description: "mock S2 (influential filtering)"}
+}
+func (f *influentialAndFlatS2Provider) Scholarly(_ context.Context, _ search.AcademicSearchParams) ([]search.AcademicResult, error) {
+	return nil, nil
+}
+func (f *influentialAndFlatS2Provider) Citations(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return []search.AcademicResult{{Title: "Cites It", URL: "https://doi.org/10.2/y", DOI: "10.2/y", Year: 2025, Source: "semanticscholar", IsInfluential: true}}, nil
+}
+func (f *influentialAndFlatS2Provider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
+	return []search.AcademicResult{{Title: "Foundational", URL: "https://doi.org/10.0/z", DOI: "10.0/z", Year: 2017, Source: "semanticscholar"}}, nil
+}
+func (f *influentialAndFlatS2Provider) SupportsInfluenceSignal() bool { return true }
 
 func TestCitationGraphUnknownProvider(t *testing.T) {
 	_, res := callTool(t, setupTestDeps(), "citation_graph", map[string]any{"paper": "x", "provider": "perplexity"})
@@ -125,6 +229,51 @@ func TestCitationGraphAutoFallbackToOpenAlex(t *testing.T) {
 	}
 	if out["provider"] != "openalex" {
 		t.Errorf("provider=%v, want openalex (fallback must have fired)", out["provider"])
+	}
+	if cb, _ := out["citedByCount"].(float64); cb != 1 {
+		t.Errorf("citedByCount=%v want 1 (OpenAlex mock result)", out["citedByCount"])
+	}
+}
+
+// TestCitationGraphAutoFallbackOnCircuitOpen is the #664 regression guard: when
+// no provider is pinned and Semantic Scholar's circuit breaker is already OPEN
+// (returning the bare circuit.ErrCircuitOpen sentinel, not a "paper not found"
+// 404), the traversal must still transparently fall back to a healthy OpenAlex
+// and succeed — not surface the breaker-open error to the caller.
+func TestCitationGraphAutoFallbackOnCircuitOpen(t *testing.T) {
+	deps := setupTestDeps()
+	deps.AcademicProviders = map[string]search.AcademicProvider{
+		"semanticscholar": &circuitOpenS2Provider{},
+		"openalex":        &mockAcademicProvider{},
+	}
+	out, res := callTool(t, deps, "citation_graph", map[string]any{"paper": "10.1038/nature14539"})
+	if res.IsError {
+		t.Fatalf("auto-select should fall back to OpenAlex on circuit-open, got error result")
+	}
+	if out["provider"] != "openalex" {
+		t.Errorf("provider=%v, want openalex (fallback must have fired on ErrCircuitOpen)", out["provider"])
+	}
+	if cb, _ := out["citedByCount"].(float64); cb != 1 {
+		t.Errorf("citedByCount=%v want 1 (OpenAlex mock result)", out["citedByCount"])
+	}
+}
+
+// TestCitationGraphAutoFallbackOnRateLimit is TestCitationGraphAutoFallbackOnCircuitOpen's
+// companion (#664): the same widened fallback condition must also cover a
+// wrapped circuit.ErrRateLimit (a 429 that hasn't tripped the breaker open
+// yet), via isRateLimitError rather than a literal ErrCircuitOpen match.
+func TestCitationGraphAutoFallbackOnRateLimit(t *testing.T) {
+	deps := setupTestDeps()
+	deps.AcademicProviders = map[string]search.AcademicProvider{
+		"semanticscholar": &rateLimitedS2Provider{},
+		"openalex":        &mockAcademicProvider{},
+	}
+	out, res := callTool(t, deps, "citation_graph", map[string]any{"paper": "10.1038/nature14539"})
+	if res.IsError {
+		t.Fatalf("auto-select should fall back to OpenAlex on rate-limit, got error result")
+	}
+	if out["provider"] != "openalex" {
+		t.Errorf("provider=%v, want openalex (fallback must have fired on rate limit)", out["provider"])
 	}
 	if cb, _ := out["citedByCount"].(float64); cb != 1 {
 		t.Errorf("citedByCount=%v want 1 (OpenAlex mock result)", out["citedByCount"])
@@ -162,6 +311,7 @@ func (f *failingOpenAlexProvider) Citations(_ context.Context, _ string, _ int) 
 func (f *failingOpenAlexProvider) References(_ context.Context, _ string, _ int) ([]search.AcademicResult, error) {
 	return nil, fmt.Errorf("openalex: not found")
 }
+func (f *failingOpenAlexProvider) SupportsInfluenceSignal() bool { return false }
 
 // TestCitationGraphBothProvidersFailErrorNamesBoth (#434, Clean-code Rule 2):
 // when the auto-select fallback ALSO fails, the surfaced error must name both

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -204,11 +204,27 @@ var providerErrorPrefixes = []string{
 func extractProviderName(err error) string {
 	s := err.Error()
 	for _, prefix := range providerErrorPrefixes {
-		if strings.HasPrefix(s, prefix[:len(prefix)-1]) || strings.Contains(s, prefix) {
+		idx := strings.Index(s, prefix)
+		if idx < 0 {
+			continue
+		}
+		// A bare substring match lets a short prefix like "core:" match inside
+		// an unrelated word (e.g. "score: too low: ..."). Require the match to
+		// start at a word boundary: either the very start of the string, or
+		// preceded by a non-alphanumeric byte (space, ';', ':', etc.) — the
+		// separators every real provider-error wrapping in this codebase uses
+		// (fmt.Errorf("%s: %w", name, err), or "%s: %w; %s: %w" for two).
+		if idx == 0 || !isWordByte(s[idx-1]) {
 			return prefix[:len(prefix)-1]
 		}
 	}
 	return ""
+}
+
+// isWordByte reports whether b is an ASCII letter or digit — used by
+// extractProviderName to require a word boundary before a provider prefix.
+func isWordByte(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9')
 }
 
 // FailureInfo is returned in partial-success compound tool results.

--- a/internal/tools/errors.go
+++ b/internal/tools/errors.go
@@ -186,9 +186,24 @@ func scrapeErrorToToolError(se *scraper.ScrapeError) ToolError {
 }
 
 // extractProviderName attempts to extract the provider name from an error string.
+//
+// #656: the prefix list must cover every "providername: ..." error prefix any
+// internal/search/*.go provider actually wraps its errors with (verified by
+// grepping fmt.Errorf("<name>: ...") across that package), not just the
+// providers a given tool call site happens to exercise most often — a gap here
+// silently drops ToolError.Provider for whichever provider was missed
+// (semanticscholar was the reported case; the rest were audited in the same
+// pass so this doesn't reoccur one entry at a time).
+var providerErrorPrefixes = []string{
+	"google:", "brave:", "serper:", "searxng:", "searchapi:", "lens:", "uspto:", "epo:", "openalex:", "crossref:", "ecosystems:",
+	"semanticscholar:", "scholarapi:", "pubmed:", "core:", "exa:", "duckduckgo:", "tavily:", "hackernews:", "reddit:", "bluesky:", "github:", "xquik:",
+	"courtlistener:", "edgar:", "fred:", "eurostat:", "oecd:", "worldbank:", "monarch:",
+	"clinicaltrials:", "unpaywall:", "wikidata:", "wayback:", "crt.sh:", "doi-handle:", "doi.org:",
+}
+
 func extractProviderName(err error) string {
 	s := err.Error()
-	for _, prefix := range []string{"google:", "brave:", "serper:", "searxng:", "searchapi:", "lens:", "uspto:", "epo:", "openalex:", "crossref:", "ecosystems:"} {
+	for _, prefix := range providerErrorPrefixes {
 		if strings.HasPrefix(s, prefix[:len(prefix)-1]) || strings.Contains(s, prefix) {
 			return prefix[:len(prefix)-1]
 		}

--- a/internal/tools/ratelimit_test.go
+++ b/internal/tools/ratelimit_test.go
@@ -105,6 +105,13 @@ func TestExtractProviderName(t *testing.T) {
 		// case, which was already correct.
 		{"semanticscholar rate limited", fmt.Errorf("semanticscholar: rate limited: %w", circuit.ErrRateLimit), "semanticscholar"},
 		{"searchapi rate limited (already correct, no regression)", fmt.Errorf("searchapi: rate limited: %w", circuit.ErrRateLimit), "searchapi"},
+		// #697 review LOW finding: a bare substring match on "core:" wrongly
+		// matched inside "score:" (s-CORE:), misattributing an unrelated error
+		// to the "core" academic provider. Requires a word boundary before the
+		// prefix match.
+		{"score is not core (word-boundary false-positive guard)", fmt.Errorf("score: too low, discarding result"), ""},
+		{"core prefix still matches at start", fmt.Errorf("core: rate limited"), "core"},
+		{"core prefix still matches after a separator", fmt.Errorf("unexpected failure; core: rate limited"), "core"},
 	}
 
 	for _, tc := range cases {

--- a/internal/tools/ratelimit_test.go
+++ b/internal/tools/ratelimit_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 
 	"github.com/zoharbabin/web-researcher-mcp/internal/cache"
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
 	"github.com/zoharbabin/web-researcher-mcp/internal/search"
 )
 
@@ -67,6 +68,11 @@ func TestIsRateLimitError(t *testing.T) {
 		{"dns error", fmt.Errorf("no such host"), false},
 		{"empty error", fmt.Errorf(""), false},
 		{"wrapped rate limit", fmt.Errorf("search for query: %w", fmt.Errorf("google API rate limited")), true},
+		// #664: a breaker-open sentinel must classify as a rate-limit condition too —
+		// it's the downstream consequence of the provider already having been
+		// rate-limited enough times to trip its circuit.
+		{"circuit breaker open (bare sentinel)", circuit.ErrCircuitOpen, true},
+		{"circuit breaker open (wrapped)", fmt.Errorf("citations lookup: %w", circuit.ErrCircuitOpen), true},
 	}
 
 	for _, tc := range cases {
@@ -94,6 +100,11 @@ func TestExtractProviderName(t *testing.T) {
 		{"ecosystems api error", fmt.Errorf("ecosystems: API error 429: too many requests"), "ecosystems"},
 		{"google prefix", fmt.Errorf("google: quota exceeded"), "google"},
 		{"unknown provider", fmt.Errorf("connection timeout"), ""},
+		// #656: semanticscholar was missing from the allowlist, so its 429s
+		// surfaced an empty ToolError.Provider. Mirrors the existing searchapi
+		// case, which was already correct.
+		{"semanticscholar rate limited", fmt.Errorf("semanticscholar: rate limited: %w", circuit.ErrRateLimit), "semanticscholar"},
+		{"searchapi rate limited (already correct, no regression)", fmt.Errorf("searchapi: rate limited: %w", circuit.ErrRateLimit), "searchapi"},
 	}
 
 	for _, tc := range cases {

--- a/internal/tools/search.go
+++ b/internal/tools/search.go
@@ -418,8 +418,12 @@ func isRateLimitError(err error) bool {
 	if err == nil {
 		return false
 	}
-	// Typed sentinel check first (fast, no string alloc).
-	if errors.Is(err, circuit.ErrRateLimit) {
+	// Typed sentinel checks first (fast, no string alloc). A breaker-open error
+	// (#664) means the provider is already known-unavailable — usually because
+	// repeated rate-limiting already tripped its circuit — so callers that gate
+	// fallback/retry or errCode classification on "is this a rate limit" must
+	// treat it the same as an explicit 429, not fall through to upstream_error.
+	if errors.Is(err, circuit.ErrRateLimit) || errors.Is(err, circuit.ErrCircuitOpen) {
 		return true
 	}
 	// Legacy string fallback for any provider not yet wrapped.

--- a/internal/tools/tools_test.go
+++ b/internal/tools/tools_test.go
@@ -153,6 +153,14 @@ func (m *mockAcademicProvider) References(_ context.Context, _ string, _ int) ([
 	return []search.AcademicResult{{Title: "Foundational", URL: "https://doi.org/10.0/z", DOI: "10.0/z", Year: 2017, Source: "openalex"}}, nil
 }
 
+// SupportsInfluenceSignal implements CitationSearcher, mirroring real OpenAlex
+// (this mock is named "openalex"): counts-only edges, no influence signal
+// (#655). The IsInfluential:true set on the Citations mock result above is
+// deliberately unused signal noise a real OpenAlex response could carry
+// (always false in production) — this method, not that field, is what gates
+// citation_graph's influential_only filter.
+func (m *mockAcademicProvider) SupportsInfluenceSignal() bool { return false }
+
 // ResolveByDOI implements the DOIResolver capability: it returns the exact record
 // ONLY for the DOI it knows (10.1234/x, a valid-shaped DOI the doiPattern accepts),
 // and nil for anything else — modeling a real entity lookup that has no record for


### PR DESCRIPTION
## Summary

Three related academic/citation-graph reliability fixes, shipped together:

- **#655** — `citation_graph`'s `influential_only:true` dropped ALL results for providers that don't supply the influence signal (OpenAlex), instead of passing results through unfiltered as documented. Added `CitationSearcher.SupportsInfluenceSignal() bool`; the filter is now gated on it (Semantic Scholar: filters, OpenAlex: no-op pass-through).
- **#656** — Semantic Scholar 429s surfaced an empty `ToolError.Provider` because `extractProviderName`'s hardcoded prefix allowlist was missing `"semanticscholar:"`. Audited every `fmt.Errorf("<prefix>: ...")` construction across `internal/search/*.go` and completed the allowlist in one pass rather than patching this single entry.
- **#664** — `citation_graph`'s auto-select fallback (Semantic Scholar → OpenAlex) only fired on a 404 "paper not found," never on a circuit-open or rate-limited error, causing total failure on keyless deployments once the breaker trips. Widened the fallback condition to `isPaperNotFoundErr(err) || isRateLimitError(err)`, and `isRateLimitError` now classifies `circuit.ErrCircuitOpen`/`circuit.ErrRateLimit` via `errors.Is`. Also fixed a latent bug where the `searcher` variable wasn't reassigned on fallback success, which would have made the new #655 influence-signal gate check the wrong (failed) provider's capability after a fallback.

Closes #655
Closes #656
Closes #664

## Test plan

- [x] `internal/tools/citationgraph_test.go`: rewrote `TestCitationGraphInfluentialOnly` into two subtests — filters for a semanticscholar-named provider that supports the signal, passes through unfiltered for openalex (proves #655)
- [x] `internal/tools/citationgraph_test.go`: new `TestCitationGraphAutoFallbackOnCircuitOpen` and `TestCitationGraphAutoFallbackOnRateLimit` — auto-select falls back to OpenAlex on both conditions (#664)
- [x] `internal/tools/ratelimit_test.go`: new `TestIsRateLimitError` cases for bare and wrapped `circuit.ErrCircuitOpen` (#664)
- [x] `internal/tools/ratelimit_test.go`: new `TestExtractProviderName` cases for `semanticscholar:` and a `searchapi:` regression guard (#656)
- [x] `gofmt -l` on every touched file: empty output
- [x] `go build ./...`: passes
- [x] `go vet ./...`: passes
- [x] `go tool golangci-lint run ./internal/tools/... ./internal/search/...`: 0 issues
- [x] `go test -race ./internal/tools/... ./internal/search/...`: passes
- [x] `go test ./...`: full suite green (includes `TestToolsDocMatchesRegistry`, confirming no docs/TOOLS.md drift)
- [x] `make gen-python-client`: caught and fixed a related bug in `cmd/gen-python-client`'s own `mockAcademicProvider` (needed `SupportsInfluenceSignal()` too, or `citation_graph` silently drops out of the generated schema); regenerated client now diffs clean against committed output

🤖 Generated with [Claude Code](https://claude.com/claude-code)