### PR TITLE
fix: search provider precision + rate-limit/localization fixes (v1.49.2 audit)

### DIFF
--- a/docs/TOOLS.md
+++ b/docs/TOOLS.md
@@ -586,6 +586,7 @@ type ImageSearchOutput struct {
     Query       string           `json:"query"`
     ResultCount int              `json:"resultCount"`
     Hints       *ZeroResultHints `json:"hints,omitempty"` // present ONLY on zero-result responses (#357); same shape as web_search, including epistemicWarning
+    Warning     string           `json:"warning,omitempty"` // present ONLY when provider=google and 3+ of size/type/color_type/dominant_color/file_type were combined (#659, see Provider notes)
     Trust       string           `json:"trust"`   // "untrusted-external-content"
 }
 
@@ -604,6 +605,7 @@ type ImageResult struct {
 ### Provider notes
 - `size`, `type`, `color_type`, `dominant_color`, and `file_type` are **Google/SearchAPI-only** filters — they are not documented Brave image params, so the Brave adapter never sends them (Brave would silently drop them). `country`, `language`, and `safe` are honored across providers. The `size` bucket is a hint the provider applies loosely — returned dimensions may not strictly match the requested bucket; use `width`/`height` to filter precisely when exact sizing matters.
 - `fileSize`, `contextLink`, `width`, and `height` are **optional and provider-dependent** — each is emitted only when the configured provider reports it and is omitted (never fabricated) otherwise. No currently-configured provider populates `fileSize`, so treat it as reserved/best-effort.
+- **Combining 3+ filters against Google may silently relax them (#659)**: Google's Custom Search API can narrow `size`/`type`/`color_type`/`dominant_color`/`file_type` into an intersection too small to satisfy, and falls back to broader/default ranking with no field in the response indicating this happened — results can come back identical to an unfiltered query. This is documented behavior of Google's search backend, not a request-construction bug. When `provider=google` and 3 or more of these filters are set at once, the response carries a top-level `warning` field explaining this; try fewer simultaneous filters or a different provider if results look unfiltered.
 
 ### Cache
 - Key: SHA-256 of (query + all filter params)
@@ -636,7 +638,7 @@ type NewsSearchOutput struct {
     Query       string        `json:"query"`
     ResultCount int           `json:"resultCount"`
     Hints       *ZeroResultHints `json:"hints,omitempty"` // present ONLY on zero-result responses (see below)
-    Warning     string        `json:"warning,omitempty"` // present ONLY when sort_by="date" was honored by Google and no returned article matched a recognized news domain (#642, see Provider notes)
+    Warning     string        `json:"warning,omitempty"` // present when sort_by="date" was honored by Google with no recognized news domain in results (#642), and/or time_range="hour" was requested against Google (#665, no hour granularity — falls back to 24h); see Provider notes
     Trust       string        `json:"trust"`   // "untrusted-external-content"
 }
 
@@ -666,8 +668,9 @@ On a zero-result response, `hints` carries the same `ZeroResultHints` object as 
 ### Provider notes
 - `sort_by` and `news_source` are **Google-only** controls — Brave's news API has no sort or single-source parameter, so the Brave adapter never sends them (the schema descriptions mark them provider-conditional rather than dropping the fields, since Google genuinely honors them). `country`, `language`, and `safe` are honored by Brave news.
 - `publishedAt` is **optional and provider-dependent**: populated when the provider exposes a publish timestamp (Google CSE via page metadata; Brave/Exa/Serper/SearchAPI/SearXNG/Tavily natively), omitted (not fabricated) when the provider supplies none — so treat it as best-effort. When present it is always normalized to **ISO-8601 (RFC3339 UTC)** regardless of the provider's raw format (RFC1123, relative ages like "3 days ago"/"2h", or bare dates), so values sort and compare consistently across providers; an unparseable timestamp is dropped rather than passed through.
-- `sort_by=date` maps to Google's date-sort control; exact ordering and `time_range=hour` granularity depend on the provider's index and may be approximate. News providers may also surface high-ranking forum/aggregator pages — `news_source` narrows to a trusted outlet when that matters (Google).
+- `sort_by=date` maps to Google's date-sort control. News providers may also surface high-ranking forum/aggregator pages — `news_source` narrows to a trusted outlet when that matters (Google).
 - **`sort_by=date` discards Google's relevance ranking (#642)**: per Google's Custom Search JSON API docs, `sort=date` is a literal chronological reorder with no relevance weighting. On a broad, non-named-entity query (e.g. "global markets") this can rank recently-modified but topically unrelated corporate/government pages ahead of real news coverage; specific/named-entity queries are less affected since there's little room for an unrelated page to match at all. This is documented Google API behavior, not a bug — when none of the returned articles match a recognized news domain under `sort_by=date`, the response carries a top-level `warning` field explaining the tradeoff rather than silently reordering or dropping results (dropping risks hiding legitimate outlets absent from the small known-news-domain list). Prefer the default relevance sort for broad topics; reserve `sort_by=date` for narrow/breaking-news queries where strict recency matters more than topical precision.
+- **`time_range="hour"` has no true hour granularity on Google (#665)**: Google's Custom Search API's `dateRestrict` parameter supports only day-or-coarser windows — there is no hour-level value. `time_range="hour"` against the `google` provider falls back to a 24-hour window, byte-for-byte identical to `time_range="day"`, every time — not an approximation, a hard limitation. The response carries a top-level `warning` field stating this. Other providers (e.g. Brave) support true hour-level freshness.
 
 ### Cache
 - TTL: 15 minutes (news is time-sensitive)
@@ -2152,7 +2155,7 @@ These are upstream behaviors we cannot control — they reflect how the underlyi
 | Provider | Behavior | Impact |
 |----------|----------|--------|
 | SearchAPI | May return fewer results than `num_results` requested | Query has limited coverage in their index; not an error |
-| Google (news) | `freshness=hour` may return articles 5-10 hours old | Google's "last hour" filter is approximate, not strict |
+| Google (news) | `time_range=hour` silently falls back to a 24h window | Google's `dateRestrict` has no hour-level granularity; a `warning` field is returned (#665) |
 | Google (images) | `size=large` may return images as small as 600x600 | Google's size thresholds differ from typical expectations |
 | USPTO | Full-text search only (no field-qualified queries) | API rejects field syntax; results rely on relevance ranking |
 | OpenAlex | `pdf_only` may return 0 results for common topics | Not all papers have PDF URLs indexed in their metadata |

--- a/internal/circuit/breaker.go
+++ b/internal/circuit/breaker.go
@@ -2,6 +2,7 @@ package circuit
 
 import (
 	"errors"
+	"fmt"
 	"math/rand"
 	"sync"
 	"time"
@@ -13,6 +14,25 @@ var ErrCircuitOpen = errors.New("circuit breaker open")
 // circuit breaker opens immediately on the first rate-limit, without waiting
 // for FailureThreshold generic failures to accumulate.
 var ErrRateLimit = errors.New("rate limited")
+
+// RateLimitError wraps ErrRateLimit with the provider's own advertised
+// retry-after duration (parsed from a 429 response's body/headers). A
+// provider that knows how long the upstream asked it to wait wraps its error
+// with this instead of the bare ErrRateLimit sentinel, so onFailure can open
+// the breaker for at least that long rather than always falling back to the
+// configured ResetTimeout — a fixed cadence shorter than the provider's own
+// window retries into a still-rate-limited API and never recovers (#666).
+// errors.Is still matches ErrRateLimit through Unwrap, so providers that keep
+// wrapping the bare sentinel are unaffected.
+type RateLimitError struct {
+	After time.Duration
+}
+
+func (e *RateLimitError) Error() string {
+	return fmt.Sprintf("rate limited, retry after %s", e.After)
+}
+
+func (e *RateLimitError) Unwrap() error { return ErrRateLimit }
 
 // ErrNonTripping is the sentinel a provider wraps an error with when it must
 // never count toward the breaker's failure threshold at all — e.g. a 402
@@ -41,6 +61,7 @@ type Breaker struct {
 	failures         int
 	lastFailure      time.Time
 	resetJitter      time.Duration
+	rateLimitAfter   time.Duration // provider-advertised cooldown from a RateLimitError; 0 when none was given
 	halfOpenAttempts int
 	config           Config
 }
@@ -99,9 +120,14 @@ func (b *Breaker) allowRequest() bool {
 	case StateClosed:
 		return true
 	case StateOpen:
-		if time.Since(b.lastFailure) > time.Duration(b.config.ResetTimeout)*time.Second+b.resetJitter {
+		timeout := time.Duration(b.config.ResetTimeout) * time.Second
+		if b.rateLimitAfter > timeout {
+			timeout = b.rateLimitAfter
+		}
+		if time.Since(b.lastFailure) > timeout+b.resetJitter {
 			b.state = StateHalfOpen
 			b.halfOpenAttempts = 0
+			b.rateLimitAfter = 0
 			return true
 		}
 		return false
@@ -116,6 +142,7 @@ func (b *Breaker) onSuccess() {
 	b.failures = 0
 	b.halfOpenAttempts = 0
 	b.resetJitter = 0
+	b.rateLimitAfter = 0
 }
 
 // onFailure records a failure and updates the circuit state. A wrapped
@@ -133,6 +160,12 @@ func (b *Breaker) onFailure(err error) {
 	if errors.Is(err, ErrRateLimit) {
 		b.state = StateOpen
 		b.resetJitter = b.newResetJitter()
+		var rle *RateLimitError
+		if errors.As(err, &rle) {
+			b.rateLimitAfter = rle.After
+		} else {
+			b.rateLimitAfter = 0
+		}
 		return
 	}
 
@@ -175,4 +208,5 @@ func (b *Breaker) Reset() {
 	b.state = StateClosed
 	b.failures = 0
 	b.resetJitter = 0
+	b.rateLimitAfter = 0
 }

--- a/internal/circuit/breaker_test.go
+++ b/internal/circuit/breaker_test.go
@@ -436,3 +436,91 @@ func TestBreakerJitterOnResetTimeout(t *testing.T) {
 		}
 	}
 }
+
+// TestRateLimitErrorExtendsResetTimeout is the #666 regression test: a
+// provider that wraps its error with RateLimitError{After: N} — because the
+// upstream 429 advertised its own retry-after window — must keep the breaker
+// Open for at least N, not just the breaker's configured ResetTimeout, even
+// when N is longer. Without this, a fixed retry cadence shorter than the
+// provider's advertised window retries into a still-rate-limited API and
+// never converges.
+func TestRateLimitErrorExtendsResetTimeout(t *testing.T) {
+	t.Parallel()
+
+	const configuredResetTimeout = 1 // second
+	const advertisedAfter = 3 * time.Second
+
+	b := New(Config{FailureThreshold: 1, ResetTimeout: configuredResetTimeout})
+	execErr := b.Execute(func() error {
+		return fmt.Errorf("rate limited: %w", &RateLimitError{After: advertisedAfter})
+	})
+	if !errors.Is(execErr, ErrRateLimit) {
+		t.Fatalf("expected returned error to match ErrRateLimit via Unwrap, got %v", execErr)
+	}
+	if b.State() != StateOpen {
+		t.Fatalf("expected Open immediately after a rate-limit failure, got %v", b.State())
+	}
+
+	// Past the configured 1s ResetTimeout but well before the 3s
+	// provider-advertised After, the breaker must still be Open — proving the
+	// advertised duration overrides the shorter configured default.
+	time.Sleep(1500 * time.Millisecond)
+	if b.Ready() {
+		t.Error("breaker became Ready before the provider's advertised retry-after elapsed — RateLimitError.After was not honored")
+	}
+
+	// Past the 3s After, the breaker must allow a probe again.
+	time.Sleep(2 * time.Second)
+	if !b.Ready() {
+		t.Error("breaker still not Ready well past the provider's advertised retry-after")
+	}
+}
+
+// TestRateLimitErrorAtOrBelowResetTimeoutUsesConfiguredTimeout proves the
+// additive nature of the fix: when a provider's advertised After is shorter
+// than (or equal to) the breaker's configured ResetTimeout, the configured
+// timeout still applies — RateLimitError never shortens the cooldown below
+// what operators configured.
+func TestRateLimitErrorAtOrBelowResetTimeoutUsesConfiguredTimeout(t *testing.T) {
+	t.Parallel()
+
+	const configuredResetTimeout = 2 // seconds
+
+	b := New(Config{FailureThreshold: 1, ResetTimeout: configuredResetTimeout})
+	execErr := b.Execute(func() error {
+		return fmt.Errorf("rate limited: %w", &RateLimitError{After: 500 * time.Millisecond})
+	})
+	if !errors.Is(execErr, ErrRateLimit) {
+		t.Fatalf("expected returned error to match ErrRateLimit via Unwrap, got %v", execErr)
+	}
+
+	// Well before the configured 2s ResetTimeout, must still be Open despite
+	// the shorter 500ms advertised After.
+	time.Sleep(700 * time.Millisecond)
+	if b.Ready() {
+		t.Error("breaker became Ready before the configured ResetTimeout elapsed")
+	}
+}
+
+// TestBareErrRateLimitUnaffectedByRateLimitAfter proves providers that keep
+// wrapping the bare ErrRateLimit sentinel (github, reddit, bluesky, xquik,
+// lens) are unaffected by the #666 fix — errors.Is still matches, and the
+// breaker falls back to the configured ResetTimeout exactly as before.
+func TestBareErrRateLimitUnaffectedByRateLimitAfter(t *testing.T) {
+	t.Parallel()
+
+	const configuredResetTimeout = 1 // second
+
+	b := New(Config{FailureThreshold: 1, ResetTimeout: configuredResetTimeout})
+	execErr := b.Execute(func() error {
+		return fmt.Errorf("rate limited: %w", ErrRateLimit)
+	})
+	if !errors.Is(execErr, ErrRateLimit) {
+		t.Fatalf("expected returned error to match ErrRateLimit, got %v", execErr)
+	}
+
+	time.Sleep(1500 * time.Millisecond)
+	if !b.Ready() {
+		t.Error("expected breaker to be Ready past the configured ResetTimeout when no RateLimitError was given")
+	}
+}

--- a/internal/search/bluesky.go
+++ b/internal/search/bluesky.go
@@ -113,6 +113,11 @@ func (p *BlueskyProvider) Web(ctx context.Context, params WebSearchParams) ([]Se
 	qp := url.Values{}
 	qp.Set("q", params.Query)
 	qp.Set("limit", strconv.Itoa(n))
+	// searchPosts' sort param defaults to "latest" (pure reverse-chronological)
+	// when omitted; request "top" (engagement-ranked) instead, since plain
+	// recency ranks any recent keyword match equally with substantive,
+	// higher-engagement posts on broad/non-named-entity queries (#669).
+	qp.Set("sort", "top")
 
 	body, err := p.searchPosts(ctx, p.baseURL, qp)
 	if err != nil && p.baseURL != bskyFallbackBaseURL && isBskyForbidden(err) {

--- a/internal/search/bluesky_test.go
+++ b/internal/search/bluesky_test.go
@@ -366,6 +366,28 @@ func TestBlueskyProviderNumResultsClamp(t *testing.T) {
 	}
 }
 
+// TestBlueskyProviderWeb_SortsByTop is the #669 regression test: searchPosts'
+// sort param defaults to "latest" (pure reverse-chronological) when omitted,
+// which ranks any recent keyword match equally with substantive,
+// higher-engagement posts on broad/non-named-entity queries. Web() must
+// request sort=top (engagement-ranked) explicitly.
+func TestBlueskyProviderWeb_SortsByTop(t *testing.T) {
+	t.Parallel()
+	var gotSort string
+	p := newBlueskyTestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		gotSort = r.URL.Query().Get("sort")
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"posts":[]}`))
+	})
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "AI safety", NumResults: 5})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotSort != "top" {
+		t.Errorf("sort param = %q, want %q", gotSort, "top")
+	}
+}
+
 func TestBlueskyProviderInterface(t *testing.T) {
 	t.Parallel()
 	var _ Provider = (*BlueskyProvider)(nil)

--- a/internal/search/google.go
+++ b/internal/search/google.go
@@ -70,7 +70,16 @@ func (g *GoogleProvider) doWebSearch(ctx context.Context, params WebSearchParams
 		q.Set("lr", "lang_"+params.Language)
 	}
 	if params.Country != "" {
+		// cr (country-restrict) narrows the candidate set to pages Google's
+		// crawler inferred originate from that country — an approximate,
+		// purely-filtering signal per Google's own docs. gl (geolocation
+		// bias) is the actual ranking/relevance mechanism: it re-ranks
+		// results as if the search originated from that country. Setting cr
+		// alone filters against imperfect origin tagging but never boosts
+		// region-appropriate content, producing weak/inconsistent
+		// localization (#676) — both must be set together.
 		q.Set("cr", "country"+strings.ToUpper(params.Country))
+		q.Set("gl", strings.ToLower(params.Country))
 	}
 	if params.ExactTerms != "" {
 		q.Set("exactTerms", params.ExactTerms)

--- a/internal/search/search_test.go
+++ b/internal/search/search_test.go
@@ -133,6 +133,81 @@ func TestGoogleProvider_WebSearch(t *testing.T) {
 	}
 }
 
+// TestGoogleProvider_WebSearch_CountrySetsGlAndCr is the #676 regression
+// test: setting cr (country-restrict) alone filters against Google's
+// imperfect country-of-origin page tagging but never applies the ranking/
+// relevance bias that actually localizes results — gl (geolocation bias)
+// must be set alongside it for every non-empty Country value.
+func TestGoogleProvider_WebSearch_CountrySetsGlAndCr(t *testing.T) {
+	var gotCr, gotGl string
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		gotCr = q.Get("cr")
+		gotGl = q.Get("gl")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(googleResponse{})
+	}))
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport},
+	}
+	deps := Deps{
+		HTTPClient: client,
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5}),
+	}
+
+	g := NewGoogleProvider("test-key", "test-cx", deps)
+	_, err := g.Web(context.Background(), WebSearchParams{
+		Query:   "best local restaurants",
+		Country: "DE",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if gotCr != "countryDE" {
+		t.Errorf("cr = %q, want %q", gotCr, "countryDE")
+	}
+	if gotGl != "de" {
+		t.Errorf("gl = %q, want %q", gotGl, "de")
+	}
+}
+
+// TestGoogleProvider_WebSearch_NoCountryOmitsGlAndCr proves gl/cr are only
+// sent when the caller actually asked for a country — no default region bias
+// is injected.
+func TestGoogleProvider_WebSearch_NoCountryOmitsGlAndCr(t *testing.T) {
+	var sawCr, sawGl bool
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		q := r.URL.Query()
+		sawCr = q.Has("cr")
+		sawGl = q.Has("gl")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(googleResponse{})
+	}))
+	defer ts.Close()
+
+	client := &http.Client{
+		Transport: &rewriteTransport{baseURL: ts.URL, inner: http.DefaultTransport},
+	}
+	deps := Deps{
+		HTTPClient: client,
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5}),
+	}
+
+	g := NewGoogleProvider("test-key", "test-cx", deps)
+	_, err := g.Web(context.Background(), WebSearchParams{Query: "golang testing"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if sawCr {
+		t.Error("expected no cr param when Country is empty")
+	}
+	if sawGl {
+		t.Error("expected no gl param when Country is empty")
+	}
+}
+
 func TestGoogleProvider_WebSearch_WithSiteAndTimeRange(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		q := r.URL.Query()

--- a/internal/search/searchapi.go
+++ b/internal/search/searchapi.go
@@ -305,6 +305,10 @@ func (s *SearchAPIProvider) doRequest(ctx context.Context, params url.Values) ([
 	defer resp.Body.Close()
 
 	if resp.StatusCode == 429 {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		if after := parseSearchAPIRetryAfter(body, resp.Header); after > 0 {
+			return nil, fmt.Errorf("searchapi: rate limited, retry after %ds: %w", int(after.Seconds()), &circuit.RateLimitError{After: after})
+		}
 		return nil, fmt.Errorf("searchapi: rate limited: %w", circuit.ErrRateLimit)
 	}
 	if resp.StatusCode == 401 || resp.StatusCode == 403 {
@@ -316,6 +320,26 @@ func (s *SearchAPIProvider) doRequest(ctx context.Context, params url.Values) ([
 	}
 
 	return io.ReadAll(io.LimitReader(resp.Body, 5*1024*1024))
+}
+
+// parseSearchAPIRetryAfter extracts the provider's advertised rate-limit
+// cooldown from a 429 response, preferring the documented `retryAfterSeconds`
+// JSON body field and falling back to the standard `Retry-After` HTTP header
+// (#666). Returns 0 when neither is present or parseable, signaling the
+// caller to fall back to the breaker's configured default cooldown.
+func parseSearchAPIRetryAfter(body []byte, header http.Header) time.Duration {
+	var payload struct {
+		RetryAfterSeconds float64 `json:"retryAfterSeconds"`
+	}
+	if err := json.Unmarshal(body, &payload); err == nil && payload.RetryAfterSeconds > 0 {
+		return time.Duration(payload.RetryAfterSeconds * float64(time.Second))
+	}
+	if ra := strings.TrimSpace(header.Get("Retry-After")); ra != "" {
+		if secs, err := strconv.Atoi(ra); err == nil && secs > 0 {
+			return time.Duration(secs) * time.Second
+		}
+	}
+	return 0
 }
 
 func mapSearchAPITimePeriod(tr string) string {

--- a/internal/search/searchapi_test.go
+++ b/internal/search/searchapi_test.go
@@ -1,0 +1,104 @@
+package search
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/circuit"
+)
+
+func newSearchAPITestProvider(t *testing.T, handler http.HandlerFunc) *SearchAPIProvider {
+	t.Helper()
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+	deps := Deps{
+		HTTPClient: srv.Client(),
+		Breaker:    circuit.New(circuit.Config{FailureThreshold: 5}),
+	}
+	p := NewSearchAPIProvider("test-key", deps)
+	p.SetBaseURL(srv.URL)
+	return p
+}
+
+// TestSearchAPIProvider_429SurfacesRetryAfter is the #666 regression test:
+// a 429 response's retryAfterSeconds body field must be parsed and surfaced
+// as a circuit.RateLimitError the breaker can honor, instead of being
+// silently discarded in favor of the bare circuit.ErrRateLimit sentinel.
+func TestSearchAPIProvider_429SurfacesRetryAfter(t *testing.T) {
+	t.Parallel()
+	p := newSearchAPITestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"retryAfterSeconds": 60}`))
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "test"})
+	if err == nil {
+		t.Fatal("expected an error on HTTP 429, got nil")
+	}
+	if !strings.Contains(err.Error(), "60") {
+		t.Errorf("expected error message to mention the 60s retry-after, got %q", err.Error())
+	}
+
+	var rle *circuit.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected error to unwrap to *circuit.RateLimitError, got %v", err)
+	}
+	if rle.After != 60*time.Second {
+		t.Errorf("RateLimitError.After = %s, want 60s", rle.After)
+	}
+	if !errors.Is(err, circuit.ErrRateLimit) {
+		t.Error("expected error to still match circuit.ErrRateLimit via errors.Is")
+	}
+}
+
+// TestSearchAPIProvider_429FallsBackToRetryAfterHeader proves the standard
+// HTTP Retry-After header is honored when the response body carries no
+// retryAfterSeconds field.
+func TestSearchAPIProvider_429FallsBackToRetryAfterHeader(t *testing.T) {
+	t.Parallel()
+	p := newSearchAPITestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "45")
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "test"})
+	if err == nil {
+		t.Fatal("expected an error on HTTP 429, got nil")
+	}
+
+	var rle *circuit.RateLimitError
+	if !errors.As(err, &rle) {
+		t.Fatalf("expected error to unwrap to *circuit.RateLimitError, got %v", err)
+	}
+	if rle.After != 45*time.Second {
+		t.Errorf("RateLimitError.After = %s, want 45s", rle.After)
+	}
+}
+
+// TestSearchAPIProvider_429NoSignalFallsBackToBareErrRateLimit proves that
+// when the provider gives no retry-after signal at all, the bare
+// circuit.ErrRateLimit sentinel is used (the breaker's configured
+// ResetTimeout applies, unchanged from prior behavior).
+func TestSearchAPIProvider_429NoSignalFallsBackToBareErrRateLimit(t *testing.T) {
+	t.Parallel()
+	p := newSearchAPITestProvider(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+	})
+
+	_, err := p.Web(context.Background(), WebSearchParams{Query: "test"})
+	if err == nil {
+		t.Fatal("expected an error on HTTP 429, got nil")
+	}
+	if !errors.Is(err, circuit.ErrRateLimit) {
+		t.Error("expected error to match circuit.ErrRateLimit")
+	}
+	var rle *circuit.RateLimitError
+	if errors.As(err, &rle) {
+		t.Errorf("expected no RateLimitError when no retry-after signal was given, got %+v", rle)
+	}
+}

--- a/internal/tools/imagesearch.go
+++ b/internal/tools/imagesearch.go
@@ -11,6 +11,37 @@ import (
 	"github.com/zoharbabin/web-researcher-mcp/internal/search"
 )
 
+// manyImageFiltersWarning returns an advisory for issue #659: Google's
+// Custom Search JSON API's own request construction here is correct — each
+// of imgSize/imgType/imgColorType/imgDominantColor/fileType is set
+// independently under its documented param name (see doImageSearch in
+// internal/search/google.go), so there is no mismapping or overwrite in this
+// codebase's query. The actual root cause is upstream: when 3+ of these
+// filters combine into an intersection narrow enough that too few images
+// satisfy every constraint, Google's server silently relaxes the combined
+// filter set and falls back toward broader/default ranking — the response
+// carries no field indicating anything was relaxed, so results can come back
+// byte-identical to an unfiltered query with no error and no signal. This
+// cannot be detected or corrected client-side, so the fix is an honest
+// warning rather than a request-construction change. Fires only for the
+// google provider, only once 3 or more filters are combined — the threshold
+// at which live testing showed the relaxation kick in.
+func manyImageFiltersWarning(params search.ImageSearchParams, providerUsed string) string {
+	if providerUsed != "google" {
+		return ""
+	}
+	set := 0
+	for _, v := range []string{params.Size, params.Type, params.ColorType, params.DominantColor, params.FileType} {
+		if v != "" {
+			set++
+		}
+	}
+	if set < 3 {
+		return ""
+	}
+	return "3 or more image filters were combined (size/type/color_type/dominant_color/file_type). Google's Custom Search API may silently relax combined filters when too few images satisfy every constraint at once, returning broader results than requested with no field in the response indicating this happened. If results look unfiltered, try fewer simultaneous filters or a different provider."
+}
+
 type imageSearchInput struct {
 	Query         string `json:"query" jsonschema:"Descriptive search query for images (e.g. 'golden retriever puppy playing fetch'). More descriptive = better results.,required"`
 	NumResults    int    `json:"num_results,omitempty" jsonschema:"Number of image results (1-200, default: 5). Brave returns up to 200; Google up to 10."`
@@ -71,20 +102,22 @@ func registerImageSearch(srv *mcp.Server, deps Dependencies) {
 			return errResult, nil, nil
 		}
 
+		imgParams := search.ImageSearchParams{
+			Query:         input.Query,
+			NumResults:    numResults,
+			Size:          input.Size,
+			Type:          input.Type,
+			ColorType:     input.ColorType,
+			DominantColor: input.DominantColor,
+			FileType:      input.FileType,
+			Safe:          input.Safe,
+			Country:       input.Country,
+			Language:      input.Language,
+		}
+
 		traceCtx, trace := search.NewRoutingTrace(ctx)
 		results, err := coalescedFetch(ctx, deps, cacheKey, func() ([]search.ImageResult, error) {
-			return provider.Images(traceCtx, search.ImageSearchParams{
-				Query:         input.Query,
-				NumResults:    numResults,
-				Size:          input.Size,
-				Type:          input.Type,
-				ColorType:     input.ColorType,
-				DominantColor: input.DominantColor,
-				FileType:      input.FileType,
-				Safe:          input.Safe,
-				Country:       input.Country,
-				Language:      input.Language,
-			})
+			return provider.Images(traceCtx, imgParams)
 		})
 		if err != nil {
 			errCode := "upstream_error"
@@ -95,7 +128,8 @@ func registerImageSearch(srv *mcp.Server, deps Dependencies) {
 			auditToolCall(ctx, deps, "image_search", time.Since(start), err, errCode)
 			return upstreamErrorResponse("image search", err), nil, nil
 		}
-		rt := routingMeta(trace.Decision(), time.Since(start), false)
+		decision := trace.Decision()
+		rt := routingMeta(decision, time.Since(start), false)
 
 		output := map[string]any{
 			"images":      results,
@@ -106,6 +140,14 @@ func registerImageSearch(srv *mcp.Server, deps Dependencies) {
 
 		if len(results) == 0 {
 			output["hints"] = buildZeroResultHints(hintProviderName(provider), nil, nil)
+		}
+
+		effectiveProvider := decision.ProviderUsed
+		if effectiveProvider == "" {
+			effectiveProvider = provider.Name()
+		}
+		if warning := manyImageFiltersWarning(imgParams, effectiveProvider); warning != "" {
+			output["warning"] = warning
 		}
 
 		jsonBytes, _ := json.Marshal(output)

--- a/internal/tools/imagesearch_test.go
+++ b/internal/tools/imagesearch_test.go
@@ -1,0 +1,159 @@
+package tools
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/modelcontextprotocol/go-sdk/mcp"
+
+	"github.com/zoharbabin/web-researcher-mcp/internal/search"
+)
+
+// TestManyImageFiltersWarning is the #659 regression test: Google's Custom
+// Search API may silently relax 3+ combined image filters and fall back to
+// broader/default ranking with no signal in the response — the tool should
+// surface a warning rather than pretend the request was honored as-is.
+func TestManyImageFiltersWarning(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		params       search.ImageSearchParams
+		providerUsed string
+		wantWarning  bool
+	}{
+		{
+			name:         "google with 3 filters set warns",
+			params:       search.ImageSearchParams{Size: "large", Type: "clipart", ColorType: "trans"},
+			providerUsed: "google",
+			wantWarning:  true,
+		},
+		{
+			name:         "google with all 5 filters set warns",
+			params:       search.ImageSearchParams{Size: "large", Type: "clipart", ColorType: "trans", DominantColor: "blue", FileType: "png"},
+			providerUsed: "google",
+			wantWarning:  true,
+		},
+		{
+			name:         "google with only 1 filter set does not warn",
+			params:       search.ImageSearchParams{Type: "clipart"},
+			providerUsed: "google",
+			wantWarning:  false,
+		},
+		{
+			name:         "google with 2 filters set does not warn",
+			params:       search.ImageSearchParams{Type: "clipart", Size: "large"},
+			providerUsed: "google",
+			wantWarning:  false,
+		},
+		{
+			name:         "non-google provider with all 5 filters set does not warn",
+			params:       search.ImageSearchParams{Size: "large", Type: "clipart", ColorType: "trans", DominantColor: "blue", FileType: "png"},
+			providerUsed: "brave",
+			wantWarning:  false,
+		},
+		{
+			name:         "no filters set does not warn",
+			params:       search.ImageSearchParams{},
+			providerUsed: "google",
+			wantWarning:  false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := manyImageFiltersWarning(c.params, c.providerUsed)
+			if c.wantWarning && got == "" {
+				t.Errorf("expected a non-empty warning, got empty")
+			}
+			if !c.wantWarning && got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
+}
+
+// googleNamedImageProvider is a mock provider whose Name() returns "google" so
+// integration tests can exercise the image_search tool's provider-conditional
+// warning wiring end-to-end.
+type googleNamedImageProvider struct{}
+
+func (p *googleNamedImageProvider) Web(_ context.Context, _ search.WebSearchParams) ([]search.SearchResult, error) {
+	return nil, nil
+}
+func (p *googleNamedImageProvider) Images(_ context.Context, _ search.ImageSearchParams) ([]search.ImageResult, error) {
+	return []search.ImageResult{
+		{Title: "Test Image", Link: "https://example.com/img.png", DisplayLink: "example.com"},
+	}, nil
+}
+func (p *googleNamedImageProvider) News(_ context.Context, _ search.NewsSearchParams) ([]search.NewsResult, error) {
+	return nil, nil
+}
+func (p *googleNamedImageProvider) Name() string { return "google" }
+
+func TestImageSearchToolSurfacesManyFiltersWarning(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	deps.Search = &googleNamedImageProvider{}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "image_search",
+		Arguments: map[string]any{
+			"query":          "cat",
+			"size":           "large",
+			"type":           "clipart",
+			"color_type":     "trans",
+			"dominant_color": "blue",
+			"file_type":      "png",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+
+	text := res.Content[0].(*mcp.TextContent).Text
+	var output struct {
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(text), &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.Warning == "" {
+		t.Fatal("expected a warning when 3+ image filters are combined against google, got none")
+	}
+}
+
+func TestImageSearchToolNoWarningWithFewFilters(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	deps.Search = &googleNamedImageProvider{}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name: "image_search",
+		Arguments: map[string]any{
+			"query": "cat",
+			"type":  "clipart",
+		},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+
+	text := res.Content[0].(*mcp.TextContent).Text
+	var output struct {
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(text), &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.Warning != "" {
+		t.Fatalf("expected no warning with only 1 filter set, got %q", output.Warning)
+	}
+}

--- a/internal/tools/newssearch.go
+++ b/internal/tools/newssearch.go
@@ -55,6 +55,21 @@ func newsDateSortRelevanceWarning(sortBy, providerUsed string, articles []newsAr
 	return "sort_by=\"date\" tells Google to order results strictly by date, replacing its relevance ranking (Google's documented Custom Search API behavior, not a bug in this tool). For broad queries this can surface recently-modified but topically unrelated pages ahead of real news coverage. None of these results matched a recognized news domain — try a more specific query, or omit sort_by to use Google's default relevance ranking."
 }
 
+// newsHourGranularityWarning returns an advisory for issue #665: Google's
+// Custom Search JSON API `dateRestrict` param has no hour-level granularity
+// (see mapTimeRange in internal/search/google.go) — time_range="hour" maps to
+// "d1" (24h), byte-for-byte identical to time_range="day", 100% of the time.
+// This is a genuine upstream API constraint the mapping already handles
+// correctly, not a bug; the gap is that nothing told the caller their
+// "hour" request silently became a 24h window. Fires only when the caller
+// explicitly asked for "hour" granularity against the google provider.
+func newsHourGranularityWarning(timeRange, providerUsed string) string {
+	if timeRange != "hour" || providerUsed != "google" {
+		return ""
+	}
+	return "time_range=\"hour\" was requested, but Google's Custom Search API has no hour-level date restriction — it fell back to day granularity (results from the last 24 hours), identical to time_range=\"day\". This is a hard limitation of Google's API, not an approximation. Use a different provider (e.g. brave) if strict last-hour freshness matters."
+}
+
 func classifyNewsResults(results []search.NewsResult) []newsArticleOutput {
 	out := make([]newsArticleOutput, 0, len(results))
 	for _, r := range results {
@@ -171,19 +186,27 @@ func registerNewsSearch(srv *mcp.Server, deps Dependencies) {
 			"trust":       untrustedContentTrust,
 		}
 
+		effectiveProvider := decision.ProviderUsed
+		if effectiveProvider == "" {
+			effectiveProvider = provider.Name()
+		}
+
 		// Zero-result recovery hints (issue #100): same ZeroResultHints shape as
 		// web/academic/patent. Only configured + healthy alternatives suggested.
 		if len(results) == 0 {
 			used := hintProviderName(provider)
 			output["hints"] = buildNewsHints(input, freshness, used, healthyAlternatives(deps, used))
-		} else {
-			effectiveProvider := decision.ProviderUsed
-			if effectiveProvider == "" {
-				effectiveProvider = provider.Name()
-			}
-			if warning := newsDateSortRelevanceWarning(sortBy, effectiveProvider, articles); warning != "" {
-				output["warning"] = warning
-			}
+		}
+
+		var warnings []string
+		if w := newsDateSortRelevanceWarning(sortBy, effectiveProvider, articles); w != "" {
+			warnings = append(warnings, w)
+		}
+		if w := newsHourGranularityWarning(input.TimeRange, effectiveProvider); w != "" {
+			warnings = append(warnings, w)
+		}
+		if len(warnings) > 0 {
+			output["warning"] = strings.Join(warnings, " ")
 		}
 
 		jsonBytes, _ := json.Marshal(output)

--- a/internal/tools/newssearch_test.go
+++ b/internal/tools/newssearch_test.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -155,6 +156,69 @@ func TestNewsSearchNoWarningWhenNotGoogle(t *testing.T) {
 	})
 	if warning := newsDateSortRelevanceWarning("date", "brave", articles); warning != "" {
 		t.Errorf("expected no warning for non-Google provider (sort_by is ignored there), got %q", warning)
+	}
+}
+
+// TestNewsHourGranularityWarning is the #665 regression test: Google's
+// Custom Search API has no hour-level dateRestrict, so time_range="hour"
+// silently maps to the same 24h window as "day" — the caller should be told,
+// not left to notice the identical results on their own.
+func TestNewsHourGranularityWarning(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name         string
+		timeRange    string
+		providerUsed string
+		wantWarning  bool
+	}{
+		{"hour + google warns", "hour", "google", true},
+		{"day + google does not warn", "day", "google", false},
+		{"hour + brave does not warn", "hour", "brave", false},
+		{"empty time_range + google does not warn", "", "google", false},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := newsHourGranularityWarning(c.timeRange, c.providerUsed)
+			if c.wantWarning && got == "" {
+				t.Errorf("expected a non-empty warning, got empty")
+			}
+			if !c.wantWarning && got != "" {
+				t.Errorf("expected no warning, got %q", got)
+			}
+		})
+	}
+}
+
+func TestNewsSearchToolSurfacesHourGranularityWarning(t *testing.T) {
+	ctx := context.Background()
+	deps := setupTestDeps()
+	deps.Search = &nonNewsGoogleProvider{}
+	srv := createTestServer(deps)
+	session := connectTestClient(ctx, t, srv)
+	defer session.Close()
+
+	res, err := session.CallTool(ctx, &mcp.CallToolParams{
+		Name:      "news_search",
+		Arguments: map[string]any{"query": "climate change", "time_range": "hour"},
+	})
+	if err != nil {
+		t.Fatalf("CallTool failed: %v", err)
+	}
+
+	text := res.Content[0].(*mcp.TextContent).Text
+	var output struct {
+		Warning string `json:"warning"`
+	}
+	if err := json.Unmarshal([]byte(text), &output); err != nil {
+		t.Fatalf("failed to parse output: %v", err)
+	}
+	if output.Warning == "" {
+		t.Fatal("expected a warning for time_range=hour against google, got none")
+	}
+	if !strings.Contains(output.Warning, "hour") {
+		t.Errorf("expected warning to mention the hour-granularity limitation, got %q", output.Warning)
 	}
 }
 

--- a/internal/tools/schemas.go
+++ b/internal/tools/schemas.go
@@ -73,6 +73,7 @@ var imageSearchOutputSchema = map[string]any{
 		"query":       map[string]any{"type": "string"},
 		"resultCount": map[string]any{"type": "integer"},
 		"hints":       map[string]any{"type": "object"},
+		"warning":     map[string]any{"type": "string", "description": "Present only when provider=google and 3 or more of size/type/color_type/dominant_color/file_type were combined (#659) — Google's Custom Search API may silently relax combined image filters and return broader results than requested, with no field in the response indicating this happened."},
 		"trust":       trustUntrustedExternal,
 		"images": map[string]any{
 			"type": "array",
@@ -99,7 +100,7 @@ var newsSearchOutputSchema = map[string]any{
 		"query":       map[string]any{"type": "string"},
 		"resultCount": map[string]any{"type": "integer"},
 		"hints":       map[string]any{"type": "object"},
-		"warning":     map[string]any{"type": "string", "description": "Present only when sort_by=\"date\" was honored by Google and none of the returned articles matched a recognized news domain (#642) — Google's date sort discards relevance ranking, so broad queries can surface non-news pages."},
+		"warning":     map[string]any{"type": "string", "description": "Present when either: sort_by=\"date\" was honored by Google and none of the returned articles matched a recognized news domain (#642) — Google's date sort discards relevance ranking, so broad queries can surface non-news pages; or time_range=\"hour\" was requested against Google, which has no hour-level date restriction and silently falls back to day granularity (#665). Both messages are joined with a space when they co-occur."},
 		"trust":       trustUntrustedExternal,
 		"articles": map[string]any{
 			"type": "array",

--- a/python/web_researcher_mcp/models.py
+++ b/python/web_researcher_mcp/models.py
@@ -1206,6 +1206,7 @@ class ImageSearchResponse:
     query: Optional[str] = None
     resultCount: Optional[int] = None
     trust: Optional[str] = None
+    warning: Optional[str] = None
 
     @classmethod
     def from_dict(cls, d: dict[str, Any] | None) -> "ImageSearchResponse | None":
@@ -1217,6 +1218,7 @@ class ImageSearchResponse:
             query=d.get('query'),
             resultCount=d.get('resultCount'),
             trust=d.get('trust'),
+            warning=d.get('warning'),
         )
 
 @dataclass


### PR DESCRIPTION
## Summary

Five fixes from the v1.49.2 Live E2E Audit:

- **Closes #666** — `searchapi`'s 429 handler discarded the response body, so any `retryAfterSeconds`/`Retry-After` signal was never parsed. The circuit breaker always reopened for its configured `ResetTimeout` regardless, producing a sawtooth of half-open probes shorter than the provider's real cooldown that never converged. Added `circuit.RateLimitError{After}` (additive — `errors.Is` still matches the bare `ErrRateLimit` sentinel other providers use) and wired `searchapi` to parse and wrap it.
- **Closes #676** — Google CSE web search set only `cr` (country-restrict, a hard filter against Google's imperfect country-of-origin tagging) and never `gl` (geolocation bias, the actual ranking mechanism). `country=DE`/`JP` queries were filtered but never got the relevance boost toward region-appropriate content. Now sets both.
- **Closes #669** — Bluesky's `searchPosts` defaults to `sort=latest` (pure recency) when omitted, so broad/non-named-entity queries ranked any recent keyword match equally with substantive, higher-engagement posts. Now requests `sort=top`. (github/reddit/xquik audited alongside this and found already at their API's precision ceiling — no code change needed, per the issue's own analysis.)
- **Closes #659** — Google's Custom Search API can silently relax 3+ combined image filters (`size`/`type`/`color_type`/`dominant_color`/`file_type`) when the combined intersection is too narrow, falling back to broader/default ranking with no signal in the response. `image_search` now returns a `warning` field when `provider=google` and 3+ filters are combined.
- **Closes #665** — Google's `dateRestrict` has no hour-level granularity, so `time_range="hour"` silently falls back to the same 24h window as `"day"`. `news_search` now returns a `warning` field for this case, and `docs/TOOLS.md` is corrected from "may be approximate" to state the hard limitation as fact.

## Test plan

- [x] `gofmt -l .` clean
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go tool golangci-lint run` — 0 issues
- [x] `go test -race ./...` — all packages pass
- [x] `go test ./...` — all packages pass
- [x] `make check-python-drift` — clean after `make gen-python-client`
- [x] New regression tests per issue: `TestRateLimitErrorExtendsResetTimeout`/`TestRateLimitErrorAtOrBelowResetTimeoutUsesConfiguredTimeout`/`TestBareErrRateLimitUnaffectedByRateLimitAfter` (circuit), `TestSearchAPIProvider_429SurfacesRetryAfter`/`...FallsBackToRetryAfterHeader`/`...NoSignalFallsBackToBareErrRateLimit` (searchapi), `TestGoogleProvider_WebSearch_CountrySetsGlAndCr`/`...NoCountryOmitsGlAndCr` (google), `TestBlueskyProviderWeb_SortsByTop` (bluesky), `TestManyImageFiltersWarning` + tool-level integration tests (imagesearch), `TestNewsHourGranularityWarning` + tool-level integration test (newssearch)
- [x] `docs/TOOLS.md` updated for the new `warning` output fields and corrected Google hour-granularity claim; `TestToolsDocMatchesRegistry`/`TestOutputSchemaMatchesResponse` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)