### PR TITLE
ci(release): fail loudly instead of silently on Smithery publish failure

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -503,10 +503,15 @@ jobs:
           # the CLI's own exit code AND grep its output for "Deployment
           # failed" — smithery-cli has been observed to print that string on
           # a rejected publish, so either signal alone must fail the job loudly.
+          # `set +e` around the pipeline is required: PIPESTATUS must be read
+          # immediately after the pipeline runs, before any other command
+          # (including a trailing `|| true`) executes and overwrites it.
+          set +e
           smithery mcp publish "dist/mcpb/web-researcher-mcp_${VERSION}_linux_amd64.mcpb" \
             -n web-researcher-mcp/web-researcher-mcp \
-            2>&1 | tee smithery-publish.log || true
+            2>&1 | tee smithery-publish.log
           publish_exit="${PIPESTATUS[0]}"
+          set -e
 
           if [ "$publish_exit" -ne 0 ] || grep -q "Deployment failed" smithery-publish.log; then
             echo "::error::Smithery publish failed (exit code ${publish_exit}) — see log above. This used to be silently swallowed as a warning; see issue #673."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -496,9 +496,22 @@ jobs:
           VERSION="${RELEASE_TAG#v}"
           mkdir -p "$HOME/.config/smithery"
           echo "{\"apiKey\":\"${SMITHERY_API_KEY}\"}" > "$HOME/.config/smithery/settings.json"
+
+          # Never let this fail silently (see #673): a prior soft `|| echo
+          # "::warning..."` fallback let this job report green while every
+          # release since v1.49.0 actually failed to reach Smithery. Capture
+          # the CLI's own exit code AND grep its output for "Deployment
+          # failed" — smithery-cli has been observed to print that string on
+          # a rejected publish, so either signal alone must fail the job loudly.
           smithery mcp publish "dist/mcpb/web-researcher-mcp_${VERSION}_linux_amd64.mcpb" \
             -n web-researcher-mcp/web-researcher-mcp \
-            || echo "::warning::Smithery publish failed (may already exist or API key expired)"
+            2>&1 | tee smithery-publish.log || true
+          publish_exit="${PIPESTATUS[0]}"
+
+          if [ "$publish_exit" -ne 0 ] || grep -q "Deployment failed" smithery-publish.log; then
+            echo "::error::Smithery publish failed (exit code ${publish_exit}) — see log above. This used to be silently swallowed as a warning; see issue #673."
+            exit 1
+          fi
 
   # ── 🐍 PyPI platform wheels ───────────────────────────────────────────────────
   # Wraps the cross-compiled binaries (built by the `release` job) into platform

--- a/docs/CICD.md
+++ b/docs/CICD.md
@@ -230,6 +230,8 @@ Depends on `release` directly (not `docker-sign`) — the registry only needs th
 
 Downloads the `.mcpb` bundle that was already built and uploaded by the `release` job (no re-build from source). Publishes to [Smithery](https://smithery.ai). Gated on `vars.SMITHERY_ENABLED == 'true'`.
 
+The publish step captures `smithery mcp publish`'s exit code and greps its own output for `Deployment failed`; either signal fails the job with `::error::` (not a warning). Before #673, a soft `|| echo "::warning::..."` fallback let this job report green across multiple releases while every publish actually failed with a 400 from the Smithery API — the `.mcpb` manifest's `tools` field (`mcpb/manifest.json`) only carries `name`/`description` per the [mcpb spec](https://github.com/anthropics/mcpb) (no `inputSchema`), but smithery-cli forwards it as-is into `serverCard.tools`, which the Smithery publish API appears to require full `inputSchema` objects for. The manifest template no longer ships a static `tools`/`tools_generated` list, so Smithery introspects tool schemas from the live server instead of a stub that can never satisfy its schema. If this job fails again, check the log for the exact error before assuming it's just an expired `SMITHERY_API_KEY`.
+
 ### 🐍 [publish-pypi] — PyPI platform wheels
 
 Downloads the cross-compiled binaries from the `release` job artifact, wraps them into platform wheels, smoke-tests the manylinux wheel (import check), then publishes via Trusted Publishing (OIDC — no token secret). Gated on `vars.PYPI_PUBLISH_ENABLED == 'true'`.
@@ -326,7 +328,7 @@ Runs GitHub's CodeQL engine with `security-extended,security-and-quality` query 
 
 1. Add a new job to `release.yml` with `needs: release`.
 2. Gate it on a repo var (e.g., `vars.MY_CHANNEL_ENABLED == 'true'`) so an unconfigured fork is a clean no-op.
-3. Use `|| echo "::warning::..."` for non-fatal publish failures so a channel hiccup doesn't block the overall release.
+3. Don't swallow the actual failure signal. A bare `|| echo "::warning::..."` reports the job green even when the publish never happened — this hid a real 400 from Smithery across multiple releases (#673). If a failure is expected to be benign (e.g. "already published"), still capture the command's exit code and its output, and only downgrade to a warning after confirming the specific known-benign case (grep the output for the expected message); anything else must fail the job loudly. See `publish-smithery`'s "Publish to Smithery" step for the pattern.
 4. Document the required secret/var in the table above.
 
 ### Cutting a release
@@ -369,7 +371,7 @@ git push origin v1.38.0
 | PyPI publish failure | Check `pypi` environment is configured with Trusted Publishing OIDC |
 | Docker sign failure | Check GHCR image exists; check cosign OIDC token permissions |
 | MCP Registry warning | Non-fatal; check `mcp-publisher` OIDC credentials, may already be published |
-| Smithery warning | Non-fatal; check `SMITHERY_API_KEY` secret, may already be published |
+| Smithery publish fails | Fatal (fails the job, see #673) — check the step log for the actual `smithery mcp publish` error; check `SMITHERY_API_KEY` secret validity before assuming a schema issue |
 | Release workflow didn't fire on tag push | GitHub infrastructure glitch — use `Actions → 🚀 Release → Run workflow` and supply the tag (e.g. `v1.37.5`) to retrigger manually |
 
 ---

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -84,48 +84,5 @@
       "required": false,
       "sensitive": true
     }
-  },
-  "tools": [
-    {
-      "name": "web_search",
-      "description": "Search the web and get results from only the sites you trust, using search lenses"
-    },
-    {
-      "name": "scrape_page",
-      "description": "Read the full text from any URL — web pages, PDFs, Word docs, YouTube transcripts, Hacker News threads"
-    },
-    {
-      "name": "search_and_scrape",
-      "description": "Search the web and read the top results in one step, ranked by quality"
-    },
-    {
-      "name": "image_search",
-      "description": "Search for images with size and type filters"
-    },
-    {
-      "name": "news_search",
-      "description": "Search news articles with freshness controls"
-    },
-    {
-      "name": "academic_search",
-      "description": "Search academic papers via Scholar, arXiv, and PubMed"
-    },
-    {
-      "name": "patent_search",
-      "description": "Search patents with multi-office filtering (US, EP, WO, CN, JP, KR)"
-    },
-    {
-      "name": "verify_citation",
-      "description": "Verify a citation exists, matches a real record, and hasn't been retracted before you rely on it"
-    },
-    {
-      "name": "sequential_search",
-      "description": "Track multi-step research projects, noting what you found and what's still unanswered. Sessions persist for 4 hours and survive restarts."
-    },
-    {
-      "name": "get_research_session",
-      "description": "Recover a sequential_search session after context loss. Returns summary and recent steps."
-    }
-  ],
-  "tools_generated": true
+  }
 }


### PR DESCRIPTION
## Summary

Closes #673.

The `publish-smithery` job in `.github/workflows/release.yml` has failed identically on every release since v1.49.0 with a 400 `expected object, received undefined` (repeated 10x) from Smithery's publish API. The failure was soft-swallowed by `|| echo "::warning::..."`, so the job reported green while no artifact ever reached Smithery.

### Diagnosis

- Downloaded the actual CI log for run 32396991186 (v1.49.1) — confirmed the exact repro from the issue.
- Decompiled `@smithery/cli@4.11.1` (the version already pinned in `.github/npm/smithery-cli/package.json` — it's already `latest`, so a version bump wasn't the fix) to find the code path that builds the publish payload for an `.mcpb` bundle target (`tee()` in `dist/index.js`). It builds `serverCard.tools` by forwarding the mcpb manifest's `tools` field verbatim, unmodified.
- Checked `mcpb/manifest.json`: its static `tools` array has **exactly 10 entries**, each with only `name` + `description` — matching the **exactly 10** identical error messages one-for-one.
- Verified against `@anthropic-ai/mcpb`'s own manifest JSON Schema (v0.1 through latest): a tool entry's schema is `{name, description}` with `additionalProperties: false` — the mcpb spec has no way to attach an `inputSchema` per tool. So our manifest was already spec-compliant; there was no way to "fix" it by adding the missing field without breaking our own `scripts/validate-mcpb.sh` gate.
- Conclusion: Smithery's publish API appears to validate `serverCard.tools[i]` against something resembling the full MCP `Tool` type (which requires an `inputSchema` object), but smithery-cli hands it mcpb's much thinner `{name, description}` shape. This is an upstream mismatch between smithery-cli's mcpb integration and Smithery's own API contract — not something we can fix by changing the schema shape on our side, since the spec forbids it.

**What I could NOT fully confirm without live Smithery credentials/API access**: whether Smithery's backend schema literally requires `inputSchema` per tool (I inferred this from the exact 10-error/10-tool match plus the code path, but never saw Smithery's server-side validator or schema directly). I did not attempt a live `smithery mcp publish` against production or staging Smithery, per the task's explicit scope boundary.

### Fix

1. **`mcpb/manifest.json`**: removed the static `tools` and `tools_generated: true` fields. Since the mcpb spec can't carry `inputSchema` per tool anyway, this stub could never satisfy whatever Smithery's backend wants — better to let Smithery introspect the live server's real tool schemas instead of forwarding a manifest field that's structurally guaranteed to fail. Re-validated with `scripts/validate-mcpb.sh` (full build + `npx @anthropic-ai/mcpb validate`) — passes.
2. **`.github/workflows/release.yml`** (`publish-smithery` job): replaced the silent `|| echo "::warning::..."` fallback with a check that captures the CLI's own exit code (via `PIPESTATUS`, the same pattern already used elsewhere in this repo's `ci.yml`) **and** greps the publish step's output for `Deployment failed`. Either signal now fails the job with `::error::` instead of a swallowed warning.
3. **`docs/CICD.md`**: documented the new fail-loud behavior and root-cause summary under the Smithery job section; fixed the stale "Smithery warning — non-fatal" troubleshooting row; updated the general "adding a post-release distribution channel" guidance to warn against swallowing real failures with a bare `|| echo "::warning::..."`.

### Out of scope (per task instructions)

- Did not run `smithery mcp publish` against real/staging Smithery (needs live credentials, not available here).
- Did not manually re-publish v1.49.1 — left for the maintainer to do after this PR merges and the workflow fix is confirmed on the next tagged release.

## Test plan

- [x] `bash scripts/validate-mcpb.sh` — full mcpb bundle build + official `@anthropic-ai/mcpb validate` against the modified manifest: **passes** ("Manifest schema validation passes!").
- [x] `python3 -c "import json; json.load(open('mcpb/manifest.json'))"` — manifest is valid JSON.
- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release.yml'))"` — workflow YAML parses.
- [x] Verified the new grep/exit-code check locally against three fixtures (can't run the real CI job without live Smithery creds):
  - real repro (nonzero exit + "Deployment failed" in output) → correctly fails
  - hypothetical soft-failure (exit 0 but "Deployment failed" printed) → correctly fails
  - clean success (exit 0, no failure string) → correctly passes
- [x] `go build ./...` — no Go code touched, sanity pass only.
- [ ] Live/staging `smithery mcp publish` against the fixed manifest — explicitly out of scope for this PR; maintainer to verify on the next tagged release.