### PR TITLE
ci: bump github/codeql-action to v4.37.9 across all steps

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,15 +43,15 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary

Dependabot opened 4 separate PRs for the codeql-action v4.37.8 → v4.37.9 bump: #713 (init), #714 (autobuild), #715 (analyze), #716 (upload-sarif). Each only touches one usage, but CodeQL requires the `init`/`autobuild`/`analyze` steps in `codeql.yml` (and `upload-sarif` in `scorecard.yml`) to run the same version. Merging any one of those PRs alone fails CI:

```
Loaded a configuration file for version '4.37.9', but running version '4.37.8'
CodeQL job status was configuration error.
```

This PR bumps all 4 references together so the version stays consistent.

## Validation
- CI CodeQL job must pass on this PR (confirms the version-skew error is gone).

Supersedes #713, #714, #715, #716 — closing those once this merges.