### PR TITLE
fix(ci): always run CodeQL on push to main

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -3,7 +3,9 @@ name: 🔍 CodeQL Security Analysis
 on:
   push:
     branches: [main]
-    paths-ignore: &docs_paths
+  pull_request:
+    branches: [main]
+    paths-ignore:
       - "**/*.md"
       - "docs/**"
       - "assets/**"
@@ -13,9 +15,6 @@ on:
       - "overrides/**"
       - ".github/**_TEMPLATE**"
       - ".github/ISSUE_TEMPLATE/**"
-  pull_request:
-    branches: [main]
-    paths-ignore: *docs_paths
   schedule:
     - cron: "0 6 * * 1" # Every Monday at 06:00 UTC
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -43,15 +43,15 @@ jobs:
           cache: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: go
           queries: security-extended,security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/autobuild@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -45,6 +45,6 @@ jobs:
           retention-days: 5
 
       - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@db488ddef3bf6cb639b32c2e9a7c0a7ea8271d28 # v4.37.8
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
## Summary
- Addresses code-scanning alert #131 (OpenSSF Scorecard SAST check, score 9/10: "27 commits out of 30 are checked with a SAST tool").
- Root cause: `codeql.yml` applied `paths-ignore` (docs/markdown/assets) to both `push` and `pull_request` triggers. Docs-only PRs (e.g. #707, #671) never ran CodeQL, so Scorecard counted their merges as "unchecked".
- Fix: drop `paths-ignore` from the `push` trigger so every merge to `main` always runs CodeQL, regardless of changed paths. Keep it on `pull_request` so iterative review pushes on docs-only PRs still skip the scan — the cost tradeoff only applies once per merge, not per push.

## Test plan
- [ ] CI green on this PR (CodeQL runs on the PR since this diff isn't docs-only)
- [ ] After merge, confirm the push-triggered CodeQL run fires on the merge commit
- [ ] Scorecard's next scheduled run reflects a higher SAST coverage ratio